### PR TITLE
Clean up Select components and related state in Resources step of plan wizard

### DIFF
--- a/src/app/common/components/SimpleSelect.tsx
+++ b/src/app/common/components/SimpleSelect.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { Select, SelectOption } from '@patternfly/react-core';
+
+interface SimpleSelectProps {
+  id: string;
+  onChange: (selection: string) => void;
+  options: string[];
+  value: string;
+}
+
+// This can be used wherever we only need a simple select dropdown of strings.
+// If we need complex values, this could be enhanced to support option objects with a toString property
+const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({ onChange, options, value }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <Select
+      id="sourceCluster"
+      placeholderText="Select..."
+      isExpanded={isExpanded}
+      onToggle={setIsExpanded}
+      onSelect={(event, selection: string) => {
+        onChange(selection);
+        setIsExpanded(false);
+      }}
+      selections={value}
+    >
+      {options.map(option => (
+        <SelectOption key={option} value={option} />
+      ))}
+    </Select>
+  );
+};
+
+export default SimpleSelect;

--- a/src/app/common/components/SimpleSelect.tsx
+++ b/src/app/common/components/SimpleSelect.tsx
@@ -1,21 +1,30 @@
 import React, { useState } from 'react';
-import { Select, SelectOption } from '@patternfly/react-core';
+import { Select, SelectOption, SelectProps, Omit } from '@patternfly/react-core';
 
