### PR TITLE
Allow "host" to be selected as source

### DIFF
--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -57,7 +57,6 @@ const ResourceSelectForm = props => {
           });
         }
         if (
-          !clusterList[i].MigCluster.spec.isHostCluster &&
           clusterList[i].MigCluster.metadata.name !== values.targetCluster
           && clusterList[i].ClusterStatus.hasReadyCondition
         ) {


### PR DESCRIPTION
This is important to support cases where the source cluster is also
acting as the control cluster rather than the destination.

Closes #634 