### PR TITLE
Replace react-table with PF Table in Resources step of plan wizard

### DIFF
--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -23,65 +23,12 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
 
   if (values.sourceCluster === null) return null;
 
-  /*
-  update formik when local state changes -- no need
   useEffect(() => {
-    if (sourceClusterNamespaces.length > 0) {
-      const formValuesForNamespaces = sourceClusterNamespaces
-        .filter(item => {
-          const keys = Object.keys(checkedNamespaceRows);
+    console.log('>>>>>>>>>>> SELECTED NAMESPACES CHANGED', values.selectedNamespaces);
+  }, [values.selectedNamespaces]);
 
-          for (const key of keys) {
-            if (item.name === key && checkedNamespaceRows[key]) {
-              return item;
-            }
-          }
-        })
-        .map(namespace => namespace.name);
-
-      setFieldValue('selectedNamespaces', formValuesForNamespaces);
-    }
-  }, [checkedNamespaceRows]);
-  */
-
-  /* initialize local state from formik -- no need
-  useEffect(() => {
-    if (values.selectedNamespaces.length > 0 && sourceClusterNamespaces.length > 0) {
-      const newSelected = Object.assign({}, checkedNamespaceRows);
-      values.selectedNamespaces.filter((item, _) => {
-        for (let i = 0; sourceClusterNamespaces.length > i; i++) {
-          if (item === sourceClusterNamespaces[i].name) {
-            newSelected[item] = true;
-          }
-        }
-      });
-      setCheckedNamespaceRows(newSelected);
-    }
-  }, [sourceClusterNamespaces]);
-  */
-
-  /* update local state on select all -- no need?
-  const toggleSelectAll = () => {
-    const newSelected = {};
-
-    if (selectAll === 0) {
-      sourceClusterNamespaces.forEach(item => {
-        newSelected[item.name] = true;
-      });
-    }
-    setSelectAll(selectAll === 0 ? 1 : 0);
-    setCheckedNamespaceRows(newSelected);
-  };
-  */
-
-  /* update local state on select -- update formik directly instead
-  const selectRow = rowId => {
-    const newSelected = Object.assign({}, checkedNamespaceRows);
-    newSelected[rowId] = !checkedNamespaceRows[rowId];
-    setCheckedNamespaceRows(newSelected);
-    setSelectAll(2);
-  };
-  */
+  const currentSelected = JSON.parse(JSON.stringify(values.selectedNamespaces));
+  console.log('>>> -- selected namespaces at render time?', currentSelected);
 
   const columns = [
     { title: 'Name' },
@@ -91,11 +38,12 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
   ];
   const rows = sourceClusterNamespaces.map(namespace => ({
     cells: [namespace.name, namespace.podCount, namespace.pvcCount, namespace.serviceCount],
-    selected: values.selectedNamespaces.includes(namespace.name),
+    selected: currentSelected.includes(namespace.name),
   }));
 
   const onSelect = (event, isSelected, rowIndex) => {
-    console.log('was already selected?', values.selectedNamespaces);
+    console.log('=========  SELECT  ============');
+    console.log('??? -- selected namespaces at select time?', [...currentSelected]);
     let newSelected;
     if (rowIndex === -1) {
       if (isSelected) {
@@ -106,10 +54,9 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
     } else {
       const thisNamespace = sourceClusterNamespaces[rowIndex];
       if (isSelected) {
-        console.log('New shit:', [...values.selectedNamespaces, thisNamespace.name]);
-        newSelected = [...new Set([...values.selectedNamespaces, thisNamespace.name])];
+        newSelected = [...new Set([...currentSelected, thisNamespace.name])];
       } else {
-        newSelected = values.selectedNamespaces.filter(name => name !== thisNamespace.name);
+        newSelected = currentSelected.filter(name => name !== thisNamespace.name);
       }
     }
     setFieldValue('selectedNamespaces', newSelected);

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -1,5 +1,15 @@
-import React from 'react';
-import { GridItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import {
+  GridItem,
+  Text,
+  TextContent,
+  TextVariants,
+  Level,
+  LevelItem,
+  Pagination,
+  PaginationProps,
+  PaginationVariant,
+} from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
@@ -47,15 +57,27 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
         newSelected = []; // Deselect all
       }
     } else {
-      const { selectedNamespaces } = rowData.meta;
-      const thisNamespace = sourceClusterNamespaces[rowIndex];
+      const { meta, name } = rowData;
       if (isSelected) {
-        newSelected = [...new Set([...selectedNamespaces, thisNamespace.name])];
+        newSelected = [...new Set([...meta.selectedNamespaces, name.title])];
       } else {
-        newSelected = selectedNamespaces.filter(name => name !== thisNamespace.name);
+        newSelected = meta.selectedNamespaces.filter(selected => selected !== name.title);
       }
     }
     setFieldValue('selectedNamespaces', newSelected);
+  };
+
+  const [currentPageNumber, setCurrentPageNumber] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
+  const pageStartIndex = (currentPageNumber - 1) * itemsPerPage;
+  const currentPageRows = rows.slice(pageStartIndex, pageStartIndex + itemsPerPage);
+
+  const paginationProps: PaginationProps = {
+    itemCount: rows.length,
+    perPage: itemsPerPage,
+    page: currentPageNumber,
+    onSetPage: (event, pageNumber) => setCurrentPageNumber(pageNumber),
+    onPerPageSelect: (event, perPage) => setItemsPerPage(perPage),
   };
 
   return (
@@ -66,17 +88,36 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
         </TextContent>
       </GridItem>
       <GridItem>
+        <Level>
+          <LevelItem>
+            <TextContent>
+              <Text
+                component={TextVariants.small}
+                className={spacing.mlLg}
+              >{`${values.selectedNamespaces.length} selected`}</Text>
+            </TextContent>
+          </LevelItem>
+          <LevelItem>
+            <Pagination widgetId="namespace-table-pagination-top" {...paginationProps} />
+          </LevelItem>
+        </Level>
         <Table
           aria-label="Projects table"
           variant={TableVariant.compact}
           cells={columns}
-          rows={rows}
+          rows={currentPageRows}
           onSelect={onSelect}
           canSelectAll
         >
           <TableHeader />
           <TableBody />
         </Table>
+        <Pagination
+          widgetId="namespace-table-pagination-bottom"
+          variant={PaginationVariant.bottom}
+          className={spacing.mtMd}
+          {...paginationProps}
+        />
       </GridItem>
     </React.Fragment>
   );

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -9,6 +9,7 @@ import {
   Pagination,
   PaginationProps,
   PaginationVariant,
+  DropdownDirection,
 } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