-interface SimpleSelectProps {
+interface SimpleSelectProps
+  extends Omit<SelectProps, 'onChange' | 'isExpanded' | 'onToggle' | 'onSelect' | 'selections'> {
   id: string;
   onChange: (selection: string) => void;
   options: string[];
   value: string;
+  placeholderText?: string;
 }
 
 // This can be used wherever we only need a simple select dropdown of strings.
 // If we need complex values, this could be enhanced to support option objects with a toString property
-const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({ onChange, options, value }) => {
+const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({
+  id,
+  onChange,
+  options,
+  value,
+  placeholderText = 'Select...',
+  ...props
+}) => {
   const [isExpanded, setIsExpanded] = useState(false);
   return (
     <Select
-      id="sourceCluster"
-      placeholderText="Select..."
+      id={id}
+      placeholderText={placeholderText}
       isExpanded={isExpanded}
       onToggle={setIsExpanded}
       onSelect={(event, selection: string) => {
@@ -23,6 +32,7 @@ const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({ onChange, op
         setIsExpanded(false);
       }}
       selections={value}
+      {...props}
     >
       {options.map(option => (
         <SelectOption key={option} value={option} />

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -101,44 +101,53 @@ const ResourceSelectForm = props => {
         <Form>
           <Grid md={6} gutter="md">
             <GridItem>
-              <FormGroup label="Source cluster" isRequired fieldId="sourceCluster">
+              <FormGroup
+                label="Source cluster"
+                isRequired
+                fieldId="sourceCluster"
+                helperTextInvalid={touched.sourceCluster && errors.sourceCluster}
+                isValid={!(touched.sourceCluster && errors.sourceCluster)}
+              >
                 <SimpleSelect
                   id="sourceCluster"
                   onChange={handleSourceChange}
                   options={srcClusterOptions}
                   value={values.sourceCluster}
                 />
-                {errors.sourceCluster && touched.sourceCluster && (
-                  <div id="feedback">{errors.sourceCluster}</div>
-                )}
               </FormGroup>
             </GridItem>
 
             <GridItem>
-              <FormGroup label="Target cluster" isRequired fieldId="targetCluster">
+              <FormGroup
+                label="Target cluster"
+                isRequired
+                fieldId="targetCluster"
+                helperTextInvalid={touched.targetCluster && errors.targetCluster}
+                isValid={!(touched.targetCluster && errors.targetCluster)}
+              >
                 <SimpleSelect
                   id="targetCluster"
                   onChange={handleTargetChange}
                   options={targetClusterOptions}
                   value={values.targetCluster}
                 />
-                {errors.targetCluster && touched.targetCluster && (
-                  <div id="feedback">{errors.targetCluster}</div>
-                )}
               </FormGroup>
             </GridItem>
 
             <GridItem>
-              <FormGroup label="Replication repository" isRequired fieldId="selectedStorage">
+              <FormGroup
+                label="Replication repository"
+                isRequired
+                fieldId="selectedStorage"
+                helperTextInvalid={touched.selectedStorage && errors.selectedStorage}
+                isValid={!(touched.selectedStorage && errors.selectedStorage)}
+              >
                 <SimpleSelect
                   id="selectedStorage"
                   onChange={handleStorageChange}
                   options={storageOptions}
                   value={values.selectedStorage}
                 />
-                {errors.selectedStorage && touched.selectedStorage && (
-                  <div id="feedback">{errors.selectedStorage}</div>
-                )}
               </FormGroup>
             </GridItem>
           </Grid>

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -6,9 +6,10 @@ import {
   FormGroup,
   Grid,
   GridItem,
+  Select,
+  SelectOption,
   Title,
 } from '@patternfly/react-core';
-import Select from 'react-select';
 import NamespaceTable from './NameSpaceTable';
 import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 
@@ -31,7 +32,7 @@ const ResourceSelectForm = props => {
     isFetchingNamespaceList,
     fetchNamespacesRequest,
     sourceClusterNamespaces,
-    isEdit
+    isEdit,
   } = props;
   useEffect(() => {
     if (isEdit) {
@@ -48,8 +49,9 @@ const ResourceSelectForm = props => {
       const targetOptions = [];
       const clusterLen = clusterList.length;
       for (let i = 0; i < clusterLen; i++) {
-        if (clusterList[i].MigCluster.metadata.name !== values.sourceCluster
-          && clusterList[i].ClusterStatus.hasReadyCondition
+        if (
+          clusterList[i].MigCluster.metadata.name !== values.sourceCluster &&
+          clusterList[i].ClusterStatus.hasReadyCondition
         ) {
           targetOptions.push({
             label: clusterList[i].MigCluster.metadata.name,
@@ -57,8 +59,8 @@ const ResourceSelectForm = props => {
           });
         }
         if (
-          clusterList[i].MigCluster.metadata.name !== values.targetCluster
-          && clusterList[i].ClusterStatus.hasReadyCondition
+          clusterList[i].MigCluster.metadata.name !== values.targetCluster &&
+          clusterList[i].ClusterStatus.hasReadyCondition
         ) {
           sourceOptions.push({
             label: clusterList[i].MigCluster.metadata.name,
@@ -101,9 +103,7 @@ const ResourceSelectForm = props => {
     const newStorageOptions = [];
     const storageLen = storageList.length;
     for (let i = 0; i < storageLen; i++) {
-      if (
-        storageList[i].StorageStatus.hasReadyCondition
-      ) {
+      if (storageList[i].StorageStatus.hasReadyCondition) {
         newStorageOptions.push({
           label: storageList[i].MigStorage.metadata.name,
           value: storageList[i].MigStorage.metadata.name,
@@ -121,7 +121,6 @@ const ResourceSelectForm = props => {
           label: existingStorageSelection.MigStorage.metadata.name,
           value: existingStorageSelection.MigStorage.metadata.name,
         });
-
       }
     }
   }, [values]);
@@ -158,23 +157,40 @@ const ResourceSelectForm = props => {
     });
     setFieldTouched('targetCluster');
   };
+
+  const [sourceClusterExpanded, setSourceClusterExpanded] = useState(false);
+  const [targetClusterExpanded, setTargetClusterExpanded] = useState(false);
+  const [storageExpanded, setStorageExpanded] = useState(false);
+
+  const extendWithToString = option => ({ ...option, toString: () => option.label });
+  const srcClusterOptionsMeta = srcClusterOptions.map(extendWithToString);
+  const targetClusterOptionsMeta = targetClusterOptions.map(extendWithToString);
+  const storageOptionsMeta = storageOptions.map(extendWithToString);
+
   return (
     <Grid gutter="md">
       <GridItem>
         <Form>
           <Grid md={6} gutter="md">
             <GridItem>
-              <FormGroup
-                label="Source cluster"
-                isRequired
-                fieldId="sourceCluster"
-              >
+              <FormGroup label="Source cluster" isRequired fieldId="sourceCluster">
                 <Select
-                  name="sourceCluster"
-                  onChange={handleSourceChange}
-                  options={srcClusterOptions}
-                  value={selectedSrcCluster}
-                />
+                  id="sourceCluster"
+                  placeholderText="Select..."
+                  isExpanded={sourceClusterExpanded}
+                  onToggle={setSourceClusterExpanded}
+                  onSelect={(event, selection) => {
+                    handleSourceChange(selection);
+                    setSourceClusterExpanded(false);
+                  }}
+                  selections={srcClusterOptionsMeta.find(
+                    option => selectedSrcCluster && option.value === selectedSrcCluster.value
+                  )}
+                >
+                  {srcClusterOptionsMeta.map(option => (
+                    <SelectOption key={option.value} value={option} />
+                  ))}
+                </Select>
                 {errors.sourceCluster && touched.sourceCluster && (
                   <div id="feedback">{errors.sourceCluster}</div>
                 )}
@@ -182,17 +198,24 @@ const ResourceSelectForm = props => {
             </GridItem>
 
             <GridItem>
-              <FormGroup
-                label="Target cluster"
-                isRequired
-                fieldId="targetCluster"
-              >
+              <FormGroup label="Target cluster" isRequired fieldId="targetCluster">
                 <Select
-                  name="targetCluster"
-                  onChange={handleTargetChange}
-                  options={targetClusterOptions}
-                  value={selectedTargetCluster}
-                />
+                  id="targetCluster"
+                  placeholderText="Select..."
+                  isExpanded={targetClusterExpanded}
+                  onToggle={setTargetClusterExpanded}
+                  onSelect={(event, selection) => {
+                    handleTargetChange(selection);
+                    setTargetClusterExpanded(false);
+                  }}
+                  selections={targetClusterOptionsMeta.find(
+                    option => selectedTargetCluster && option.value === selectedTargetCluster.value
+                  )}
+                >
+                  {targetClusterOptionsMeta.map(option => (
+                    <SelectOption key={option.value} value={option} />
+                  ))}
+                </Select>
                 {errors.targetCluster && touched.targetCluster && (
                   <div id="feedback">{errors.targetCluster}</div>
                 )}
@@ -200,17 +223,24 @@ const ResourceSelectForm = props => {
             </GridItem>
 
             <GridItem>
-              <FormGroup
-                label="Replication repository"
-                isRequired
-                fieldId="selectedStorage"
-              >
+              <FormGroup label="Replication repository" isRequired fieldId="selectedStorage">
                 <Select
-                  name="selectedStorage"
-                  onChange={handleStorageChange}
-                  options={storageOptions}
-                  value={selectedStorage}
-                />
+                  id="selectedStorage"
+                  placeholderText="Select..."
+                  isExpanded={storageExpanded}
+                  onToggle={setStorageExpanded}
+                  onSelect={(event, selection) => {
+                    handleStorageChange(selection);
+                    setStorageExpanded(false);
+                  }}
+                  selections={storageOptionsMeta.find(
+                    option => selectedStorage && option.value === selectedStorage.value
+                  )}
+                >
+                  {storageOptionsMeta.map(option => (
+                    <SelectOption key={option.value} value={option} />
+                  ))}
+                </Select>
                 {errors.selectedStorage && touched.selectedStorage && (
                   <div id="feedback">{errors.selectedStorage}</div>
                 )}

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -65,16 +65,10 @@ const ResourceSelectForm = props => {
       setTargetClusterOptions(targetOptions);
 
       if (values.sourceCluster !== null) {
-        const existingSrcCluster = clusterList.find(
-          c => c.MigCluster.metadata.name === values.sourceCluster
-        );
-        setSelectedSrcCluster(existingSrcCluster.MigCluster.metadata.name);
+        setSelectedSrcCluster(values.sourceCluster);
       }
       if (values.targetCluster !== null) {
-        const existingTargetCluster = clusterList.find(
-          c => c.MigCluster.metadata.name === values.targetCluster
-        );
-        setSelectedTargetCluster(existingTargetCluster.MigCluster.metadata.name);
+        setSelectedTargetCluster(values.targetCluster);
       }
     } else {
       setSrcClusterOptions(['No valid clusters found']);
@@ -92,35 +86,33 @@ const ResourceSelectForm = props => {
     setStorageOptions(newStorageOptions);
 
     if (values.selectedStorage !== null) {
-      const existingStorageSelection = storageList.find(
-        c => c.MigStorage.metadata.name === values.selectedStorage
-      );
-      if (existingStorageSelection) {
-        setSelectedStorage(existingStorageSelection.MigStorage.metadata.name);
-      }
+      setSelectedStorage(values.selectedStorage);
     }
   }, [values]);
 
   const handleStorageChange = value => {
+    // value came from storageList[].MigStorage.metadata.name
     setFieldValue('selectedStorage', value);
-    const matchingStorage = storageList.find(c => c.MigStorage.metadata.name === value);
-    setSelectedStorage(matchingStorage.MigStorage.metadata.name);
+    setSelectedStorage(value);
     setFieldTouched('selectedStorage');
+    // TODO do we even need the state here, or can we just use formik as the source of truth?
   };
 
   const handleSourceChange = value => {
+    // value came from clusterList[].MigCluster.metadata.name
     setFieldValue('sourceCluster', value);
-    const matchingCluster = clusterList.find(c => c.MigCluster.metadata.name === value);
-    setSelectedSrcCluster(matchingCluster.MigCluster.metadata.name);
+    setSelectedSrcCluster(value);
     setFieldTouched('sourceCluster');
-    fetchNamespacesRequest(matchingCluster.MigCluster.metadata.name);
+    fetchNamespacesRequest(value);
+    // TODO do we even need the state here, or can we just use formik as the source of truth?
   };
 
   const handleTargetChange = value => {
+    // value came from clusterList[].MigCluster.metadata.name
     setFieldValue('targetCluster', value);
-    const matchingCluster = clusterList.find(c => c.MigCluster.metadata.name === value);
-    setSelectedTargetCluster(matchingCluster.MigCluster.metadata.name);
+    setSelectedTargetCluster(value);
     setFieldTouched('targetCluster');
+    // TODO do we even need the state here, or can we just use formik as the source of truth?
   };
 
   return (

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -119,6 +119,7 @@ const ResourceSelectForm = props => {
                   onChange={handleSourceChange}
                   options={srcClusterOptions}
                   value={values.sourceCluster}
+                  placeholderText="Select source..."
                 />
               </FormGroup>
             </GridItem>
@@ -136,6 +137,7 @@ const ResourceSelectForm = props => {
                   onChange={handleTargetChange}
                   options={targetClusterOptions}
                   value={values.targetCluster}
+                  placeholderText="Select target..."
                 />
               </FormGroup>
             </GridItem>
@@ -153,6 +155,7 @@ const ResourceSelectForm = props => {
                   onChange={handleStorageChange}
                   options={storageOptions}
                   value={values.selectedStorage}
+                  placeholderText="Select repository..."
                 />
               </FormGroup>
             </GridItem>

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -77,22 +77,28 @@ const ResourceSelectForm = props => {
   }, [values]);
 
   const handleStorageChange = value => {
-    // value came from storageList[].MigStorage.metadata.name
-    setFieldValue('selectedStorage', value);
-    setFieldTouched('selectedStorage');
+    const matchingStorage = storageList.find(c => c.MigStorage.metadata.name === value);
+    if (matchingStorage) {
+      setFieldValue('selectedStorage', value);
+      setFieldTouched('selectedStorage');
+    }
   };
 
   const handleSourceChange = value => {
-    // value came from clusterList[].MigCluster.metadata.name
-    setFieldValue('sourceCluster', value);
-    setFieldTouched('sourceCluster');
-    fetchNamespacesRequest(value);
+    const matchingCluster = clusterList.find(c => c.MigCluster.metadata.name === value);
+    if (matchingCluster) {
+      setFieldValue('sourceCluster', value);
+      setFieldTouched('sourceCluster');
+      fetchNamespacesRequest(value);
+    }
   };
 
   const handleTargetChange = value => {
-    // value came from clusterList[].MigCluster.metadata.name
-    setFieldValue('targetCluster', value);
-    setFieldTouched('targetCluster');
+    const matchingCluster = clusterList.find(c => c.MigCluster.metadata.name === value);
+    if (matchingCluster) {
+      setFieldValue('targetCluster', value);
+      setFieldTouched('targetCluster');
+    }
   };
 
   return (

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -6,12 +6,11 @@ import {
   FormGroup,
   Grid,
   GridItem,
-  Select,
-  SelectOption,
   Title,
 } from '@patternfly/react-core';
 import NamespaceTable from './NameSpaceTable';
 import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
+import SimpleSelect from '../../../common/components/SimpleSelect';
 
 const ResourceSelectForm = props => {
   const [srcClusterOptions, setSrcClusterOptions] = useState([]);
@@ -53,19 +52,13 @@ const ResourceSelectForm = props => {
           clusterList[i].MigCluster.metadata.name !== values.sourceCluster &&
           clusterList[i].ClusterStatus.hasReadyCondition
         ) {
-          targetOptions.push({
-            label: clusterList[i].MigCluster.metadata.name,
-            value: clusterList[i].MigCluster.metadata.name,
-          });
+          targetOptions.push(clusterList[i].MigCluster.metadata.name);
         }
         if (
           clusterList[i].MigCluster.metadata.name !== values.targetCluster &&
           clusterList[i].ClusterStatus.hasReadyCondition
         ) {
-          sourceOptions.push({
-            label: clusterList[i].MigCluster.metadata.name,
-            value: clusterList[i].MigCluster.metadata.name,
-          });
+          sourceOptions.push(clusterList[i].MigCluster.metadata.name);
         }
       }
       setSrcClusterOptions(sourceOptions);
@@ -75,27 +68,16 @@ const ResourceSelectForm = props => {
         const existingSrcCluster = clusterList.find(
           c => c.MigCluster.metadata.name === values.sourceCluster
         );
-        setSelectedSrcCluster({
-          label: existingSrcCluster.MigCluster.metadata.name,
-          value: existingSrcCluster.MigCluster.metadata.name,
-        });
+        setSelectedSrcCluster(existingSrcCluster.MigCluster.metadata.name);
       }
       if (values.targetCluster !== null) {
         const existingTargetCluster = clusterList.find(
           c => c.MigCluster.metadata.name === values.targetCluster
         );
-        setSelectedTargetCluster({
-          label: existingTargetCluster.MigCluster.metadata.name,
-          value: existingTargetCluster.MigCluster.metadata.name,
-        });
+        setSelectedTargetCluster(existingTargetCluster.MigCluster.metadata.name);
       }
     } else {
-      const myOptions: any = [];
-      myOptions.push({
-        label: 'No valid clusters found',
-        value: 'N/A',
-      });
-      setSrcClusterOptions(myOptions);
+      setSrcClusterOptions(['No valid clusters found']);
     }
     // ***
     // * Populate storage dropdown
@@ -104,10 +86,7 @@ const ResourceSelectForm = props => {
     const storageLen = storageList.length;
     for (let i = 0; i < storageLen; i++) {
       if (storageList[i].StorageStatus.hasReadyCondition) {
-        newStorageOptions.push({
-          label: storageList[i].MigStorage.metadata.name,
-          value: storageList[i].MigStorage.metadata.name,
-        });
+        newStorageOptions.push(storageList[i].MigStorage.metadata.name);
       }
     }
     setStorageOptions(newStorageOptions);
@@ -117,55 +96,32 @@ const ResourceSelectForm = props => {
         c => c.MigStorage.metadata.name === values.selectedStorage
       );
       if (existingStorageSelection) {
-        setSelectedStorage({
-          label: existingStorageSelection.MigStorage.metadata.name,
-          value: existingStorageSelection.MigStorage.metadata.name,
-        });
+        setSelectedStorage(existingStorageSelection.MigStorage.metadata.name);
       }
     }
   }, [values]);
 
-  const handleStorageChange = option => {
-    setFieldValue('selectedStorage', option.value);
-    const matchingStorage = storageList.find(c => c.MigStorage.metadata.name === option.value);
-
-    setSelectedStorage({
-      label: matchingStorage.MigStorage.metadata.name,
-      value: matchingStorage.MigStorage.metadata.name,
-    });
-
+  const handleStorageChange = value => {
+    setFieldValue('selectedStorage', value);
+    const matchingStorage = storageList.find(c => c.MigStorage.metadata.name === value);
+    setSelectedStorage(matchingStorage.MigStorage.metadata.name);
     setFieldTouched('selectedStorage');
   };
 
-  const handleSourceChange = option => {
-    setFieldValue('sourceCluster', option.value);
-    const matchingCluster = clusterList.find(c => c.MigCluster.metadata.name === option.value);
-    setSelectedSrcCluster({
-      label: matchingCluster.MigCluster.metadata.name,
-      value: matchingCluster.MigCluster.metadata.name,
-    });
+  const handleSourceChange = value => {
+    setFieldValue('sourceCluster', value);
+    const matchingCluster = clusterList.find(c => c.MigCluster.metadata.name === value);
+    setSelectedSrcCluster(matchingCluster.MigCluster.metadata.name);
     setFieldTouched('sourceCluster');
     fetchNamespacesRequest(matchingCluster.MigCluster.metadata.name);
   };
 
-  const handleTargetChange = option => {
-    setFieldValue('targetCluster', option.value);
-    const matchingCluster = clusterList.find(c => c.MigCluster.metadata.name === option.value);
-    setSelectedTargetCluster({
-      label: matchingCluster.MigCluster.metadata.name,
-      value: matchingCluster.MigCluster.metadata.name,
-    });
+  const handleTargetChange = value => {
+    setFieldValue('targetCluster', value);
+    const matchingCluster = clusterList.find(c => c.MigCluster.metadata.name === value);
+    setSelectedTargetCluster(matchingCluster.MigCluster.metadata.name);
     setFieldTouched('targetCluster');
   };
-
-  const [sourceClusterExpanded, setSourceClusterExpanded] = useState(false);
-  const [targetClusterExpanded, setTargetClusterExpanded] = useState(false);
-  const [storageExpanded, setStorageExpanded] = useState(false);
-
-  const extendWithToString = option => ({ ...option, toString: () => option.label });
-  const srcClusterOptionsMeta = srcClusterOptions.map(extendWithToString);
-  const targetClusterOptionsMeta = targetClusterOptions.map(extendWithToString);
-  const storageOptionsMeta = storageOptions.map(extendWithToString);
 
   return (
     <Grid gutter="md">
@@ -174,23 +130,12 @@ const ResourceSelectForm = props => {
           <Grid md={6} gutter="md">
             <GridItem>
               <FormGroup label="Source cluster" isRequired fieldId="sourceCluster">
-                <Select
+                <SimpleSelect
                   id="sourceCluster"
-                  placeholderText="Select..."
-                  isExpanded={sourceClusterExpanded}
-                  onToggle={setSourceClusterExpanded}
-                  onSelect={(event, selection) => {
-                    handleSourceChange(selection);
-                    setSourceClusterExpanded(false);
-                  }}
-                  selections={srcClusterOptionsMeta.find(
-                    option => selectedSrcCluster && option.value === selectedSrcCluster.value
-                  )}
-                >
-                  {srcClusterOptionsMeta.map(option => (
-                    <SelectOption key={option.value} value={option} />
-                  ))}
-                </Select>
+                  onChange={handleSourceChange}
+                  options={srcClusterOptions}
+                  value={selectedSrcCluster}
+                />
                 {errors.sourceCluster && touched.sourceCluster && (
                   <div id="feedback">{errors.sourceCluster}</div>
                 )}
@@ -199,23 +144,12 @@ const ResourceSelectForm = props => {
 
             <GridItem>
               <FormGroup label="Target cluster" isRequired fieldId="targetCluster">
-                <Select
+                <SimpleSelect
                   id="targetCluster"
-                  placeholderText="Select..."
-                  isExpanded={targetClusterExpanded}
-                  onToggle={setTargetClusterExpanded}
-                  onSelect={(event, selection) => {
-                    handleTargetChange(selection);
-                    setTargetClusterExpanded(false);
-                  }}
-                  selections={targetClusterOptionsMeta.find(
-                    option => selectedTargetCluster && option.value === selectedTargetCluster.value
-                  )}
-                >
-                  {targetClusterOptionsMeta.map(option => (
-                    <SelectOption key={option.value} value={option} />
-                  ))}
-                </Select>
+                  onChange={handleTargetChange}
+                  options={targetClusterOptions}
+                  value={selectedTargetCluster}
+                />
                 {errors.targetCluster && touched.targetCluster && (
                   <div id="feedback">{errors.targetCluster}</div>
                 )}
@@ -224,23 +158,12 @@ const ResourceSelectForm = props => {
 
             <GridItem>
               <FormGroup label="Replication repository" isRequired fieldId="selectedStorage">
-                <Select
+                <SimpleSelect
                   id="selectedStorage"
-                  placeholderText="Select..."
-                  isExpanded={storageExpanded}
-                  onToggle={setStorageExpanded}
-                  onSelect={(event, selection) => {
-                    handleStorageChange(selection);
-                    setStorageExpanded(false);
-                  }}
-                  selections={storageOptionsMeta.find(
-                    option => selectedStorage && option.value === selectedStorage.value
-                  )}
-                >
-                  {storageOptionsMeta.map(option => (
-                    <SelectOption key={option.value} value={option} />
-                  ))}
-                </Select>
+                  onChange={handleStorageChange}
+                  options={storageOptions}
+                  value={selectedStorage}
+                />
                 {errors.selectedStorage && touched.selectedStorage && (
                   <div id="feedback">{errors.selectedStorage}</div>
                 )}

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -17,9 +17,6 @@ const ResourceSelectForm = props => {
   const [targetClusterOptions, setTargetClusterOptions] = useState([]);
   const [storageOptions, setStorageOptions] = useState([]);
 
-  const [selectedSrcCluster, setSelectedSrcCluster] = useState(null);
-  const [selectedTargetCluster, setSelectedTargetCluster] = useState(null);
-  const [selectedStorage, setSelectedStorage] = useState(null);
   const {
     clusterList,
     storageList,
@@ -63,13 +60,6 @@ const ResourceSelectForm = props => {
       }
       setSrcClusterOptions(sourceOptions);
       setTargetClusterOptions(targetOptions);
-
-      if (values.sourceCluster !== null) {
-        setSelectedSrcCluster(values.sourceCluster);
-      }
-      if (values.targetCluster !== null) {
-        setSelectedTargetCluster(values.targetCluster);
-      }
     } else {
       setSrcClusterOptions(['No valid clusters found']);
     }
@@ -84,35 +74,25 @@ const ResourceSelectForm = props => {
       }
     }
     setStorageOptions(newStorageOptions);
-
-    if (values.selectedStorage !== null) {
-      setSelectedStorage(values.selectedStorage);
-    }
   }, [values]);
 
   const handleStorageChange = value => {
     // value came from storageList[].MigStorage.metadata.name
     setFieldValue('selectedStorage', value);
-    setSelectedStorage(value);
     setFieldTouched('selectedStorage');
-    // TODO do we even need the state here, or can we just use formik as the source of truth?
   };
 
   const handleSourceChange = value => {
     // value came from clusterList[].MigCluster.metadata.name
     setFieldValue('sourceCluster', value);
-    setSelectedSrcCluster(value);
     setFieldTouched('sourceCluster');
     fetchNamespacesRequest(value);
-    // TODO do we even need the state here, or can we just use formik as the source of truth?
   };
 
   const handleTargetChange = value => {
     // value came from clusterList[].MigCluster.metadata.name
     setFieldValue('targetCluster', value);
-    setSelectedTargetCluster(value);
     setFieldTouched('targetCluster');
-    // TODO do we even need the state here, or can we just use formik as the source of truth?
   };
 
   return (
@@ -126,7 +106,7 @@ const ResourceSelectForm = props => {
                   id="sourceCluster"
                   onChange={handleSourceChange}
                   options={srcClusterOptions}
-                  value={selectedSrcCluster}
+                  value={values.sourceCluster}
                 />
                 {errors.sourceCluster && touched.sourceCluster && (
                   <div id="feedback">{errors.sourceCluster}</div>
@@ -140,7 +120,7 @@ const ResourceSelectForm = props => {
                   id="targetCluster"
                   onChange={handleTargetChange}
                   options={targetClusterOptions}
-                  value={selectedTargetCluster}
+                  value={values.targetCluster}
                 />
                 {errors.targetCluster && touched.targetCluster && (
                   <div id="feedback">{errors.targetCluster}</div>
@@ -154,7 +134,7 @@ const ResourceSelectForm = props => {
                   id="selectedStorage"
                   onChange={handleStorageChange}
                   options={storageOptions}
-                  value={selectedStorage}
+                  value={values.selectedStorage}
                 />
                 {errors.selectedStorage && touched.selectedStorage && (
                   <div id="feedback">{errors.selectedStorage}</div>


### PR DESCRIPTION
This PR implements everything for #585 except the table changes.

* I replaced the `react-select` component with patternfly's `Select`  via a thin wrapper called `SimpleSelect` that I added to avoid repeating boilerplate for simple string selections.

  * `react-select` is still present in a few other places, but they are all covered by other issues so I'll address them individually. (#586, #587, #663, #736)

* I replaced the default "Select..." placeholder text with "Select source...", "Select repository...", and "Select target..." per @vconzola's comment: https://github.com/konveyor/mig-ui/issues/585#issuecomment-532332415

* The `{ label, value }` objects used for options in the previous Select component are now unnecessary, and while `Select` does support complex values like this, they were adding nothing here so I simplified things by switching to plain string values for the select options.

* The selected value of each `Select` was being stored both in React `useState` and up the tree in Formik state. I removed the local state and just used the Formik values as the source of truth so we don't have to keep redundant state synced up here.

* The `fieldId` prop of `FormGroup` was used incorrectly: in order for it to associate labels to the right fields for screen-reader users, there must be an `id` prop on the actual field itself matching the `fieldId`.

* Errors were rendered with a special `<div id="feedback">` instead of the `helperTextInvalid` prop of `FormGroup`. (see #691 and #698)

* When no valid source clusters are found, an option was rendered in the source clusters menu with the value "N/A". Selecting this value caused a JS error in the change handler:
  ```
  Uncaught TypeError: Cannot read property 'MigCluster' of undefined
      at Object.handleSourceChange [as onChange] (ResourceSelectForm.tsx?e280:144)
  ```

  To fix this error, I check that the matching cluster/storage exists before trying to reference its properties.