### PR TITLE
Wizard: Destructuring props directly and use TypeScript types along with types annotations

### DIFF
--- a/src/app/plan/components/Wizard/GeneralForm.tsx
+++ b/src/app/plan/components/Wizard/GeneralForm.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import { FormikProps, FormikActions, FormikState } from 'formik';
+import { IFormValues, IOtherProps } from './WizardContainer';
 import {
   Form,
   FormGroup,
@@ -11,15 +13,25 @@ interface IProps {
   component: React.ReactNode;
 }
 
-const GeneralForm: React.SFC<IProps & RouteComponentProps> = ({
-  handleChange,
-  handleBlur,
-  values,
+interface IGeneralFormProps
+  extends Pick<
+    IOtherProps,
+    | 'isEdit'
+    >,
+    Pick<FormikActions<IFormValues>, 'setFieldTouched'>,
+    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'>,
+    Pick<FormikState<IFormValues>, 'touched'> {
+      errors: any;
+    }
+const GeneralForm: React.FunctionComponent<IGeneralFormProps & RouteComponentProps> = ({
   errors,
-  touched,
+  handleBlur,
+  handleChange,
+  isEdit,
   setFieldTouched,
-  isEdit
-}) => {
+  touched,
+  values,
+}: IGeneralFormProps & RouteComponentProps) => {
   const onHandleChange = (val, e) => {
     handleChange(e);
   };

--- a/src/app/plan/components/Wizard/GeneralForm.tsx
+++ b/src/app/plan/components/Wizard/GeneralForm.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
 import { FormikProps, FormikActions, FormikState } from 'formik';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import {
@@ -14,13 +13,21 @@ interface IProps {
 }
 
 interface IGeneralFormProps
-  extends Pick<IOtherProps, 'isEdit'>,
-    Pick<FormikActions<IFormValues>, 'setFieldTouched'>,
-    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'>,
-    Pick<FormikState<IFormValues>, 'touched'> {
+  extends Pick<
+    IOtherProps, 'isEdit'
+    >,
+    Pick<FormikProps<IFormValues>, 
+    | 'handleBlur'
+    | 'handleChange'
+    | 'setFieldTouched' 
+    | 'values' 
+    | 'touched'
+    > 
+    {
       errors: any;
     }
-const GeneralForm: React.FunctionComponent<IGeneralFormProps & RouteComponentProps> = ({
+
+const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   errors,
   handleBlur,
   handleChange,
@@ -28,7 +35,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps & RouteComponentPro
   setFieldTouched,
   touched,
   values,
-}: IGeneralFormProps & RouteComponentProps) => {
+}: IGeneralFormProps) => {
   const onHandleChange = (val, e) => {
     handleChange(e);
   };

--- a/src/app/plan/components/Wizard/GeneralForm.tsx
+++ b/src/app/plan/components/Wizard/GeneralForm.tsx
@@ -14,10 +14,7 @@ interface IProps {
 }
 
 interface IGeneralFormProps
-  extends Pick<
-    IOtherProps,
-    | 'isEdit'
-    >,
+  extends Pick<IOtherProps, 'isEdit'>,
     Pick<FormikActions<IFormValues>, 'setFieldTouched'>,
     Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'>,
     Pick<FormikState<IFormValues>, 'touched'> {

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -22,7 +22,7 @@ interface INamespaceTableProps
     | 'isEdit'
     | 'sourceClusterNamespaces'
     >,
-  Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
+    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
 
 const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
   setFieldValue, sourceClusterNamespaces, values

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { FormikProps } from 'formik';
+import { IFormValues, IOtherProps } from './WizardContainer';
 import {
   GridItem,
   Text,
@@ -14,23 +16,17 @@ import { Table, TableHeader, TableBody, TableVariant } from '@patternfly/react-t
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { usePaginationState } from '../../../common/duck/hooks';
 
-interface INamespaceTableProps {
-  isEdit: boolean;
-  values: any;
-  sourceClusterNamespaces: [
-    {
-      name: string;
-      podCount: number;
-      pvcCount: number;
-      serviceCount: number;
-    }
-  ];
-  setFieldValue: (fieldName, fieldValue) => void;
-}
+interface INamespaceTableProps
+  extends Pick<
+    IOtherProps,
+    | 'isEdit'
+    | 'sourceClusterNamespaces'
+    >,
+  Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
 
-const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
-  const { setFieldValue, sourceClusterNamespaces, values } = props;
-
+const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
+  setFieldValue, sourceClusterNamespaces, values
+}: INamespaceTableProps) => {
   if (values.sourceCluster === null) return null;
 
   const columns = [

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -18,11 +18,11 @@ interface IResourceSelectFormProps
   extends Pick<
     IOtherProps,
     | 'clusterList'
-    | 'storageList'
-    | 'isFetchingNamespaceList'
     | 'fetchNamespacesRequest'
-    | 'sourceClusterNamespaces'
     | 'isEdit'
+    | 'isFetchingNamespaceList'
+    | 'sourceClusterNamespaces'
+    | 'storageList'
     >,
     Pick<FormikActions<IFormValues>, 'setFieldTouched'>,
     Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'>,
@@ -32,16 +32,16 @@ interface IResourceSelectFormProps
 
 const ResourceSelectForm: React.FunctionComponent<IResourceSelectFormProps> = ({
   clusterList,
-  storageList,
-  values,
   errors,
-  touched,
-  setFieldValue,
-  setFieldTouched,
-  isFetchingNamespaceList,
   fetchNamespacesRequest,
-  sourceClusterNamespaces,
   isEdit,
+  isFetchingNamespaceList,
+  setFieldTouched,
+  setFieldValue,
+  sourceClusterNamespaces,
+  storageList,
+  touched,
+  values,
 }: IResourceSelectFormProps) => {
   useEffect(() => {
     if (isEdit) {

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -24,9 +24,13 @@ interface IResourceSelectFormProps
     | 'sourceClusterNamespaces'
     | 'storageList'
     >,
-    Pick<FormikActions<IFormValues>, 'setFieldTouched'>,
-    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'>,
-    Pick<FormikState<IFormValues>, 'touched'> {
+    Pick<FormikProps<IFormValues>, 
+    | 'setFieldTouched'
+    | 'setFieldValue' 
+    | 'touched'
+    | 'values'
+    > 
+    {
       errors: any;
     }
 

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { FormikProps, FormikActions, FormikState } from 'formik';
+import { IFormValues, IOtherProps } from './WizardContainer';
 import {
   Bullseye,
   EmptyState,
@@ -12,21 +14,35 @@ import NamespaceTable from './NameSpaceTable';
 import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 import SimpleSelect from '../../../common/components/SimpleSelect';
 
-const ResourceSelectForm = props => {  
-  const {
-    clusterList,
-    storageList,
-    values,
-    errors,
-    touched,
-    setFieldValue,
-    setFieldTouched,
-    isFetchingNamespaceList,
-    fetchNamespacesRequest,
-    sourceClusterNamespaces,
-    isEdit,
-  } = props;
+interface IResourceSelectFormProps
+  extends Pick<
+    IOtherProps,
+    | 'clusterList'
+    | 'storageList'
+    | 'isFetchingNamespaceList'
+    | 'fetchNamespacesRequest'
+    | 'sourceClusterNamespaces'
+    | 'isEdit'
+    >,
+    Pick<FormikActions<IFormValues>, 'setFieldTouched'>,
+    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'>,
+    Pick<FormikState<IFormValues>, 'touched'> {
+      errors: any;
+    }
 
+const ResourceSelectForm: React.FunctionComponent<IResourceSelectFormProps> = ({
+  clusterList,
+  storageList,
+  values,
+  errors,
+  touched,
+  setFieldValue,
+  setFieldTouched,
+  isFetchingNamespaceList,
+  fetchNamespacesRequest,
+  sourceClusterNamespaces,
+  isEdit,
+}: IResourceSelectFormProps) => {
   useEffect(() => {
     if (isEdit) {
       fetchNamespacesRequest(values.sourceCluster);
@@ -36,7 +52,7 @@ const ResourceSelectForm = props => {
   let srcClusterOptions: string[] = ['No valid clusters found'];
   let targetClusterOptions: string[] = [];
   let storageOptions: string[] = ['No valid storage found'];
-  
+
   if (clusterList.length) {
     srcClusterOptions = clusterList
       .filter(cluster => cluster.MigCluster.metadata.name !== values.targetCluster && cluster.ClusterStatus.hasReadyCondition)
@@ -52,7 +68,7 @@ const ResourceSelectForm = props => {
       .filter(storage => storage.StorageStatus.hasReadyCondition)
       .map(storage => storage.MigStorage.metadata.name)
   }
-  
+
   const handleStorageChange = value => {
     const matchingStorage = storageList.find(c => c.MigStorage.metadata.name === value);
     if (matchingStorage) {

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -21,12 +21,12 @@ interface IStorageClassFormProps
     Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
 
 const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
-   clusterList,
-   currentPlan,
-   isEdit,
-   isFetchingPVList,
-   setFieldValue,
-   values,
+  clusterList,
+  currentPlan,
+  isEdit,
+  isFetchingPVList,
+  setFieldValue,
+  values,
 }: IStorageClassFormProps) => { 
   return (
     <Grid gutter="md">

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -6,9 +6,28 @@ import {
   TextContent,
   TextVariants
 } from '@patternfly/react-core';
+import { FormikProps } from 'formik';
+import { IFormValues, IOtherProps } from './WizardContainer';
 import StorageClassTable from './StorageClassTable';
-const StorageClassForm = props => {
-  const { isEdit, setFieldValue, values, currentPlan, clusterList, isFetchingPVList } = props;
+
+interface IStorageClassFormProps
+  extends Pick<
+    IOtherProps,
+    | 'clusterList'
+    | 'currentPlan'
+    | 'isEdit'
+    | 'isFetchingPVList'
+    >,
+    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
+
+const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
+   clusterList,
+   currentPlan,
+   isEdit,
+   isFetchingPVList,
+   setFieldValue,
+   values,
+}: IStorageClassFormProps) => { 
   return (
     <Grid gutter="md">
       <GridItem>

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -39,7 +39,6 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
       </GridItem>
       <GridItem>
         <StorageClassTable
-          isEdit={isEdit}
           isFetchingPVList={isFetchingPVList}
           setFieldValue={setFieldValue}
           values={values}

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -7,13 +7,29 @@ import {
   EmptyState,
   Title,
 } from '@patternfly/react-core';
+import { FormikProps } from 'formik';
+import { IFormValues, IOtherProps } from './WizardContainer';
 import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 
 export const pvStorageClassAssignmentKey = 'pvStorageClassAssignment';
 export const pvCopyMethodAssignmentKey = 'pvCopyMethodAssignment';
 
-const StorageClassTable = (props) => {
-  const { currentPlan, clusterList, values, isFetchingPVList } = props;
+interface IStorageClassTableForm
+  extends Pick<
+    IOtherProps,
+    | 'clusterList'
+    | 'currentPlan'
+    | 'isFetchingPVList'
+    >,
+    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
+
+const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
+  clusterList,
+  currentPlan,
+  isFetchingPVList,
+  setFieldValue,
+  values,
+}: IStorageClassTableForm) => {
   const [rows, setRows] = useState([]);
   const [storageClassOptions, setStorageClassOptions] = useState([]);
   const [pvStorageClassAssignment, setPvStorageClassAssignment] = useState({});
@@ -36,7 +52,7 @@ const StorageClassTable = (props) => {
     };
 
     setPvStorageClassAssignment(updatedAssignment);
-    props.setFieldValue(pvStorageClassAssignmentKey, updatedAssignment);
+    setFieldValue(pvStorageClassAssignmentKey, updatedAssignment);
   };
 
   const handleCopyMethodChange = (selectedPV, option) => {
@@ -49,7 +65,7 @@ const StorageClassTable = (props) => {
     };
 
     setPvCopyMethodAssignment(updatedAssignment);
-    props.setFieldValue(pvCopyMethodAssignmentKey, updatedAssignment);
+    setFieldValue(pvCopyMethodAssignmentKey, updatedAssignment);
   };
 
   useEffect(() => {
@@ -75,7 +91,7 @@ const StorageClassTable = (props) => {
         return assignedScs;
       }, {}) : {};
       setPvStorageClassAssignment(initialAssignedScs);
-      props.setFieldValue(pvStorageClassAssignmentKey, initialAssignedScs);
+      setFieldValue(pvStorageClassAssignmentKey, initialAssignedScs);
     }
 
 
@@ -91,7 +107,7 @@ const StorageClassTable = (props) => {
     }, {}) : {};
 
     setPvCopyMethodAssignment(initialAssignedCms);
-    props.setFieldValue(pvCopyMethodAssignmentKey, initialAssignedCms);
+    setFieldValue(pvCopyMethodAssignmentKey, initialAssignedCms);
 
     if (values.persistentVolumes.length) {
       setRows(values.persistentVolumes.filter(v => v.type === 'copy'));

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -107,8 +107,6 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
                 values={values}
                 errors={errors}
                 touched={touched}
-                handleBlur={handleBlur}
-                handleChange={handleChange}
                 setFieldValue={setFieldValue}
                 setFieldTouched={setFieldTouched}
                 clusterList={clusterList}
@@ -168,12 +166,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
               <StorageClassForm
                 isEdit={isEdit}
                 values={values}
-                errors={errors}
-                touched={touched}
-                handleBlur={handleBlur}
-                handleChange={handleChange}
                 setFieldValue={setFieldValue}
-                setFieldTouched={setFieldTouched}
                 currentPlan={currentPlan}
                 isFetchingPVList={isFetchingPVList}
                 clusterList={clusterList}

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -50,7 +50,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     isEdit,
     editPlanObj,
     updateCurrentPlanStatus,
-    pvUpdatePollStop
+    pvUpdatePollStop,
   } = props;
 
   enum stepId {
@@ -77,146 +77,146 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     }
   }, [isOpen]);
 
-  useEffect(() => {
-    const steps = [
-      {
-        id: stepId.General,
-        name: 'General',
-        component: (
-          <WizardStepContainer title="General">
-            <GeneralForm
+  useEffect(
+    () => {
+      const steps = [
+        {
+          id: stepId.General,
+          name: 'General',
+          component: (
+            <WizardStepContainer title="General">
+              <GeneralForm
+                values={values}
+                errors={errors}
+                touched={touched}
+                handleBlur={handleBlur}
+                handleChange={handleChange}
+                setFieldTouched={setFieldTouched}
+                isEdit={isEdit}
+              />
+            </WizardStepContainer>
+          ),
+          enableNext: !errors.planName && (touched.planName === true || isEdit === true),
+        },
+        {
+          id: stepId.MigrationSource,
+          name: 'Resources',
+          component: (
+            <WizardStepContainer title="Resources">
+              <ResourceSelectForm
+                values={values}
+                errors={errors}
+                touched={touched}
+                handleBlur={handleBlur}
+                handleChange={handleChange}
+                setFieldValue={setFieldValue}
+                setFieldTouched={setFieldTouched}
+                clusterList={clusterList}
+                storageList={storageList}
+                isFetchingNamespaceList={isFetchingNamespaceList}
+                fetchNamespacesRequest={fetchNamespacesRequest}
+                sourceClusterNamespaces={sourceClusterNamespaces}
+                isEdit={isEdit}
+              />
+            </WizardStepContainer>
+          ),
+          enableNext:
+            (!errors.selectedStorage &&
+              touched.selectedStorage === true &&
+              !errors.targetCluster &&
+              touched.targetCluster === true &&
+              !errors.sourceCluster &&
+              touched.sourceCluster === true &&
+              !errors.selectedNamespaces) ||
+            (isEdit &&
+              !errors.selectedStorage &&
+              !errors.targetCluster &&
+              !errors.sourceCluster &&
+              !errors.selectedNamespaces),
+          canJumpTo: stepIdReached >= stepId.MigrationSource,
+        },
+        {
+          id: stepId.PersistentVolumes,
+          name: 'Persistent volumes',
+          component: (
+            <WizardStepContainer title="Persistent volumes">
+              <VolumesForm
+                values={values}
+                setFieldValue={setFieldValue}
+                currentPlan={currentPlan}
+                isPVError={isPVError}
+                getPVResourcesRequest={getPVResourcesRequest}
+                pvResourceList={pvResourceList}
+                isFetchingPVResources={isFetchingPVList}
+                isPollingStatus={isPollingStatus}
+                planUpdateRequest={planUpdateRequest}
+                currentPlanStatus={currentPlanStatus}
+              />
+            </WizardStepContainer>
+          ),
+          enableNext:
+            !isFetchingPVList &&
+            currentPlanStatus.state !== 'Pending' &&
+            currentPlanStatus.state !== 'Critical',
+          canJumpTo: stepIdReached >= stepId.PersistentVolumes,
+        },
+        {
+          id: stepId.StorageClass,
+          name: 'Storage class',
+          component: (
+            <WizardStepContainer title="Storage class">
+              <StorageClassForm
+                isEdit={isEdit}
+                values={values}
+                errors={errors}
+                touched={touched}
+                handleBlur={handleBlur}
+                handleChange={handleChange}
+                setFieldValue={setFieldValue}
+                setFieldTouched={setFieldTouched}
+                currentPlan={currentPlan}
+                isFetchingPVList={isFetchingPVList}
+                clusterList={clusterList}
+              />
+            </WizardStepContainer>
+          ),
+          canJumpTo: stepIdReached >= stepId.StorageClass,
+          nextButtonText: 'Finish',
+        },
+        {
+          id: stepId.Results,
+          name: 'Results',
+          isFinishedStep: true,
+          component: (
+            <ResultsStep
               values={values}
               errors={errors}
-              touched={touched}
-              handleBlur={handleBlur}
-              handleChange={handleChange}
-              setFieldTouched={setFieldTouched}
-              isEdit={isEdit}
-            />
-          </WizardStepContainer>
-        ),
-        enableNext: !errors.planName && (touched.planName === true || isEdit === true),
-      },
-      {
-        id: stepId.MigrationSource,
-        name: 'Resources',
-        component: (
-          <WizardStepContainer title="Resources">
-            <ResourceSelectForm
-              values={values}
-              errors={errors}
-              touched={touched}
-              handleBlur={handleBlur}
-              handleChange={handleChange}
-              setFieldValue={setFieldValue}
-              setFieldTouched={setFieldTouched}
-              clusterList={clusterList}
-              storageList={storageList}
-              isFetchingNamespaceList={isFetchingNamespaceList}
-              fetchNamespacesRequest={fetchNamespacesRequest}
-              sourceClusterNamespaces={sourceClusterNamespaces}
-              isEdit={isEdit}
-            />
-          </WizardStepContainer>
-        ),
-        enableNext:
-          !errors.selectedStorage &&
-          touched.selectedStorage === true &&
-          !errors.targetCluster &&
-          touched.targetCluster === true &&
-          !errors.sourceCluster &&
-          touched.sourceCluster === true &&
-          !errors.selectedNamespaces ||
-          (isEdit &&
-            !errors.selectedStorage &&
-            !errors.targetCluster &&
-            !errors.sourceCluster &&
-            !errors.selectedNamespaces),
-        canJumpTo: stepIdReached >= stepId.MigrationSource,
-      },
-      {
-        id: stepId.PersistentVolumes,
-        name: 'Persistent volumes',
-        component: (
-          <WizardStepContainer title="Persistent volumes">
-            <VolumesForm
-              values={values}
-              setFieldValue={setFieldValue}
               currentPlan={currentPlan}
-              isPVError={isPVError}
-              getPVResourcesRequest={getPVResourcesRequest}
-              pvResourceList={pvResourceList}
-              isFetchingPVResources={isFetchingPVList}
-              isPollingStatus={isPollingStatus}
-              planUpdateRequest={planUpdateRequest}
               currentPlanStatus={currentPlanStatus}
+              isPollingStatus={isPollingStatus}
+              startPlanStatusPolling={startPlanStatusPolling}
+              onClose={handleClose}
             />
-          </WizardStepContainer>
-        ),
-        enableNext:
-          !isFetchingPVList &&
-          currentPlanStatus.state !== 'Pending' &&
-          currentPlanStatus.state !== 'Critical',
-        canJumpTo: stepIdReached >= stepId.PersistentVolumes,
-      },
-      {
-        id: stepId.StorageClass,
-        name: 'Storage class',
-        component: (
-          <WizardStepContainer title="Storage class">
-            <StorageClassForm
-              isEdit={isEdit}
-              values={values}
-              errors={errors}
-              touched={touched}
-              handleBlur={handleBlur}
-              handleChange={handleChange}
-              setFieldValue={setFieldValue}
-              setFieldTouched={setFieldTouched}
-              currentPlan={currentPlan}
-              isFetchingPVList={isFetchingPVList}
-              clusterList={clusterList}
-            />
-          </WizardStepContainer>
-        ),
-        canJumpTo: stepIdReached >= stepId.StorageClass,
-        nextButtonText: 'Finish'
-      },
-      {
-        id: stepId.Results,
-        name: 'Results',
-        isFinishedStep: true,
-        component: (
-          <ResultsStep
-            values={values}
-            errors={errors}
-            currentPlan={currentPlan}
-            currentPlanStatus={currentPlanStatus}
-            isPollingStatus={isPollingStatus}
-            startPlanStatusPolling={startPlanStatusPolling}
-            onClose={handleClose}
-          />
-        ),
-      },
-    ];
+          ),
+        },
+      ];
 
-    setUpdatedSteps(steps);
-
-  },
-  //****************** Don't forget to update this array if you add changes to wizard children!!! */ 
-  [
-    currentPlan,
-    values,
-    isPVError,
-    isFetchingPVList,
-    isPollingStatus,
-    isFetchingNamespaceList,
-    pvResourceList,
-    errors,
-    touched,
-    currentPlanStatus
-  ]);
-
+      setUpdatedSteps(steps);
+    },
+    //****************** Don't forget to update this array if you add changes to wizard children!!! */
+    [
+      currentPlan,
+      values,
+      isPVError,
+      isFetchingPVList,
+      isPollingStatus,
+      isFetchingNamespaceList,
+      pvResourceList,
+      errors,
+      touched,
+      currentPlanStatus,
+    ]
+  );
 
   const onMove = (curr, prev) => {
     //stop pv polling when navigating
@@ -263,7 +263,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
           isFullWidth
           isCompactNav
           className={styles.wizardModifier}
-          onSubmit={event => event.preventDefault()}
+          onSubmit={(event) => event.preventDefault()}
         />
       )}
     </React.Fragment>

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -13,6 +13,7 @@ export interface IFormValues {
   selectedStorage: string;
   selectedNamespaces: any[];
   persistentVolumes: any[]; // TODO replace this with selections-only version after refactor
+  pvStorageClassAssignment: any[];
 }
 
 // TODO add more specific types instead of using `any`
@@ -62,6 +63,7 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
       selectedNamespaces: [],
       selectedStorage: null,
       persistentVolumes: [],
+      pvStorageClassAssignment: [],
     };
     if (editPlanObj && isEdit) {
       values.planName = editPlanObj.metadata.name || '';

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -13,7 +13,7 @@ export interface IFormValues {
   selectedStorage: string;
   selectedNamespaces: any[];
   persistentVolumes: any[]; // TODO replace this with selections-only version after refactor
-  pvStorageClassAssignment: any[];
+  pvStorageClassAssignment: any[]; 
 }
 
 // TODO add more specific types instead of using `any`

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -4,7 +4,7 @@ import { PlanActions } from '../../duck/actions';
 import planSelectors from '../../duck/selectors';
 import { connect } from 'react-redux';
 import utils from '../../../common/duck/utils';
-import { IPlan, IPlanPersistentVolume, IPersistentVolumeResource } from './types';
+import { IPlan, IPlanPersistentVolume, IPersistentVolumeResource, ISourceClusterNamespace } from './types';
 import { ICurrentPlanStatus } from '../../duck/reducers';
 export interface IFormValues {
   planName: string;
@@ -45,7 +45,7 @@ export interface IOtherProps {
     sourceClusterName: IFormValues['sourceCluster']
   ) => void;
   addPlanRequest: (migPlan) => void;
-  sourceClusterNamespaces: any[];
+  sourceClusterNamespaces: ISourceClusterNamespace[];
   pvResourceList: IPersistentVolumeResource[];
   onHandleWizardModalClose: () => void;
   editPlanObj?: any;

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -13,7 +13,7 @@ export interface IFormValues {
   selectedStorage: string;
   selectedNamespaces: any[];
   persistentVolumes: any[]; // TODO replace this with selections-only version after refactor
-  pvStorageClassAssignment: any[]; 
+  pvStorageClassAssignment: any; 
 }
 
 // TODO add more specific types instead of using `any`

--- a/src/app/plan/components/Wizard/types.ts
+++ b/src/app/plan/components/Wizard/types.ts
@@ -33,3 +33,10 @@ export interface IPersistentVolumeResource {
   name: string;
   [key: string]: any;
 }
+
+export interface ISourceClusterNamespace {
+  name: string;
+  podCount: number;
+  pvcCount: number;
+  serviceCount: number;
+}


### PR DESCRIPTION
Destructuring props directly in component instead of using proxy props object.
This allows props validation and to make sure unnecessary properties aren't passed to components
