### PR TITLE
Enhance PVs step of plan wizard: switch to PF table, fix useEffect logic, add types, other UX cleanup

### DIFF
--- a/src/app/common/components/SimpleSelect.tsx
+++ b/src/app/common/components/SimpleSelect.tsx
@@ -1,19 +1,26 @@
 import React, { useState } from 'react';
-import { Select, SelectOption, SelectProps, Omit } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectOptionObject,
+  SelectProps,
+  Omit,
+} from '@patternfly/react-core';
+
+type OptionLike = string | SelectOptionObject;
 
 interface SimpleSelectProps
-  extends Omit<SelectProps, 'onChange' | 'isExpanded' | 'onToggle' | 'onSelect' | 'selections'> {
-  id: string;
-  onChange: (selection: string) => void;
-  options: string[];
-  value: string;
+  extends Omit<
+    SelectProps,
+    'onChange' | 'isExpanded' | 'onToggle' | 'onSelect' | 'selections' | 'value'
+  > {
+  onChange: (selection: OptionLike) => void;
+  options: OptionLike[];
+  value: OptionLike | OptionLike[];
   placeholderText?: string;
 }
 
-// This can be used wherever we only need a simple select dropdown of strings.
-// If we need complex values, this could be enhanced to support option objects with a toString property
 const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({
-  id,
   onChange,
   options,
   value,
@@ -23,11 +30,10 @@ const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({
   const [isExpanded, setIsExpanded] = useState(false);
   return (
     <Select
-      id={id}
       placeholderText={placeholderText}
       isExpanded={isExpanded}
       onToggle={setIsExpanded}
-      onSelect={(event, selection: string) => {
+      onSelect={(event, selection: OptionLike) => {
         onChange(selection);
         setIsExpanded(false);
       }}
@@ -35,7 +41,7 @@ const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({
       {...props}
     >
       {options.map(option => (
-        <SelectOption key={option} value={option} />
+        <SelectOption key={option.toString()} value={option} />
       ))}
     </Select>
   );

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { PaginationProps } from '@patternfly/react-core';
+
+export const usePaginationState = (items: any[], initialItemsPerPage: number) => {
+  const [currentPageNumber, setCurrentPageNumber] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(initialItemsPerPage);
+
+  const pageStartIndex = (currentPageNumber - 1) * itemsPerPage;
+  const currentPageItems = items.slice(pageStartIndex, pageStartIndex + itemsPerPage);
+
+  const paginationProps: PaginationProps = {
+    itemCount: items.length,
+    perPage: itemsPerPage,
+    page: currentPageNumber,
+    onSetPage: (event, pageNumber) => setCurrentPageNumber(pageNumber),
+    onPerPageSelect: (event, perPage) => setItemsPerPage(perPage),
+  };
+
+  return { currentPageItems, paginationProps };
+};

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -7,12 +7,12 @@ import {
   Level,
   LevelItem,
   Pagination,
-  PaginationProps,
   PaginationVariant,
   DropdownDirection,
 } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { usePaginationState } from '../../../common/duck/hooks';
 
 interface INamespaceTableProps {
   isEdit: boolean;
@@ -68,18 +68,7 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
     setFieldValue('selectedNamespaces', newSelected);
   };
 
-  const [currentPageNumber, setCurrentPageNumber] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(10);
-  const pageStartIndex = (currentPageNumber - 1) * itemsPerPage;
-  const currentPageRows = rows.slice(pageStartIndex, pageStartIndex + itemsPerPage);
-
-  const paginationProps: PaginationProps = {
-    itemCount: rows.length,
-    perPage: itemsPerPage,
-    page: currentPageNumber,
-    onSetPage: (event, pageNumber) => setCurrentPageNumber(pageNumber),
-    onPerPageSelect: (event, perPage) => setItemsPerPage(perPage),
-  };
+  const { currentPageItems, paginationProps } = usePaginationState(rows, 10);
 
   return (
     <React.Fragment>
@@ -106,7 +95,7 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
           aria-label="Projects table"
           variant={TableVariant.compact}
           cells={columns}
-          rows={currentPageRows}
+          rows={currentPageItems}
           onSelect={onSelect}
           canSelectAll
         >

--- a/src/app/plan/components/Wizard/VolumesForm.tsx
+++ b/src/app/plan/components/Wizard/VolumesForm.tsx
@@ -53,9 +53,10 @@ const VolumesForm = props => {
     }
   }, []);
 
+  const discoveredPersistentVolumes = (currentPlan && currentPlan.spec.persistentVolumes) || [];
+
   useEffect(() => {
-    if (currentPlan) {
-      const discoveredPersistentVolumes = currentPlan.spec.persistentVolumes || [];
+    if (discoveredPersistentVolumes.length > 0) {
       getPVResourcesRequest(discoveredPersistentVolumes, values.sourceCluster || '');
       let mappedPVs;
       if (values.persistentVolumes) {
@@ -100,7 +101,7 @@ const VolumesForm = props => {
       setFieldValue('persistentVolumes', mappedPVs);
       setRows(mappedPVs); // ???
     }
-  }, [currentPlan, isPollingStatus]); // Only re-run the effect if fetching value changes
+  }, [discoveredPersistentVolumes.length]); // Only re-run the effect if fetching value changes
 
   //TODO: added this component level error state to handle the case of no PVs
   // showing up after 3 checks of the interval. When the isPVError flag is checked,

--- a/src/app/plan/components/Wizard/VolumesForm.tsx
+++ b/src/app/plan/components/Wizard/VolumesForm.tsx
@@ -60,7 +60,7 @@ const VolumesForm = props => {
           }
           // TODO do we really need to generate these meta-objects and keep them in formik?
           // currentPlan.spec.persistentVolumes is in global state, so we could just
-          // infer from that everywhere and keep only a mapping of action selections in formik
+          // infer from that everywhere and keep only a mapping of pv id => type selections in formik
           return {
             name: planVolume.name,
             project: planVolume.pvc.namespace,
@@ -148,7 +148,7 @@ const VolumesForm = props => {
       isEdit={isEdit}
       pvResourceList={pvResourceList}
       isFetchingPVResources={isFetchingPVResources}
-      rows={values.persistentVolumes}
+      persistentVolumes={values.persistentVolumes}
       onTypeChange={onTypeChange}
     />
   );

--- a/src/app/plan/components/Wizard/VolumesForm.tsx
+++ b/src/app/plan/components/Wizard/VolumesForm.tsx
@@ -1,7 +1,19 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import VolumesTable from './VolumesTable';
+import {
+  Grid,
+  GridItem,
+  Bullseye,
+  EmptyState,
+  Spinner,
+  Title,
+  Alert,
+} from '@patternfly/react-core';
+import StatusIcon from '../../../common/components/StatusIcon';
+const styles = require('./VolumesTable.module');
 
 const VolumesForm = props => {
+  // TODO add a typescript interface for these props
   const {
     setFieldValue,
     values,
@@ -16,6 +28,20 @@ const VolumesForm = props => {
     isPollingStatus,
   } = props;
 
+  const [rows, setRows] = useState([]); // TODO do we need state here? can we use redux+formik?
+
+  const updateTableData = (rowIndex, updatedValue) => {
+    const rowsCopy = [...rows];
+    if (currentPlan !== null && values.persistentVolumes) {
+      const updatedRow = { ...rowsCopy[rowIndex], type: updatedValue };
+
+      rowsCopy[rowIndex] = updatedRow;
+    }
+
+    setRows(rowsCopy);
+    setFieldValue('persistentVolumes', rowsCopy);
+  };
+
   useEffect(() => {
     //kick off pv discovery once volumes form is reached with current selected namespaces
     let isRerunPVDiscovery = null;
@@ -27,18 +53,104 @@ const VolumesForm = props => {
     }
   }, []);
 
+  useEffect(() => {
+    if (currentPlan) {
+      const discoveredPersistentVolumes = currentPlan.spec.persistentVolumes || [];
+      getPVResourcesRequest(discoveredPersistentVolumes, values.sourceCluster || '');
+      let mappedPVs;
+      if (values.persistentVolumes) {
+        mappedPVs = discoveredPersistentVolumes.map(planVolume => {
+          let pvAction = 'copy'; // Default to copy
+          if (values.persistentVolumes.length !== 0) {
+            const rowVal = values.persistentVolumes.find(v => v.name === planVolume.name);
+            if (rowVal && rowVal.selection) {
+              pvAction = rowVal.selection.action;
+            } else {
+              if (rowVal && rowVal.type) {
+                pvAction = rowVal.type;
+              }
+            }
+          }
+          return {
+            name: planVolume.name,
+            project: planVolume.pvc.namespace,
+            storageClass: planVolume.storageClass || 'None',
+            size: planVolume.capacity,
+            claim: planVolume.pvc.name,
+            type: pvAction,
+            details: '',
+            supportedActions: planVolume.supported.actions,
+          };
+        });
+      } else {
+        mappedPVs = discoveredPersistentVolumes.map(planVolume => {
+          const pvAction = 'copy'; // Default to copy
+          return {
+            name: planVolume.name,
+            project: planVolume.pvc.namespace,
+            storageClass: planVolume.storageClass || '',
+            size: planVolume.capacity,
+            claim: planVolume.pvc.name,
+            type: pvAction,
+            details: '',
+            supportedActions: planVolume.supported.actions,
+          };
+        });
+      }
+      setFieldValue('persistentVolumes', mappedPVs);
+      setRows(mappedPVs); // ???
+    }
+  }, [currentPlan, isPollingStatus]); // Only re-run the effect if fetching value changes
+
+  //TODO: added this component level error state to handle the case of no PVs
+  // showing up after 3 checks of the interval. When the isPVError flag is checked,
+  // the volumes form will show this error. Need to add redux actions & state to encapsulate
+  // validation so that this error state enables the user to go to next page( that possibly
+  // shows a different set of forms catered to stateless apps)
+
+  if (isPVError) {
+    return (
+      <Grid gutter="md" className={styles.centerAlign}>
+        <GridItem>
+          <div className={styles.errorDiv}>
+            <StatusIcon isReady={false} />
+            PV Discovery Error
+          </div>
+        </GridItem>
+      </Grid>
+    );
+  }
+  if (isPollingStatus || currentPlanStatus.state === 'Pending') {
+    return (
+      <Bullseye>
+        <EmptyState variant="large">
+          <div className="pf-c-empty-state__icon">
+            <Spinner size="xl" />
+          </div>
+          <Title headingLevel="h2" size="xl">
+            Discovering persistent volumes attached to source projects...
+          </Title>
+        </EmptyState>
+      </Bullseye>
+    );
+  }
+  if (currentPlanStatus.state === 'Critical') {
+    return (
+      <Bullseye>
+        <EmptyState variant="large">
+          <Alert variant="danger" isInline title={currentPlanStatus.errorMessage} />
+        </EmptyState>
+      </Bullseye>
+    );
+  }
+
   return (
     <VolumesTable
       isEdit={isEdit}
-      isPVError={isPVError}
-      setFieldValue={setFieldValue}
-      values={values}
-      currentPlan={currentPlan}
-      currentPlanStatus={currentPlanStatus}
-      getPVResourcesRequest={getPVResourcesRequest}
       pvResourceList={pvResourceList}
       isFetchingPVResources={isFetchingPVResources}
-      isPollingStatus={isPollingStatus}
+      rows={rows}
+      updateTableData={updateTableData}
     />
   );
 };

--- a/src/app/plan/components/Wizard/VolumesForm.tsx
+++ b/src/app/plan/components/Wizard/VolumesForm.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
+import { FormikProps } from 'formik';
+import { IFormValues, IOtherProps } from './WizardContainer';
 import VolumesTable from './VolumesTable';
 import {
   Grid,
@@ -10,24 +12,35 @@ import {
   Alert,
 } from '@patternfly/react-core';
 import StatusIcon from '../../../common/components/StatusIcon';
+
 const styles = require('./VolumesTable.module');
 
-const VolumesForm = props => {
-  // TODO add a typescript interface for these props
-  const {
-    setFieldValue,
-    values,
-    isPVError,
-    currentPlan,
-    currentPlanStatus,
-    getPVResourcesRequest,
-    pvResourceList,
-    isFetchingPVResources,
-    isEdit,
-    planUpdateRequest,
-    isPollingStatus,
-  } = props;
+interface IVolumesFormProps
+  extends Pick<
+      IOtherProps,
+      | 'isPVError'
+      | 'currentPlan'
+      | 'currentPlanStatus'
+      | 'getPVResourcesRequest'
+      | 'pvResourceList'
+      | 'isFetchingPVResources'
+      | 'planUpdateRequest'
+      | 'isPollingStatus'
+    >,
+    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
 
+const VolumesForm: React.FunctionComponent<IVolumesFormProps> = ({
+  setFieldValue,
+  values,
+  isPVError,
+  currentPlan,
+  currentPlanStatus,
+  getPVResourcesRequest,
+  pvResourceList,
+  isFetchingPVResources,
+  planUpdateRequest,
+  isPollingStatus,
+}: IVolumesFormProps) => {
   useEffect(() => {
     //kick off pv discovery once volumes form is reached with current selected namespaces
     let isRerunPVDiscovery = null;
@@ -133,19 +146,20 @@ const VolumesForm = props => {
     );
   }
 
-  const updatePersistentVolumes = (pvIndex, newValues) => {
+  const updatePersistentVolumes = (pvIndex: number, newValues: { type: string }) => {
     if (currentPlan !== null && values.persistentVolumes) {
       const newPVs = [...values.persistentVolumes];
       newPVs[pvIndex] = { ...newPVs[pvIndex], ...newValues };
+      // TODO this should only store selections, we should inherit the rest from currentPlan.spec.persistentVolumes
       setFieldValue('persistentVolumes', newPVs);
     }
   };
 
-  const onTypeChange = (pvIndex, value) => updatePersistentVolumes(pvIndex, { type: value });
+  const onTypeChange = (pvIndex: number, value: string) =>
+    updatePersistentVolumes(pvIndex, { type: value });
 
   return (
     <VolumesTable
-      isEdit={isEdit}
       pvResourceList={pvResourceList}
       isFetchingPVResources={isFetchingPVResources}
       persistentVolumes={values.persistentVolumes}

--- a/src/app/plan/components/Wizard/VolumesForm.tsx
+++ b/src/app/plan/components/Wizard/VolumesForm.tsx
@@ -1,11 +1,4 @@
 import React, { useEffect } from 'react';
-import {
-  Grid,
-  GridItem,
-  Text,
-  TextContent,
-  TextVariants,
-} from '@patternfly/react-core';
 import VolumesTable from './VolumesTable';
 
 const VolumesForm = props => {
@@ -35,29 +28,18 @@ const VolumesForm = props => {
   }, []);
 
   return (
-    <Grid gutter="md">
-      <GridItem>
-        <TextContent>
-          <Text component={TextVariants.p}>
-            Choose to move or copy persistent volumes:
-          </Text>
-        </TextContent>
-      </GridItem>
-      <GridItem>
-        <VolumesTable
-          isEdit={isEdit}
-          isPVError={isPVError}
-          setFieldValue={setFieldValue}
-          values={values}
-          currentPlan={currentPlan}
-          currentPlanStatus={currentPlanStatus}
-          getPVResourcesRequest={getPVResourcesRequest}
-          pvResourceList={pvResourceList}
-          isFetchingPVResources={isFetchingPVResources}
-          isPollingStatus={isPollingStatus}
-        />
-      </GridItem>
-    </Grid>
+    <VolumesTable
+      isEdit={isEdit}
+      isPVError={isPVError}
+      setFieldValue={setFieldValue}
+      values={values}
+      currentPlan={currentPlan}
+      currentPlanStatus={currentPlanStatus}
+      getPVResourcesRequest={getPVResourcesRequest}
+      pvResourceList={pvResourceList}
+      isFetchingPVResources={isFetchingPVResources}
+      isPollingStatus={isPollingStatus}
+    />
   );
 };
 export default VolumesForm;

--- a/src/app/plan/components/Wizard/VolumesTable.module.scss
+++ b/src/app/plan/components/Wizard/VolumesTable.module.scss
@@ -1,23 +1,5 @@
-@import "src/colors";
-
-  .centerAlign{
-      text-align:center;
-  }
-
-  .errorDiv{
-    margin: 1em 0 1em 0;
-    color: $statusRed
-  }
-
-  .volumesTableStyle{
-    font-size: 14px;
-
-    .rt-td{
-        margin: auto 0;
-    }
-  }
-  .popoverStyle{
-    overflow-y: scroll;
-    max-height: 20rem;
-    width: 40rem;
-  }
+.jsonPopover {
+  overflow-y: scroll;
+  max-height: 20rem;
+  width: 40rem;
+}

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -13,7 +13,6 @@ import {
   EmptyStateBody,
   Grid,
   GridItem,
-  PaginationProps,
   Pagination,
   PaginationVariant,
   SelectOptionObject,
@@ -23,6 +22,7 @@ import ReactJson from 'react-json-view';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import SimpleSelect from '../../../common/components/SimpleSelect';
+import { usePaginationState } from '../../../common/duck/hooks';
 
 const styles = require('./VolumesTable.module');
 
@@ -112,19 +112,7 @@ const VolumesTable = (props): any => {
     };
   });
 
-  // TODO abstract this away into a shared hook with NameSpaceTable
-  const [currentPageNumber, setCurrentPageNumber] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(10);
-  const pageStartIndex = (currentPageNumber - 1) * itemsPerPage;
-  const currentPageRows = rows.slice(pageStartIndex, pageStartIndex + itemsPerPage);
-
-  const paginationProps: PaginationProps = {
-    itemCount: rows.length,
-    perPage: itemsPerPage,
-    page: currentPageNumber,
-    onSetPage: (event, pageNumber) => setCurrentPageNumber(pageNumber),
-    onPerPageSelect: (event, perPage) => setItemsPerPage(perPage),
-  };
+  const { currentPageItems, paginationProps } = usePaginationState(rows, 10);
 
   return (
     <Grid gutter="md">
@@ -139,7 +127,7 @@ const VolumesTable = (props): any => {
           aria-label="Persistent volumes table"
           variant={TableVariant.compact}
           cells={columns}
-          rows={currentPageRows}
+          rows={currentPageItems}
         >
           <TableHeader />
           <TableBody />

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -1,11 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import ReactTable from 'react-table';
 import 'react-table/react-table.css';
 import Select from 'react-select';
-import StatusIcon from '../../../common/components/StatusIcon';
 import {
-  Alert,
-  Bullseye,
   TextContent,
   Text,
   TextVariants,
@@ -22,7 +19,6 @@ import {
 } from '@patternfly/react-core';
 import ReactJson from 'react-json-view';
 import { BlueprintIcon, WarningTriangleIcon } from '@patternfly/react-icons';
-import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 
 const styles = require('./VolumesTable.module');
 const classNames = require('classnames');
@@ -36,129 +32,18 @@ const capitalize = (s: string) => {
 };
 
 const VolumesTable = (props): any => {
+  // TODO add a typescript interface for these props
   const {
-    setFieldValue,
-    currentPlan,
-    values,
-    isPVError,
-    getPVResourcesRequest,
     isFetchingPVResources,
     pvResourceList,
-    isPollingStatus,
-    currentPlanStatus,
+    rows, // TODO should be inferred from redux/formik?
+    updateTableData, // TODO this should be more abstract, right?
   } = props;
-  const [rows, setRows] = useState([]);
-
-  const updateTableData = (rowIndex, updatedValue) => {
-    const rowsCopy = [...rows];
-    if (currentPlan !== null && values.persistentVolumes) {
-      const updatedRow = { ...rowsCopy[rowIndex], type: updatedValue };
-
-      rowsCopy[rowIndex] = updatedRow;
-    }
-
-    setRows(rowsCopy);
-    setFieldValue('persistentVolumes', rowsCopy);
-  };
 
   const handleTypeChange = (row, option) => {
     updateTableData(row.index, option.value);
   };
 
-  const getPVResources = (pvList = [], clusterName = '') => {
-    getPVResourcesRequest(pvList, clusterName);
-  };
-
-  useEffect(() => {
-    if (currentPlan) {
-      const discoveredPersistentVolumes = currentPlan.spec.persistentVolumes || [];
-      getPVResources(discoveredPersistentVolumes, values.sourceCluster);
-      let mappedPVs;
-      if (values.persistentVolumes) {
-        mappedPVs = discoveredPersistentVolumes.map(planVolume => {
-          let pvAction = 'copy'; // Default to copy
-          if (values.persistentVolumes.length !== 0) {
-            const rowVal = values.persistentVolumes.find(v => v.name === planVolume.name);
-            if (rowVal && rowVal.selection) {
-              pvAction = rowVal.selection.action;
-            } else {
-              if (rowVal && rowVal.type) {
-                pvAction = rowVal.type;
-              }
-            }
-          }
-          return {
-            name: planVolume.name,
-            project: planVolume.pvc.namespace,
-            storageClass: planVolume.storageClass || 'None',
-            size: planVolume.capacity,
-            claim: planVolume.pvc.name,
-            type: pvAction,
-            details: '',
-            supportedActions: planVolume.supported.actions,
-          };
-        });
-      } else {
-        mappedPVs = discoveredPersistentVolumes.map(planVolume => {
-          const pvAction = 'copy'; // Default to copy
-          return {
-            name: planVolume.name,
-            project: planVolume.pvc.namespace,
-            storageClass: planVolume.storageClass || '',
-            size: planVolume.capacity,
-            claim: planVolume.pvc.name,
-            type: pvAction,
-            details: '',
-            supportedActions: planVolume.supported.actions,
-          };
-        });
-      }
-      setFieldValue('persistentVolumes', mappedPVs);
-      setRows(mappedPVs);
-    }
-  }, [currentPlan, isPollingStatus]); // Only re-run the effect if fetching value changes
-
-  //TODO: added this component level error state to handle the case of no PVs
-  // showing up after 3 checks of the interval. When the isPVError flag is checked,
-  // the volumes form will show this error. Need to add redux actions & state to encapsulate
-  // validation so that this error state enables the user to go to next page( that possibly
-  // shows a different set of forms catered to stateless apps)
-
-  if (isPVError) {
-    return (
-      <Grid gutter="md" className={styles.centerAlign}>
-        <GridItem>
-          <div className={styles.errorDiv}>
-            <StatusIcon isReady={false} />
-            PV Discovery Error
-          </div>
-        </GridItem>
-      </Grid>
-    );
-  }
-  if (isPollingStatus || currentPlanStatus.state === 'Pending') {
-    return (
-      <Bullseye>
-        <EmptyState variant="large">
-          <div className="pf-c-empty-state__icon">
-            <Spinner size="xl" />
-          </div>
-          <Title headingLevel="h2" size="xl">
-            Discovering persistent volumes attached to source projects...
-          </Title>
-        </EmptyState>
-      </Bullseye>
-    );
-  }
-  if (currentPlanStatus.state === 'Critical') {
-    return (
-      <Bullseye>
-        <EmptyState variant="large">
-          <Alert variant="danger" isInline title={currentPlanStatus.errorMessage} />
-        </EmptyState>
-      </Bullseye>
-    );
-  }
   const { volumesTableStyle } = styles;
   const tableClass = classNames('-striped', '-highlight', { volumesTableStyle });
   return (

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -23,8 +23,15 @@ import { WarningTriangleIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import SimpleSelect from '../../../common/components/SimpleSelect';
 import { usePaginationState } from '../../../common/duck/hooks';
+import { IFormValues, IOtherProps } from './WizardContainer';
 
 const styles = require('./VolumesTable.module');
+
+interface IVolumesTableProps
+  extends Pick<IOtherProps, 'isFetchingPVResources' | 'pvResourceList'>,
+    Pick<IFormValues, 'persistentVolumes'> {
+  onTypeChange: (pvIndex: number, value: string) => void;
+}
 
 interface OptionWithValue extends SelectOptionObject {
   value: string;
@@ -38,10 +45,12 @@ const capitalize = (s: string) => {
   }
 };
 
-const VolumesTable = (props): any => {
-  // TODO add a typescript interface for these props
-  const { isFetchingPVResources, pvResourceList, persistentVolumes, onTypeChange } = props;
-
+const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
+  isFetchingPVResources,
+  pvResourceList,
+  persistentVolumes,
+  onTypeChange,
+}: IVolumesTableProps) => {
   const columns = [
     { title: 'PV name' },
     { title: 'Claim' },

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -7,6 +7,8 @@ import {
   Alert,
   Bullseye,
   TextContent,
+  Text,
+  TextVariants,
   Popover,
   PopoverPosition,
   Title,
@@ -16,13 +18,13 @@ import {
   EmptyStateIcon,
   EmptyStateBody,
   Grid,
-  GridItem
+  GridItem,
 } from '@patternfly/react-core';
 import ReactJson from 'react-json-view';
 import { BlueprintIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 
-const styles = require('./VolumesTable.module')
+const styles = require('./VolumesTable.module');
 const classNames = require('classnames');
 
 const capitalize = (s: string) => {
@@ -43,10 +45,9 @@ const VolumesTable = (props): any => {
     isFetchingPVResources,
     pvResourceList,
     isPollingStatus,
-    currentPlanStatus
+    currentPlanStatus,
   } = props;
   const [rows, setRows] = useState([]);
-
 
   const updateTableData = (rowIndex, updatedValue) => {
     const rowsCopy = [...rows];
@@ -80,11 +81,9 @@ const VolumesTable = (props): any => {
             const rowVal = values.persistentVolumes.find(v => v.name === planVolume.name);
             if (rowVal && rowVal.selection) {
               pvAction = rowVal.selection.action;
-            }
-            else {
+            } else {
               if (rowVal && rowVal.type) {
                 pvAction = rowVal.type;
-
               }
             }
           }
@@ -119,7 +118,6 @@ const VolumesTable = (props): any => {
     }
   }, [currentPlan, isPollingStatus]); // Only re-run the effect if fetching value changes
 
-
   //TODO: added this component level error state to handle the case of no PVs
   // showing up after 3 checks of the interval. When the isPVError flag is checked,
   // the volumes form will show this error. Need to add redux actions & state to encapsulate
@@ -138,8 +136,7 @@ const VolumesTable = (props): any => {
       </Grid>
     );
   }
-  if (isPollingStatus ||
-    (currentPlanStatus.state === 'Pending')) {
+  if (isPollingStatus || currentPlanStatus.state === 'Pending') {
     return (
       <Bullseye>
         <EmptyState variant="large">
@@ -153,8 +150,7 @@ const VolumesTable = (props): any => {
       </Bullseye>
     );
   }
-  if (
-    (currentPlanStatus.state === 'Critical')) {
+  if (currentPlanStatus.state === 'Critical') {
     return (
       <Bullseye>
         <EmptyState variant="large">
@@ -163,169 +159,181 @@ const VolumesTable = (props): any => {
       </Bullseye>
     );
   }
-  const { volumesTableStyle } = styles
-  const tableClass = classNames('-striped', '-highlight', { volumesTableStyle })
+  const { volumesTableStyle } = styles;
+  const tableClass = classNames('-striped', '-highlight', { volumesTableStyle });
   return (
-    <ReactTable
-      className={tableClass}
-      data={rows}
-      columns={[
-        {
-          Header: () => (
-            <div
-              style={{
-                textAlign: 'left',
-                fontWeight: 600,
-              }}
-            >
-              PV Name
-            </div>
-          ),
-          accessor: 'name',
-          width: 180,
-        },
-        {
-          Header: () => (
-            <div
-              style={{
-                textAlign: 'left',
-                fontWeight: 600,
-              }}
-            >
-              Project
-            </div>
-          ),
-          accessor: 'project',
-          width: 150,
-        },
-        {
-          Header: () => (
-            <div
-              style={{
-                textAlign: 'left',
-                fontWeight: 600,
-              }}
-            >
-              Storage Class
-            </div>
-          ),
-          accessor: 'storageClass',
-          width: 150,
-        },
-        {
-          Header: () => (
-            <div
-              style={{
-                textAlign: 'left',
-                fontWeight: 600,
-              }}
-            >
-              Size
-            </div>
-          ),
-          accessor: 'size',
-          width: 75,
-        },
-        {
-          Header: () => (
-            <div
-              style={{
-                textAlign: 'left',
-                fontWeight: 600,
-              }}
-            >
-              Claim
-            </div>
-          ),
-          accessor: 'claim',
-          width: 180,
-        },
-        {
-          Header: () => (
-            <div
-              style={{
-                textAlign: 'left',
-                fontWeight: 600,
-              }}
-            >
-              Type
-            </div>
-          ),
-          accessor: 'type',
-          width: 120,
-          style: { overflow: 'visible' },
-          Cell: row => (
-            <Select
-              onChange={(option: any) => handleTypeChange(row, option)}
-              options={row.original.supportedActions.map((a: string) => {
-                // NOTE: Each PV may not support all actions (any at all even),
-                // we need to inspect the PV to determine this
-                return { value: a, label: capitalize(a) };
-              })}
-              name="persistentVolumes"
-              value={{
-                label: capitalize(row.original.type),
-                value: row.original.type,
-              }}
-            />
-          ),
-        },
-        {
-          Header: () => (
-            <div
-              style={{
-                textAlign: 'left',
-                fontWeight: 600,
-              }}
-            >
-              Details
-            </div>
-          ),
-          accessor: 'details',
-          width: 200,
-          resizable: false,
-          Cell: row => {
-            const matchingPVResource = pvResourceList.find(
-              pvResource => pvResource.name === row.original.name
-            );
-            return (
-              <Popover
-                className={styles.popoverStyle}
-                position={PopoverPosition.bottom}
-                bodyContent={
-                  <React.Fragment>
-                    {matchingPVResource ?
-                      <ReactJson src={matchingPVResource} enableClipboard={false} /> :
-                      <EmptyState variant={EmptyStateVariant.small}>
-                        <EmptyStateIcon icon={WarningTriangleIcon} />
-                        <Title headingLevel="h5" size="sm">
-                          No PV data found
-                        </Title>
-                        <EmptyStateBody>
-                          Unable to retrieve PV data
-                        </EmptyStateBody>
-                      </EmptyState>
+    <Grid gutter="md">
+      <GridItem>
+        <TextContent>
+          <Text component={TextVariants.p}>Choose to move or copy persistent volumes:</Text>
+        </TextContent>
+      </GridItem>
+      <GridItem>
+        <ReactTable
+          className={tableClass}
+          data={rows}
+          columns={[
+            {
+              Header: () => (
+                <div
+                  style={{
+                    textAlign: 'left',
+                    fontWeight: 600,
+                  }}
+                >
+                  PV Name
+                </div>
+              ),
+              accessor: 'name',
+              width: 180,
+            },
+            {
+              Header: () => (
+                <div
+                  style={{
+                    textAlign: 'left',
+                    fontWeight: 600,
+                  }}
+                >
+                  Project
+                </div>
+              ),
+              accessor: 'project',
+              width: 150,
+            },
+            {
+              Header: () => (
+                <div
+                  style={{
+                    textAlign: 'left',
+                    fontWeight: 600,
+                  }}
+                >
+                  Storage Class
+                </div>
+              ),
+              accessor: 'storageClass',
+              width: 150,
+            },
+            {
+              Header: () => (
+                <div
+                  style={{
+                    textAlign: 'left',
+                    fontWeight: 600,
+                  }}
+                >
+                  Size
+                </div>
+              ),
+              accessor: 'size',
+              width: 75,
+            },
+            {
+              Header: () => (
+                <div
+                  style={{
+                    textAlign: 'left',
+                    fontWeight: 600,
+                  }}
+                >
+                  Claim
+                </div>
+              ),
+              accessor: 'claim',
+              width: 180,
+            },
+            {
+              Header: () => (
+                <div
+                  style={{
+                    textAlign: 'left',
+                    fontWeight: 600,
+                  }}
+                >
+                  Type
+                </div>
+              ),
+              accessor: 'type',
+              width: 120,
+              style: { overflow: 'visible' },
+              Cell: row => (
+                <Select
+                  onChange={(option: any) => handleTypeChange(row, option)}
+                  options={row.original.supportedActions.map((a: string) => {
+                    // NOTE: Each PV may not support all actions (any at all even),
+                    // we need to inspect the PV to determine this
+                    return { value: a, label: capitalize(a) };
+                  })}
+                  name="persistentVolumes"
+                  value={{
+                    label: capitalize(row.original.type),
+                    value: row.original.type,
+                  }}
+                />
+              ),
+            },
+            {
+              Header: () => (
+                <div
+                  style={{
+                    textAlign: 'left',
+                    fontWeight: 600,
+                  }}
+                >
+                  Details
+                </div>
+              ),
+              accessor: 'details',
+              width: 200,
+              resizable: false,
+              Cell: row => {
+                const matchingPVResource = pvResourceList.find(
+                  pvResource => pvResource.name === row.original.name
+                );
+                return (
+                  <Popover
+                    className={styles.popoverStyle}
+                    position={PopoverPosition.bottom}
+                    bodyContent={
+                      <React.Fragment>
+                        {matchingPVResource ? (
+                          <ReactJson src={matchingPVResource} enableClipboard={false} />
+                        ) : (
+                          <EmptyState variant={EmptyStateVariant.small}>
+                            <EmptyStateIcon icon={WarningTriangleIcon} />
+                            <Title headingLevel="h5" size="sm">
+                              No PV data found
+                            </Title>
+                            <EmptyStateBody>Unable to retrieve PV data</EmptyStateBody>
+                          </EmptyState>
+                        )}
+                      </React.Fragment>
                     }
-                  </React.Fragment>
-                }
-                aria-label="pv-details"
-                closeBtnAriaLabel="close-pv-details"
-                maxWidth="200rem"
-              >
-                <Grid gutter="md">
-                  <GridItem>
-                    <Button isDisabled={isFetchingPVResources} variant="link" icon={<BlueprintIcon />}>
-                      View JSON
-                    </Button>
-                  </GridItem>
-                </Grid>
-              </Popover>
-            );
-          },
-        },
-      ]}
-      defaultPageSize={5}
-    />
+                    aria-label="pv-details"
+                    closeBtnAriaLabel="close-pv-details"
+                    maxWidth="200rem"
+                  >
+                    <Grid gutter="md">
+                      <GridItem>
+                        <Button
+                          isDisabled={isFetchingPVResources}
+                          variant="link"
+                          icon={<BlueprintIcon />}
+                        >
+                          View JSON
+                        </Button>
+                      </GridItem>
+                    </Grid>
+                  </Popover>
+                );
+              },
+            },
+          ]}
+          defaultPageSize={5}
+        />
+      </GridItem>
+    </Grid>
   );
 };
 

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -33,16 +33,7 @@ const capitalize = (s: string) => {
 
 const VolumesTable = (props): any => {
   // TODO add a typescript interface for these props
-  const {
-    isFetchingPVResources,
-    pvResourceList,
-    rows, // TODO should be inferred from redux/formik?
-    updateTableData, // TODO this should be more abstract, right?
-  } = props;
-
-  const handleTypeChange = (row, option) => {
-    updateTableData(row.index, option.value);
-  };
+  const { isFetchingPVResources, pvResourceList, rows, onTypeChange } = props;
 
   const { volumesTableStyle } = styles;
   const tableClass = classNames('-striped', '-highlight', { volumesTableStyle });
@@ -144,7 +135,7 @@ const VolumesTable = (props): any => {
               style: { overflow: 'visible' },
               Cell: row => (
                 <Select
-                  onChange={(option: any) => handleTypeChange(row, option)}
+                  onChange={(option: any) => onTypeChange(row.index, option.value)}
                   options={row.original.supportedActions.map((a: string) => {
                     // NOTE: Each PV may not support all actions (any at all even),
                     // we need to inspect the PV to determine this

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -134,17 +134,15 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
         name: 'Persistent Volumes',
         component: (
           <VolumesForm
-            isEdit={isEdit}
             values={values}
             setFieldValue={setFieldValue}
-            setFieldTouched={setFieldTouched}
             currentPlan={currentPlan}
             isPVError={isPVError}
             getPVResourcesRequest={getPVResourcesRequest}
             pvResourceList={pvResourceList}
+            isFetchingPVResources={isFetchingPVList}
             isPollingStatus={isPollingStatus}
             planUpdateRequest={planUpdateRequest}
-            startPlanStatusPolling={startPlanStatusPolling}
             currentPlanStatus={currentPlanStatus}
           />
         ),

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -131,7 +131,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
       },
       {
         id: stepId.PersistentVolumes,
-        name: 'Persistent Volumes',
+        name: 'Persistent volumes',
         component: (
           <VolumesForm
             values={values}
@@ -154,7 +154,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
       },
       {
         id: stepId.StorageClass,
-        name: 'Storage Class',
+        name: 'Storage class',
         component: (
           <StorageClassForm
             isEdit={isEdit}

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -4,13 +4,18 @@ import { PlanActions } from '../../duck/actions';
 import planSelectors from '../../duck/selectors';
 import { connect } from 'react-redux';
 import utils from '../../../common/duck/utils';
+import { IPlan, IPlanPersistentVolume, IPersistentVolumeResource } from './types';
+import { ICurrentPlanStatus } from '../../duck/reducers';
 export interface IFormValues {
   planName: string;
   sourceCluster: string;
   targetCluster: string;
   selectedStorage: string;
   selectedNamespaces: any[];
+  persistentVolumes: any[]; // TODO replace this with selections-only version after refactor
 }
+
+// TODO add more specific types instead of using `any`
 export interface IOtherProps {
   clusterList: any[];
   planList: any[];
@@ -26,8 +31,8 @@ export interface IOtherProps {
   isPollingStorage: boolean;
   isPollingClusters: boolean;
   isPollingPlans: boolean;
-  currentPlan: any;
-  currentPlanStatus: any;
+  currentPlan: IPlan;
+  currentPlanStatus: ICurrentPlanStatus;
   startPlanStatusPolling: (planName) => void;
   stopPlanStatusPolling: (planName) => void;
   pvUpdatePollStop: () => void;
@@ -35,10 +40,13 @@ export interface IOtherProps {
   resetCurrentPlan: () => void;
   setCurrentPlan: (plan) => void;
   fetchNamespacesRequest: (clusterName) => void;
-  getPVResourcesRequest: () => void;
+  getPVResourcesRequest: (
+    persistentVolumes: IPlanPersistentVolume[],
+    sourceClusterName: IFormValues['sourceCluster']
+  ) => void;
   addPlanRequest: (migPlan) => void;
   sourceClusterNamespaces: any[];
-  pvResourceList: any[];
+  pvResourceList: IPersistentVolumeResource[];
   onHandleWizardModalClose: () => void;
   editPlanObj?: any;
   isEdit: boolean;

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -69,7 +69,9 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
       values.targetCluster = editPlanObj.spec.destMigClusterRef.name || null;
       values.selectedNamespaces = editPlanObj.spec.namespaces || [];
       values.selectedStorage = editPlanObj.spec.migStorageRef.name || null;
-      values.persistentVolumes = editPlanObj.spec.persistentVolumes || [];
+      // TODO need to look into this closer, but it was resetting form values after pv discovery is run & messing with the UI state
+      // See https://github.com/konveyor/mig-ui/issues/797
+      // values.persistentVolumes = editPlanObj.spec.persistentVolumes || [];
     }
 
     return values;
@@ -106,7 +108,6 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
 })(WizardComponent);
 
 const mapStateToProps = state => {
-
   return {
     planName: '',
     sourceCluster: null,
@@ -130,21 +131,21 @@ const mapStateToProps = state => {
 };
 const mapDispatchToProps = dispatch => {
   return {
-    addPlanRequest: (migPlan) => dispatch(PlanActions.addPlanRequest(migPlan)),
-    fetchNamespacesRequest: (clusterName) => dispatch(PlanActions.namespaceFetchRequest(clusterName)),
-    getPVResourcesRequest: (pvList, clusterName) => dispatch(PlanActions.getPVResourcesRequest(pvList, clusterName)),
-    startPlanStatusPolling: (planName: string) => dispatch(PlanActions.startPlanStatusPolling(planName)),
-    stopPlanStatusPolling: (planName: string) => dispatch(PlanActions.stopPlanStatusPolling(planName)),
+    addPlanRequest: migPlan => dispatch(PlanActions.addPlanRequest(migPlan)),
+    fetchNamespacesRequest: clusterName => dispatch(PlanActions.namespaceFetchRequest(clusterName)),
+    getPVResourcesRequest: (pvList, clusterName) =>
+      dispatch(PlanActions.getPVResourcesRequest(pvList, clusterName)),
+    startPlanStatusPolling: (planName: string) =>
+      dispatch(PlanActions.startPlanStatusPolling(planName)),
+    stopPlanStatusPolling: (planName: string) =>
+      dispatch(PlanActions.stopPlanStatusPolling(planName)),
     planUpdateRequest: (values, isRerunPVDiscovery) =>
       dispatch(PlanActions.planUpdateRequest(values, isRerunPVDiscovery)),
     resetCurrentPlan: () => dispatch(PlanActions.resetCurrentPlan()),
-    setCurrentPlan: (plan) => dispatch(PlanActions.setCurrentPlan(plan)),
-    updateCurrentPlanStatus: (status) => dispatch(PlanActions.updateCurrentPlanStatus(status)),
+    setCurrentPlan: plan => dispatch(PlanActions.setCurrentPlan(plan)),
+    updateCurrentPlanStatus: status => dispatch(PlanActions.updateCurrentPlanStatus(status)),
     pvUpdatePollStop: () => dispatch(PlanActions.pvUpdatePollStop()),
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(WizardContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(WizardContainer);

--- a/src/app/plan/components/Wizard/types.ts
+++ b/src/app/plan/components/Wizard/types.ts
@@ -1,0 +1,35 @@
+// TODO add other properties used by components in this wizard, possibly move this somewhere more common
+// Maybe in the future we can somehow generate types like these from the CRDs in mig-controller?
+
+export interface IPlanPersistentVolume {
+  name: string;
+  pvc: {
+    namespace: string;
+    name: string;
+    [key: string]: any; // Allow additional unknown properties on each of these
+  };
+  storageClass?: string;
+  capacity: string;
+  supported: {
+    actions: string[];
+    [key: string]: any;
+  };
+  selection?: {
+    action: string;
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+export interface IPlan {
+  spec: {
+    persistentVolumes?: IPlanPersistentVolume[];
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+export interface IPersistentVolumeResource {
+  name: string;
+  [key: string]: any;
+}


### PR DESCRIPTION
Closes https://github.com/konveyor/mig-ui/issues/586

* Lifts non-table-presentation-related logic out of `VolumesTable` into `VolumesForm`.
* Moves table header text down into `VolumesTable` so it doesn't appear during discovery/polling.
* Fixes an issue with the useEffect logic where `getPVResourcesRequest` was being called four times instead of once, causing ~500ms / 2KB of extra network requests (see useEffect note below)
* Converts the PVs table to a PatternFly Table
* Converts the `react-select` components to PatternFly Select
* Abstracts out a new reusable React hook: `usePaginationState` (from code I wrote for `NameSpacesTable` pagination in https://github.com/konveyor/mig-ui/pull/749)
* Adds TypeScript prop type interfaces to `VolumesTable` and `VolumesForm` components, by using `Pick<>` to share types with `WizardContainer`, where I added some more specific types.
* ﻿﻿Changes navigation and table column headers to sentence-case capitalization.

# Screens

## Before:
* Non-PF react-table and react-select
* Header text appears before table is loaded
* Title-case capitalization on nav and headers

![Screenshot 2020-04-01 15 54 58](https://user-images.githubusercontent.com/811963/78181055-bbba7500-7431-11ea-890a-c3a9fd51c82c.png)

![Screenshot 2020-04-01 15 55 21](https://user-images.githubusercontent.com/811963/78181064-c1b05600-7431-11ea-86af-311b3da93f9f.png)

## After

![Screenshot 2020-04-01 15 47 25](https://user-images.githubusercontent.com/811963/78181079-ca089100-7431-11ea-893c-0a1738a9adbc.png)

![Screenshot 2020-04-01 15 47 35](https://user-images.githubusercontent.com/811963/78181093-cecd4500-7431-11ea-8024-b41f2c79f8d2.png)


# Note about useEffect

Because of how `useEffect`'s dependency array argument works, it's easy to have `useEffect` logic called more often than necessary. It's important to specify very specific things in that array so that the effect will only run again if that specific thing changes.

In this case, the `useEffect` that waits for discovered PVs to be present and then calls `getPVResourcesRequest` was using `[currentPlan, isPollingStatus]` as its dependencies, which means it was running again every time the component re-rendered (since `currentPlan` comes from redux state, and each state change creates a new immutable `currentPlan`, it is always changing). What we really needed was for that logic to only run when `currentPlan.spec.persistentVolumes` goes from empty to non-empty, so the real dependency is just the length of that array.

On entering the wizard step, network traffic before 2ecb64f:
![Screenshot 2020-03-25 19 49 32-bad](https://user-images.githubusercontent.com/811963/77597443-48ff4600-6ed5-11ea-8298-78e7b5b62b04.png)

Network traffic after 2ecb64f:
![Screenshot 2020-03-25 19 53 10-good](https://user-images.githubusercontent.com/811963/77597454-4dc3fa00-6ed5-11ea-8163-39c97f86f546.png)
