### PR TITLE
MigCluster : Use generateName to create unique secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,21 @@ configure your local development settings.
 `cp config/config.dev.json.example config/config.dev.json`
 
 Also ensure you have yarn installed by following recommended install instructions:
-
 https://yarnpkg.com/en/docs/install#centos-stable
+
+Install development/build dependencies
+`yarn`
+
+Start the development server
+`yarn start`
+
+Run a full build
+`yarn build`
+
+Consistent styles are enforced by travis and will gate PR merges. To check your code prior
+to submission, run:
+`yarn lint`
+
 
 ### UI development server
 
@@ -47,15 +60,5 @@ yarn start:remote # start the UI development server, backed by remote cluster
 
 ## Contributing
 
-Install development/build dependencies
-`yarn`
-
-Start the development server
-`yarn start`
-
-Run a full build
-`yarn build`
-
-Consistent styles are enforced by travis and will gate PR merges. To check your code prior
-to submission, run:
-`yarn lint`
+Contributors please read and follow the [contributing recommendations](CONTRIBUTING.md)
+which also provides more details about the project.

--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -89,9 +89,11 @@ function* removeClusterSaga(action) {
     );
     const migClusterResource = new MigResource(MigResourceKind.MigCluster, migMeta.namespace);
     
-    const secretResourceList = yield client.list(secretResource, getTokenSecretLabelSelector(MigResourceKind.MigCluster, name))
+    const secretResourceList = yield client.list(secretResource, 
+      getTokenSecretLabelSelector(MigResourceKind.MigCluster, name));
 