@@ -116,6 +117,7 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
           widgetId="namespace-table-pagination-bottom"
           variant={PaginationVariant.bottom}
           className={spacing.mtMd}
+          dropDirection={DropdownDirection.up}
           {...paginationProps}
         />
       </GridItem>

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { GridItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
-const styles = require('./NamespaceTable.module');
 interface INamespaceTableProps {
   isEdit: boolean;
   values: any;
@@ -19,7 +18,7 @@ interface INamespaceTableProps {
 }
 
 const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
-  const { isEdit, setFieldValue, sourceClusterNamespaces, values } = props;
+  const { setFieldValue, sourceClusterNamespaces, values } = props;
 
   if (values.sourceCluster === null) return null;
 

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -1,18 +1,20 @@
 import React, { useState, useEffect } from 'react';
-import ReactTable from 'react-table';
-import 'react-table/react-table.css';
-import {
-  GridItem,
-  Text,
-  TextContent,
-  TextVariants,
-} from '@patternfly/react-core';
+import { GridItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 const styles = require('./NamespaceTable.module');
 interface INamespaceTableProps {
   isEdit: boolean;
   values: any;
-  sourceClusterNamespaces: any;
+  sourceClusterNamespaces: [
+    {
+      name: string;
+      podCount: number;
+      pvcCount: number;
+      serviceCount: number;
+    }
+  ];
   setFieldValue: (fieldName, fieldValue) => void;
 }
 
@@ -23,15 +25,17 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
 
   useEffect(() => {
     if (sourceClusterNamespaces.length > 0) {
-      const formValuesForNamespaces = sourceClusterNamespaces.filter((item) => {
-        const keys = Object.keys(checkedNamespaceRows);
+      const formValuesForNamespaces = sourceClusterNamespaces
+        .filter(item => {
+          const keys = Object.keys(checkedNamespaceRows);
 
-        for (const key of keys) {
-          if (item.name === key && checkedNamespaceRows[key]) {
-            return item;
+          for (const key of keys) {
+            if (item.name === key && checkedNamespaceRows[key]) {
+              return item;
+            }
           }
-        }
-      }).map((namespace) => namespace.name);
+        })
+        .map(namespace => namespace.name);
 
       setFieldValue('selectedNamespaces', formValuesForNamespaces);
     }
@@ -70,119 +74,42 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
     setSelectAll(2);
   };
 
-  const tableStyle = {
-    fontSize: '14px',
-  };
-
   if (values.sourceCluster !== null) {
+    console.log({ sourceClusterNamespaces });
+
+    const columns = [
+      { title: 'Name' },
+      { title: 'Pods' },
+      { title: 'PV claims' },
+      { title: 'Services' },
+    ];
+    const rows = sourceClusterNamespaces.map(namespace => ({
+      cells: [namespace.name, namespace.podCount, namespace.pvcCount, namespace.serviceCount],
+    }));
+
     return (
       <React.Fragment>
         <GridItem>
-          <TextContent>
-            <Text component={TextVariants.p}>
-              Select projects to be migrated:
-            </Text>
+          <TextContent className={spacing.mtMd}>
+            <Text component={TextVariants.p}>Select projects to be migrated:</Text>
           </TextContent>
         </GridItem>
-
         <GridItem>
-          <ReactTable
-            className="-striped -highlight"
-            style={tableStyle}
-            data={sourceClusterNamespaces}
-            columns={[
-              {
-                id: 'checkbox',
-                accessor: '',
-                resizable: false,
-                width: 50,
-                Cell: ({ original }) => {
-                  return (
-                    <div style={{ textAlign: 'center' }}>
-                      <input
-                        type="checkbox"
-                        onChange={() => selectRow(original.name)}
-                        checked={checkedNamespaceRows[original.name] === true}
-                      />
-                    </div>
-                  );
-                },
-                Header: () => {
-                  return (
-                    <input
-                      type="checkbox"
-                      className="checkbox"
-                      checked={selectAll === 1}
-                      ref={input => {
-                        if (input) {
-                          input.indeterminate = selectAll === 2;
-                        }
-                      }}
-                      onChange={toggleSelectAll}
-                    />
-                  );
-                }
-              },
-              {
-                Header: () => (
-                  <div
-                    style={{
-                      textAlign: 'left',
-                      fontWeight: 600,
-                    }}
-                  >
-                    Name
-                  </div>
-                ),
-                accessor: 'name',
-              },
-              {
-                Header: () => (
-                  <div
-                    style={{
-                      textAlign: 'left',
-                      fontWeight: 600,
-                    }}
-                  >
-                    Number of pods
-                  </div>
-                ),
-                accessor: 'podCount',
-              },
-              {
-                Header: () => (
-                  <div
-                    style={{
-                      textAlign: 'left',
-                      fontWeight: 600,
-                    }}
-                  >
-                    Number of PV claims
-                  </div>
-                ),
-                accessor: 'pvcCount',
-              },
-              {
-                Header: () => (
-                  <div
-                    style={{
-                      textAlign: 'left',
-                      fontWeight: 600,
-                    }}
-                  >
-                    Number of services
-                  </div>
-                ),
-                accessor: 'serviceCount',
-              },
-            ]}
-            defaultPageSize={5}
-          />
+          <Table
+            aria-label="Projects table"
+            variant={TableVariant.compact}
+            cells={columns}
+            rows={rows}
+            // onSelect={() => {}}
+            // canSelectAll
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
         </GridItem>
       </React.Fragment>
     );
-  }
-  else {
+  } else {
     return null;
   }
 };

--- a/src/app/plan/components/Wizard/NamespaceTable.module.scss
+++ b/src/app/plan/components/Wizard/NamespaceTable.module.scss
@@ -1,0 +1,1 @@
+// TODO remove me?

--- a/src/app/plan/components/Wizard/NamespaceTable.module.scss
+++ b/src/app/plan/components/Wizard/NamespaceTable.module.scss
@@ -1,1 +1,0 @@
-// TODO remove me?


### PR DESCRIPTION
Closes #585.

This replaces the `react-table` which was in place in this wizard step with PatternFly Table and Pagination components. In the process, I removed local state and adopted Formik's state as the source of truth for which rows are selected, similarly to #738. This made all of the `useEffect` logic in this file unnecessary.

<img width="1073" alt="Screenshot 2020-03-13 19 21 07" src="https://user-images.githubusercontent.com/811963/76668144-e8c8e580-655f-11ea-8906-34f969fc3676.png">

While implementing this, I got stuck for a while on an issue with the scope accessible from the `onSelect` function being out-of-date. I think this is a bug in the PF Table component, and I plan to reproduce it in a CodeSandbox and open an issue in PatternFly for that next week. For the time being, I worked around it by passing a reference to current selection state into each row object, and referencing that `rowData` in `onSelect` instead of directly referencing the component's main function scope.