### PR TITLE
Add titles to the top of every plan wizard step

### DIFF
--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -9,6 +9,7 @@ import { PollingContext } from '../../../home/duck/context';
 import { FormikProps } from 'formik';
 import { IOtherProps, IFormValues } from './WizardContainer';
 import { CurrentPlanState } from '../../duck/reducers';
+import WizardStepContainer from './WizardStepContainer';
 
 const styles = require('./WizardComponent.module');
 
@@ -82,15 +83,17 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
         id: stepId.General,
         name: 'General',
         component: (
-          <GeneralForm
-            values={values}
-            errors={errors}
-            touched={touched}
-            handleBlur={handleBlur}
-            handleChange={handleChange}
-            setFieldTouched={setFieldTouched}
-            isEdit={isEdit}
-          />
+          <WizardStepContainer title="General">
+            <GeneralForm
+              values={values}
+              errors={errors}
+              touched={touched}
+              handleBlur={handleBlur}
+              handleChange={handleChange}
+              setFieldTouched={setFieldTouched}
+              isEdit={isEdit}
+            />
+          </WizardStepContainer>
         ),
         enableNext: !errors.planName && (touched.planName === true || isEdit === true),
       },
@@ -98,21 +101,23 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
         id: stepId.MigrationSource,
         name: 'Resources',
         component: (
-          <ResourceSelectForm
-            values={values}
-            errors={errors}
-            touched={touched}
-            handleBlur={handleBlur}
-            handleChange={handleChange}
-            setFieldValue={setFieldValue}
-            setFieldTouched={setFieldTouched}
-            clusterList={clusterList}
-            storageList={storageList}
-            isFetchingNamespaceList={isFetchingNamespaceList}
-            fetchNamespacesRequest={fetchNamespacesRequest}
-            sourceClusterNamespaces={sourceClusterNamespaces}
-            isEdit={isEdit}
-          />
+          <WizardStepContainer title="Resources">
+            <ResourceSelectForm
+              values={values}
+              errors={errors}
+              touched={touched}
+              handleBlur={handleBlur}
+              handleChange={handleChange}
+              setFieldValue={setFieldValue}
+              setFieldTouched={setFieldTouched}
+              clusterList={clusterList}
+              storageList={storageList}
+              isFetchingNamespaceList={isFetchingNamespaceList}
+              fetchNamespacesRequest={fetchNamespacesRequest}
+              sourceClusterNamespaces={sourceClusterNamespaces}
+              isEdit={isEdit}
+            />
+          </WizardStepContainer>
         ),
         enableNext:
           !errors.selectedStorage &&
@@ -133,18 +138,20 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
         id: stepId.PersistentVolumes,
         name: 'Persistent volumes',
         component: (
-          <VolumesForm
-            values={values}
-            setFieldValue={setFieldValue}
-            currentPlan={currentPlan}
-            isPVError={isPVError}
-            getPVResourcesRequest={getPVResourcesRequest}
-            pvResourceList={pvResourceList}
-            isFetchingPVResources={isFetchingPVList}
-            isPollingStatus={isPollingStatus}
-            planUpdateRequest={planUpdateRequest}
-            currentPlanStatus={currentPlanStatus}
-          />
+          <WizardStepContainer title="Persistent volumes">
+            <VolumesForm
+              values={values}
+              setFieldValue={setFieldValue}
+              currentPlan={currentPlan}
+              isPVError={isPVError}
+              getPVResourcesRequest={getPVResourcesRequest}
+              pvResourceList={pvResourceList}
+              isFetchingPVResources={isFetchingPVList}
+              isPollingStatus={isPollingStatus}
+              planUpdateRequest={planUpdateRequest}
+              currentPlanStatus={currentPlanStatus}
+            />
+          </WizardStepContainer>
         ),
         enableNext:
           !isFetchingPVList &&
@@ -156,19 +163,21 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
         id: stepId.StorageClass,
         name: 'Storage class',
         component: (
-          <StorageClassForm
-            isEdit={isEdit}
-            values={values}
-            errors={errors}
-            touched={touched}
-            handleBlur={handleBlur}
-            handleChange={handleChange}
-            setFieldValue={setFieldValue}
-            setFieldTouched={setFieldTouched}
-            currentPlan={currentPlan}
-            isFetchingPVList={isFetchingPVList}
-            clusterList={clusterList}
-          />
+          <WizardStepContainer title="Storage class">
+            <StorageClassForm
+              isEdit={isEdit}
+              values={values}
+              errors={errors}
+              touched={touched}
+              handleBlur={handleBlur}
+              handleChange={handleChange}
+              setFieldValue={setFieldValue}
+              setFieldTouched={setFieldTouched}
+              currentPlan={currentPlan}
+              isFetchingPVList={isFetchingPVList}
+              clusterList={clusterList}
+            />
+          </WizardStepContainer>
         ),
         canJumpTo: stepIdReached >= stepId.StorageClass,
         nextButtonText: 'Finish'

--- a/src/app/plan/components/Wizard/WizardStepContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardStepContainer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { TextContent, Text, TextVariants } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+
+interface IWizardStepContainerProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+const WizardStepContainer: React.FunctionComponent<IWizardStepContainerProps> = ({
+  title,
+  children,
+}: IWizardStepContainerProps) => (
+  <React.Fragment>
+    <TextContent className={spacing.mbMd}>
+      <Text component={TextVariants.h2}>{title}</Text>
+    </TextContent>
+    {children}
+  </React.Fragment>
+);
+
+export default WizardStepContainer;


### PR DESCRIPTION
Fixes #795. To avoid messing with the structure of the individual step components and duplicating the code for the heading/spacer, I just added a `WizardStepContainer` component that wraps each step in a fragment with the title above its children.

<img width="1344" alt="Screenshot 2020-04-03 17 22 32" src="https://user-images.githubusercontent.com/811963/78406134-fb1ec800-75cf-11ea-9f66-95709eda7362.png">
<img width="1347" alt="Screenshot 2020-04-03 17 22 42" src="https://user-images.githubusercontent.com/811963/78406143-007c1280-75d0-11ea-81fc-8dfb939c6055.png">
<img width="1348" alt="Screenshot 2020-04-03 17 23 12" src="https://user-images.githubusercontent.com/811963/78406145-02de6c80-75d0-11ea-9cf1-b27e5bf10265.png">
<img width="1350" alt="Screenshot 2020-04-03 17 23 25" src="https://user-images.githubusercontent.com/811963/78406147-04a83000-75d0-11ea-9ad6-f47a03d54bd4.png">
<img width="1349" alt="Screenshot 2020-04-03 17 23 45" src="https://user-images.githubusercontent.com/811963/78406148-070a8a00-75d0-11ea-99bb-f0ea72268387.png">
<img width="1351" alt="Screenshot 2020-04-03 17 23 55" src="https://user-images.githubusercontent.com/811963/78406151-096ce400-75d0-11ea-8b11-3d40db580fad.png">