-    const secretResourceName = secretResourceList.data.items[0].metadata.name;
+    const secretResourceName = (secretResourceList.data.items && secretResourceList.data.items.length > 0) 
+      ? secretResourceList.data.items[0].metadata.name : '';
 
     yield Promise.all([
       client.delete(secretResource, secretResourceName),
@@ -140,15 +142,16 @@ function* addClusterRequest(action) {
   // Ensure that none of objects that make up a cluster already exist
   try {
     const getResults = yield Q.allSettled([
-      client.list(secretResource, getTokenSecretLabelSelector(MigResourceKind.MigCluster, migCluster.metadata.name)),
+      client.list(secretResource, 
+        getTokenSecretLabelSelector(MigResourceKind.MigCluster, migCluster.metadata.name)),
       client.get(migClusterResource, migCluster.metadata.name),
     ]);
 
     const alreadyExists = getResults.reduce((exists, res) => {
       return res && res.status === 200 ?
         [...exists, { kind: res.value.data.kind, 
-          name: res.value.data.items[0].metadata.name ? res.value.data.items && 
-          res.value.data.items.length > 0 : res.value.data.metadata.name
+          name:  (res.value.data.items && res.value.data.items.length > 0) 
+            ? res.value.data.items[0].metadata.name : res.value.data.metadata.name
         }] :
         exists;
     }, []);

--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -10,6 +10,7 @@ import {
   createTokenSecret,
   createMigCluster,
   updateTokenSecret,
+  getTokenSecretLabelSelector,
 } from '../../../client/resources/conversions';
 
 import { ClusterActions, ClusterActionTypes } from './actions';
@@ -87,9 +88,13 @@ function* removeClusterSaga(action) {
       migMeta.configNamespace
     );
     const migClusterResource = new MigResource(MigResourceKind.MigCluster, migMeta.namespace);
+    
+    const secretResourceList = yield client.list(secretResource, getTokenSecretLabelSelector(MigResourceKind.MigCluster, name))
+
+    const secretResourceName = secretResourceList.data.items[0].metadata.name;
 
     yield Promise.all([
-      client.delete(secretResource, name),
+      client.delete(secretResource, secretResourceName),
       client.delete(migClusterResource, name),
     ]);
 
@@ -110,8 +115,11 @@ function* addClusterRequest(action) {
   const tokenSecret = createTokenSecret(
     clusterValues.name,
     migMeta.configNamespace,
-    clusterValues.token
+    clusterValues.token,
+    MigResourceKind.MigCluster,
+    clusterValues.name
   );
+
   const migCluster = createMigCluster(
     clusterValues.name,
     migMeta.namespace,
@@ -132,13 +140,16 @@ function* addClusterRequest(action) {
   // Ensure that none of objects that make up a cluster already exist
   try {
     const getResults = yield Q.allSettled([
-      client.get(secretResource, tokenSecret.metadata.name),
+      client.list(secretResource, getTokenSecretLabelSelector(MigResourceKind.MigCluster, migCluster.metadata.name)),
       client.get(migClusterResource, migCluster.metadata.name),
-    ]);
+    ]);;
 
     const alreadyExists = getResults.reduce((exists, res) => {
-      return res.value && res.value.status === 200 ?
-        [...exists, { kind: res.value.data.kind, name: res.value.data.metadata.name }] :
+      return res && res.status === 200 ?
+        [...exists, { kind: res.value.data.kind, 
+          name: res.value.data.items[0].metadata.name ? res.value.data.items && 
+          res.value.data.items.length > 0 : res.value.data.metadata.name
+        }] :
         exists;
     }, []);
 
@@ -162,18 +173,30 @@ function* addClusterRequest(action) {
   // If any of the objects actually fail creation, we need to rollback the others
   // so the clusters are created, or fail atomically
   try {
-    const clusterAddResults = yield Q.allSettled([
-      client.create(secretResource, tokenSecret),
-      client.create(migClusterResource, migCluster),
-    ]);
+    const clusterAddResults = [];
+    const tokenSecretAddResult = yield client.create(secretResource, tokenSecret);
+
+    if (tokenSecretAddResult.status === 201) {
+      clusterAddResults.push(tokenSecretAddResult);
+
+      Object.assign(migCluster.spec.serviceAccountSecretRef, { 
+        name: tokenSecretAddResult.data.metadata.name,
+        namespace: tokenSecretAddResult.data.metadata.namespace,
+        });
+
+      const clusterAddResult = yield client.create(migClusterResource, migCluster);
+      if (clusterAddResult.status === 201) {
+        clusterAddResults.push(clusterAddResult);
+      }
+    }
 
     // If any of the attempted object creation promises have failed, we need to
     // rollback those that succeeded so we don't have a halfway created "Cluster"
     // A rollback is only required if some objects have actually *succeeded*,
     // as well as failed.
-    const isRollbackRequired =
-      clusterAddResults.find(res => res.state === 'rejected') &&
-      clusterAddResults.find(res => res.state === 'fulfilled');
+    const isRollbackRequired = 
+      clusterAddResults.find(res => res.status === 201) &&
+      clusterAddResults.find(res => res.status !== 201)
 
     if (isRollbackRequired) {
       const kindToResourceMap = {
@@ -183,8 +206,8 @@ function* addClusterRequest(action) {
 
       // The objects that need to be rolled back are those that were fulfilled
       const rollbackObjs = clusterAddResults.reduce((rollbackAccum, res) => {
-        return res.state === 'fulfilled' ?
-          [...rollbackAccum, { kind: res.value.data.kind, name: res.value.data.metadata.name }] :
+        return res.status === 201 ?
+          [...rollbackAccum, { kind: res.data.kind, name: res.data.metadata.name }] :
           rollbackAccum;
       }, []);
 
@@ -209,7 +232,7 @@ function* addClusterRequest(action) {
     } // End rollback handling
 
     const cluster = clusterAddResults.reduce((accum, res) => {
-      const data = res.value.data;
+      const data = res.data;
       accum[data.kind] = data;
       return accum;
     }, {});
@@ -304,7 +327,7 @@ function* updateClusterRequest(action) {
 
     // Pushing a request fn to delay the call until its yielded in a batch at same time
     updatePromises.push(() => client.patch(
-      secretResource, clusterValues.name, newTokenSecret));
+      secretResource, currentCluster.spec.serviceAccountSecretRef.name, newTokenSecret));
   }
 
   try {

--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -92,8 +92,8 @@ function* removeClusterSaga(action) {
     const secretResourceList = yield client.list(secretResource, 
       getTokenSecretLabelSelector(MigResourceKind.MigCluster, name));
 
-    const secretResourceName = (secretResourceList.data.items && secretResourceList.data.items.length > 0) 
-      ? secretResourceList.data.items[0].metadata.name : '';
+    const secretResourceName = (secretResourceList.data.items && secretResourceList.data.items.length > 0) ?
+      secretResourceList.data.items[0].metadata.name : '';
 
     yield Promise.all([
       client.delete(secretResource, secretResourceName),

--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -142,7 +142,7 @@ function* addClusterRequest(action) {
     const getResults = yield Q.allSettled([
       client.list(secretResource, getTokenSecretLabelSelector(MigResourceKind.MigCluster, migCluster.metadata.name)),
       client.get(migClusterResource, migCluster.metadata.name),
-    ]);;
+    ]);
 
     const alreadyExists = getResults.reduce((exists, res) => {
       return res && res.status === 200 ?
@@ -182,7 +182,7 @@ function* addClusterRequest(action) {
       Object.assign(migCluster.spec.serviceAccountSecretRef, { 
         name: tokenSecretAddResult.data.metadata.name,
         namespace: tokenSecretAddResult.data.metadata.namespace,
-        });
+      });
 
       const clusterAddResult = yield client.create(migClusterResource, migCluster);
       if (clusterAddResult.status === 201) {

--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -148,11 +148,14 @@ function* addClusterRequest(action) {
     ]);
 
     const alreadyExists = getResults.reduce((exists, res) => {
-      return res && res.status === 200 ?
-        [...exists, { kind: res.value.data.kind, 
-          name:  (res.value.data.items && res.value.data.items.length > 0) 
-            ? res.value.data.items[0].metadata.name : res.value.data.metadata.name
-        }] :
+      return (res && res.status === 200) ?
+        [...exists,
+          {
+            kind: res.value.data.kind,
+            name: (res.value.data.items && res.value.data.items.length > 0) ?
+              res.value.data.items[0].metadata.name : res.value.data.metadata.name
+          }
+        ] :
         exists;
     }, []);
 

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -1,7 +1,7 @@
 import { pvStorageClassAssignmentKey } from '../../app/plan/components/Wizard/StorageClassTable';
 import { pvCopyMethodAssignmentKey } from '../../app/plan/components/Wizard/StorageClassTable';
 
-export function createTokenSecret(name: string, namespace: string, rawToken: string) {
+export function createTokenSecret(name: string, namespace: string, rawToken: string, createdForResourceType: string, createdForResource: string) {
   // btoa => to base64, atob => from base64
   const encodedToken = btoa(rawToken);
   return {
@@ -11,11 +11,21 @@ export function createTokenSecret(name: string, namespace: string, rawToken: str
     },
     kind: 'Secret',
     metadata: {
-      name,
+      generateName: `${name}-`,
       namespace,
+      labels: {
+        createdForResourceType,
+        createdForResource,
+      }
     },
     type: 'Opaque',
   };
+}
+
+export function getTokenSecretLabelSelector(createdForResourceType: string, createdForResource: string) {
+  return {
+    labelSelector: `createdForResourceType=${createdForResourceType},createdForResource=${createdForResource}`
+  }
 }
 
 export function updateTokenSecret(rawToken: string) {


### PR DESCRIPTION
Fixes #396 

Proposed Changes :
[1] Creating new MigCluster 
- We use `generateName` instead of `name` in tokenSecret of MigCluster. We also introduce two new labels on the Secret : `createdForResourceType`, `createdForResource`. This makes it easier to find a secret associated with a cluster.
- We create secret first, then get the resulting secret name, then we create MigCluster

[2] Deleting MigCluster
- We find the secret name before deleting MigCluster
- Then usual flow of delete

[3] Editing MigCluster
- Nothing changes here except the secret reference.