### PR TITLE
Trim whitespace from cluster and s3 URL

### DIFF
--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -269,7 +269,7 @@ function* updateClusterRequest(action) {
   const aggregatedPatch = { spec: {} };
 
   if (urlUpdated) {
-    aggregatedPatch.spec['url'] = clusterValues.url;
+    aggregatedPatch.spec['url'] = clusterValues.url.trim();
   }
 
   if (azureUpdated) {

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -42,6 +42,8 @@ export function createMigCluster(
   requireSSL: boolean,
   caBundle: string
 ) {
+  clusterUrl = clusterUrl.trim()
+
   let specObject;
   if (isAzure) {
     specObject = {
@@ -110,7 +112,7 @@ export function createMigStorage(
           backupStorageConfig: {
             awsBucketName,
             awsRegion: awsBucketRegion,
-            awsS3Url: s3Url,
+            awsS3Url: s3Url.trim(),
             credsSecretRef: {
               name: tokenSecret.metadata.name,
               namespace: tokenSecret.metadata.namespace,
@@ -209,7 +211,7 @@ export function updateMigStorage(
           backupStorageConfig: {
             awsBucketName: bucketName,
             awsRegion: bucketRegion,
-            awsS3Url: s3Url,
+            awsS3Url: s3Url.trim(),
             insecure: !requireSSL,
             s3CustomCABundle: caBundle || undefined,
           },


### PR DESCRIPTION
Trims whitespace from the cluster and s3 URLs before submitting them to the API.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1798116