### PR TITLE
Add filtering and sorting to PVs and Resources tables

### DIFF
--- a/src/app/common/components/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react';
+import {
+  SelectOptionProps,
+  Select,
+  SelectOption,
+  InputGroup,
+  Button,
+  ButtonVariant,
+  DataToolbar,
+  DataToolbarContent,
+  DataToolbarToggleGroup,
+  DataToolbarItem,
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  DataToolbarFilter,
+} from '@patternfly/react-core';
+import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
+
+export enum FilterType {
+  select = 'select',
+  search = 'search',
+}
+
+type FilterValue = any; // TODO.. SelectProps.selections? string? array?
+
+export interface IFilterCategory {
+  key: string;
+  title: string;
+  type: FilterType;
+  selectOptions?: SelectOptionProps[]; // TODO only if select type?
+  placeholderText?: string; // TODO only if select type?
+}
+
+interface IFilterValues {
+  [categoryKey: string]: FilterValue;
+}
+
+interface IFilterControlProps {
+  category: IFilterCategory;
+  value: FilterValue;
+}
+
+interface IFilterToolbarProps {
+  filterCategories: IFilterCategory[];
+  filterValues: any[][]; // TODO type this...
+  setFilterValues: (values: IFilterValues) => void;
+}
+
+const FilterControl: React.FunctionComponent<IFilterControlProps> = ({ category, value }) => {
+  const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
+  // @ts-ignore
+  const onFilterSelect = () => console.log('onFilterSelect', arguments);
+
+  // TODO split into sub components?
+
+  const [inputValue, setInputValue] = useState('');
+
+  const onInputSubmit = () => console.log('TODO');
+
+  // @ts-ignore
+  const onInputChange = () => console.log('onInputChange', arguments);
+
+  const onInputKeyDown = () => {
+    onInputSubmit();
+    // @ts-ignore
+    console.log('onInputKeyDown', arguments);
+  };
+
+  if (category.type === FilterType.select) {
+    return (
+      <Select
+        aria-label={category.title}
+        onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
+        onSelect={onFilterSelect} // TODO ???
+        selections={value}
+        isExpanded={isFilterDropdownOpen}
+        placeholderText="Any"
+      >
+        {category.selectOptions.map(optionProps => (
+          <SelectOption {...optionProps} />
+        ))}
+      </Select>
+    );
+  }
+  if (category.type === FilterType.search) {
+    const id = `${category.key}-input`;
+    return (
+      <InputGroup>
+        {/*
+          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
+        <TextInput
+          name={id}
+          id={id}
+          type="search"
+          aria-label={`${category.title} filter`}
+          onChange={onInputChange}
+          value={inputValue}
+          placeholder={category.placeholderText}
+          onKeyDown={onInputKeyDown}
+        />
+        <Button
+          variant={ButtonVariant.control}
+          aria-label="search button for search input"
+          onClick={onInputSubmit}
+        >
+          <SearchIcon />
+        </Button>
+      </InputGroup>
+    );
+  }
+  return null;
+};
+
+const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
+  filterCategories,
+  filterValues,
+  setFilterValues,
+}) => {
+  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
+  const [currentCategoryKey, setCurrentCategoryKey] = useState(filterCategories[0].key);
+
+  const onCategorySelect = category => {
+    setCurrentCategoryKey(category.key);
+    setIsCategoryDropdownOpen(false);
+  };
+
+  const clearAllFilters = () => console.log('clearAllFilters!'); // TODO
+  const onClearFilter = () => console.log('onClearFilter'); // TODO
+  const onFilterChange = () => console.log('onFilterChange'); // TODO
+
+  const currentFilterCategory = filterCategories.find(
+    category => category.key === currentCategoryKey
+  );
+
+  return (
+    <DataToolbar id="pv-table-filter-toolbar" clearAllFilters={clearAllFilters}>
+      <DataToolbarContent>
+        <DataToolbarToggleGroup variant="filter-group" toggleIcon={<FilterIcon />} breakpoint="xl">
+          <DataToolbarItem>
+            <Dropdown
+              toggle={
+                <DropdownToggle onToggle={() => setIsCategoryDropdownOpen(!isCategoryDropdownOpen)}>
+                  <FilterIcon /> {currentFilterCategory.title}
+                </DropdownToggle>
+              }
+              isOpen={isCategoryDropdownOpen}
+              dropdownItems={filterCategories.map(category => (
+                // TODO properties for row property name and title
+                <DropdownItem key={category.key} onClick={() => onCategorySelect(category)}>
+                  {category.title}
+                </DropdownItem>
+              ))}
+            />
+          </DataToolbarItem>
+          {filterCategories.map(category => (
+            <DataToolbarFilter
+              key={category.key}
+              chips={filterValues[category.key]}
+              deleteChip={onClearFilter}
+              categoryName={category.title}
+              showToolbarItem={currentFilterCategory.key === category.key}
+            >
+              <FilterControl category={category} value={filterValues[category.key]} />
+            </DataToolbarFilter>
+          ))}
+        </DataToolbarToggleGroup>
+      </DataToolbarContent>
+    </DataToolbar>
+  );
+};
+
+export default FilterToolbar;

--- a/src/app/common/components/FilterToolbar/FilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/FilterControl.tsx
@@ -13,7 +13,7 @@ export interface IFilterControlProps {
 export const FilterControl: React.FunctionComponent<IFilterControlProps> = ({
   category,
   ...props
-}) => {
+}: IFilterControlProps) => {
   if (category.type === FilterType.select) {
     return <SelectFilterControl category={category} {...props} />;
   }

--- a/src/app/common/components/FilterToolbar/FilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/FilterControl.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import {
+  Select,
+  SelectOption,
+  InputGroup,
+  TextInput,
+  Button,
+  ButtonVariant,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+
+import { IFilterCategory, FilterValue, FilterType } from './FilterToolbar';
+
+interface IFilterControlProps {
+  category: IFilterCategory;
+  value: FilterValue;
+  setValue: (newValue: FilterValue) => void;
+}
+
+export const FilterControl: React.FunctionComponent<IFilterControlProps> = ({
+  category,
+  value,
+  setValue,
+}) => {
+  const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
+  const onFilterSelect = () => console.log('onFilterSelect');
+
+  // TODO split into sub components?
+
+  const [inputValue, setInputValue] = useState('');
+  const onInputSubmit = () => console.log('onInputSubmit');
+  const onInputChange = () => console.log('onInputChange');
+
+  const onInputKeyDown = () => {
+    onInputSubmit();
+    console.log('onInputKeyDown');
+  };
+
+  if (category.type === FilterType.select) {
+    return (
+      <Select
+        aria-label={category.title}
+        onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
+        onSelect={onFilterSelect} // TODO ???
+        selections={value}
+        isExpanded={isFilterDropdownOpen}
+        placeholderText="Any"
+      >
+        {category.selectOptions.map(optionProps => (
+          <SelectOption {...optionProps} />
+        ))}
+      </Select>
+    );
+  }
+  if (category.type === FilterType.search) {
+    const id = `${category.key}-input`;
+    return (
+      <InputGroup>
+        {/*
+          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
+        <TextInput
+          name={id}
+          id={id}
+          type="search"
+          aria-label={`${category.title} filter`}
+          onChange={onInputChange}
+          value={inputValue}
+          placeholder={category.placeholderText}
+          onKeyDown={onInputKeyDown}
+        />
+        <Button
+          variant={ButtonVariant.control}
+          aria-label="search button for search input"
+          onClick={onInputSubmit}
+        >
+          <SearchIcon />
+        </Button>
+      </InputGroup>
+    );
+  }
+  return null;
+};

--- a/src/app/common/components/FilterToolbar/FilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/FilterControl.tsx
@@ -8,6 +8,7 @@ export interface IFilterControlProps {
   category: IFilterCategory;
   filterValue: FilterValue;
   setFilterValue: (newValue: FilterValue) => void;
+  showToolbarItem: boolean;
 }
 
 export const FilterControl: React.FunctionComponent<IFilterControlProps> = ({

--- a/src/app/common/components/FilterToolbar/FilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/FilterControl.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 
-import { IFilterCategory, FilterValue, FilterType } from './FilterToolbar';
+import {
+  FilterCategory,
+  FilterValue,
+  FilterType,
+  ISelectFilterCategory,
+  ISearchFilterCategory,
+} from './FilterToolbar';
 import SelectFilterControl from './SelectFilterControl';
 import SearchFilterControl from './SearchFilterControl';
 
 export interface IFilterControlProps {
-  category: IFilterCategory;
+  category: FilterCategory;
   filterValue: FilterValue;
   setFilterValue: (newValue: FilterValue) => void;
   showToolbarItem: boolean;
@@ -16,10 +22,10 @@ export const FilterControl: React.FunctionComponent<IFilterControlProps> = ({
   ...props
 }: IFilterControlProps) => {
   if (category.type === FilterType.select) {
-    return <SelectFilterControl category={category} {...props} />;
+    return <SelectFilterControl category={category as ISelectFilterCategory} {...props} />;
   }
   if (category.type === FilterType.search) {
-    return <SearchFilterControl category={category} {...props} />;
+    return <SearchFilterControl category={category as ISearchFilterCategory} {...props} />;
   }
   return null;
 };

--- a/src/app/common/components/FilterToolbar/FilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/FilterControl.tsx
@@ -1,17 +1,10 @@
-import React, { useState } from 'react';
-import {
-  Select,
-  SelectOption,
-  InputGroup,
-  TextInput,
-  Button,
-  ButtonVariant,
-} from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+import React from 'react';
 
 import { IFilterCategory, FilterValue, FilterType } from './FilterToolbar';
+import SelectFilterControl from './SelectFilterControl';
+import SearchFilterControl from './SearchFilterControl';
 
-interface IFilterControlProps {
+export interface IFilterControlProps {
   category: IFilterCategory;
   value: FilterValue;
   setValue: (newValue: FilterValue) => void;
@@ -19,64 +12,13 @@ interface IFilterControlProps {
 
 export const FilterControl: React.FunctionComponent<IFilterControlProps> = ({
   category,
-  value,
-  setValue,
+  ...props
 }) => {
-  const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
-  const onFilterSelect = () => console.log('onFilterSelect');
-
-  // TODO split into sub components?
-
-  const [inputValue, setInputValue] = useState('');
-  const onInputSubmit = () => console.log('onInputSubmit');
-  const onInputChange = () => console.log('onInputChange');
-
-  const onInputKeyDown = () => {
-    onInputSubmit();
-    console.log('onInputKeyDown');
-  };
-
   if (category.type === FilterType.select) {
-    return (
-      <Select
-        aria-label={category.title}
-        onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
-        onSelect={onFilterSelect} // TODO ???
-        selections={value}
-        isExpanded={isFilterDropdownOpen}
-        placeholderText="Any"
-      >
-        {category.selectOptions.map(optionProps => (
-          <SelectOption {...optionProps} />
-        ))}
-      </Select>
-    );
+    return <SelectFilterControl category={category} {...props} />;
   }
   if (category.type === FilterType.search) {
-    const id = `${category.key}-input`;
-    return (
-      <InputGroup>
-        {/*
-          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
-        <TextInput
-          name={id}
-          id={id}
-          type="search"
-          aria-label={`${category.title} filter`}
-          onChange={onInputChange}
-          value={inputValue}
-          placeholder={category.placeholderText}
-          onKeyDown={onInputKeyDown}
-        />
-        <Button
-          variant={ButtonVariant.control}
-          aria-label="search button for search input"
-          onClick={onInputSubmit}
-        >
-          <SearchIcon />
-        </Button>
-      </InputGroup>
-    );
+    return <SearchFilterControl category={category} {...props} />;
   }
   return null;
 };

--- a/src/app/common/components/FilterToolbar/FilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/FilterControl.tsx
@@ -6,8 +6,8 @@ import SearchFilterControl from './SearchFilterControl';
 
 export interface IFilterControlProps {
   category: IFilterCategory;
-  value: FilterValue;
-  setValue: (newValue: FilterValue) => void;
+  filterValue: FilterValue;
+  setFilterValue: (newValue: FilterValue) => void;
 }
 
 export const FilterControl: React.FunctionComponent<IFilterControlProps> = ({

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -8,7 +8,6 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
-  DataToolbarFilter,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 
@@ -25,20 +24,28 @@ export interface OptionPropsWithKey extends SelectOptionProps {
   key: string;
 }
 
-export interface IFilterCategory {
+export interface IBasicFilterCategory {
   key: string;
   title: string;
   type: FilterType; // In the future if we want to support arbitrary control types we could have this be a React.Component prop instead
-  selectOptions?: OptionPropsWithKey[]; // TODO only if select type?
-  placeholderText?: string; // TODO only if select type?
 }
+
+export interface ISelectFilterCategory extends IBasicFilterCategory {
+  selectOptions: OptionPropsWithKey[];
+}
+
+export interface ISearchFilterCategory extends IBasicFilterCategory {
+  placeholderText: string;
+}
+
+export type FilterCategory = ISearchFilterCategory | ISelectFilterCategory;
 
 export interface IFilterValues {
   [categoryKey: string]: FilterValue;
 }
 
 export interface IFilterToolbarProps {
-  filterCategories: IFilterCategory[];
+  filterCategories: FilterCategory[];
   filterValues: IFilterValues;
   setFilterValues: (values: IFilterValues) => void;
 }
@@ -56,7 +63,7 @@ export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
     setIsCategoryDropdownOpen(false);
   };
 
-  const setFilterValue = (category: IFilterCategory, newValue: FilterValue) =>
+  const setFilterValue = (category: FilterCategory, newValue: FilterValue) =>
     setFilterValues({ ...filterValues, [category.key]: newValue });
 
   const currentFilterCategory = filterCategories.find(

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -19,13 +19,17 @@ export enum FilterType {
   search = 'search',
 }
 
-export type FilterValue = any[]; // TODO.. SelectProps.selections? string? array?
+export type FilterValue = string[];
+
+export interface OptionPropsWithKey extends SelectOptionProps {
+  key: string;
+}
 
 export interface IFilterCategory {
   key: string;
   title: string;
-  type: FilterType;
-  selectOptions?: SelectOptionProps[]; // TODO only if select type?
+  type: FilterType; // In the future if we want to support arbitrary control types we could have this be a React.Component prop instead
+  selectOptions?: OptionPropsWithKey[]; // TODO only if select type?
   placeholderText?: string; // TODO only if select type?
 }
 
@@ -52,8 +56,7 @@ export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
     setIsCategoryDropdownOpen(false);
   };
 
-  const clearAllFilters = () => console.log('clearAllFilters!'); // TODO
-  const onClearFilter = () => console.log('onClearFilter'); // TODO
+  const onClearFilter = (category, chip) => console.log('onClearFilter', { category, chip }); // TODO
 
   const setFilterValue = (category: IFilterCategory, newValue: FilterValue) =>
     setFilterValues({ ...filterValues, [category.key]: newValue });
@@ -63,7 +66,7 @@ export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
   );
 
   return (
-    <DataToolbar id="pv-table-filter-toolbar" clearAllFilters={clearAllFilters}>
+    <DataToolbar id="pv-table-filter-toolbar" clearAllFilters={() => setFilterValues({})}>
       <DataToolbarContent>
         <DataToolbarToggleGroup variant="filter-group" toggleIcon={<FilterIcon />} breakpoint="xl">
           <DataToolbarItem>

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -19,7 +19,7 @@ export enum FilterType {
   search = 'search',
 }
 
-export type FilterValue = any; // TODO.. SelectProps.selections? string? array?
+export type FilterValue = any[]; // TODO.. SelectProps.selections? string? array?
 
 export interface IFilterCategory {
   key: string;
@@ -35,7 +35,7 @@ export interface IFilterValues {
 
 export interface IFilterToolbarProps {
   filterCategories: IFilterCategory[];
-  filterValues: any[][]; // TODO type this...
+  filterValues: IFilterValues;
   setFilterValues: (values: IFilterValues) => void;
 }
 
@@ -84,7 +84,7 @@ export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
           {filterCategories.map(category => (
             <DataToolbarFilter
               key={category.key}
-              chips={filterValues[category.key]}
+              chips={filterValues[category.key] || []}
               deleteChip={onClearFilter} // TODO is this one value or all of a category?
               categoryName={category.title}
               showToolbarItem={currentFilterCategory.key === category.key}

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -27,7 +27,7 @@ export interface OptionPropsWithKey extends SelectOptionProps {
 export interface IBasicFilterCategory {
   key: string;
   title: string;
-  type: FilterType; // In the future if we want to support arbitrary control types we could have this be a React.Component prop instead
+  type: FilterType; // If we want to support arbitrary filter types, this could be a React node that consumes context instead of an enum
 }
 
 export interface ISelectFilterCategory extends IBasicFilterCategory {

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -1,11 +1,6 @@
 import React, { useState } from 'react';
 import {
   SelectOptionProps,
-  Select,
-  SelectOption,
-  InputGroup,
-  Button,
-  ButtonVariant,
   DataToolbar,
   DataToolbarContent,
   DataToolbarToggleGroup,
@@ -15,14 +10,16 @@ import {
   DropdownItem,
   DataToolbarFilter,
 } from '@patternfly/react-core';
-import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
+import { FilterIcon } from '@patternfly/react-icons';
+
+import { FilterControl } from './FilterControl';
 
 export enum FilterType {
   select = 'select',
   search = 'search',
 }
 
-type FilterValue = any; // TODO.. SelectProps.selections? string? array?
+export type FilterValue = any; // TODO.. SelectProps.selections? string? array?
 
 export interface IFilterCategory {
   key: string;
@@ -32,87 +29,17 @@ export interface IFilterCategory {
   placeholderText?: string; // TODO only if select type?
 }
 
-interface IFilterValues {
+export interface IFilterValues {
   [categoryKey: string]: FilterValue;
 }
 
-interface IFilterControlProps {
-  category: IFilterCategory;
-  value: FilterValue;
-}
-
-interface IFilterToolbarProps {
+export interface IFilterToolbarProps {
   filterCategories: IFilterCategory[];
   filterValues: any[][]; // TODO type this...
   setFilterValues: (values: IFilterValues) => void;
 }
 
-const FilterControl: React.FunctionComponent<IFilterControlProps> = ({ category, value }) => {
-  const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
-  // @ts-ignore
-  const onFilterSelect = () => console.log('onFilterSelect', arguments);
-
-  // TODO split into sub components?
-
-  const [inputValue, setInputValue] = useState('');
-
-  const onInputSubmit = () => console.log('TODO');
-
-  // @ts-ignore
-  const onInputChange = () => console.log('onInputChange', arguments);
-
-  const onInputKeyDown = () => {
-    onInputSubmit();
-    // @ts-ignore
-    console.log('onInputKeyDown', arguments);
-  };
-
-  if (category.type === FilterType.select) {
-    return (
-      <Select
-        aria-label={category.title}
-        onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
-        onSelect={onFilterSelect} // TODO ???
-        selections={value}
-        isExpanded={isFilterDropdownOpen}
-        placeholderText="Any"
-      >
-        {category.selectOptions.map(optionProps => (
-          <SelectOption {...optionProps} />
-        ))}
-      </Select>
-    );
-  }
-  if (category.type === FilterType.search) {
-    const id = `${category.key}-input`;
-    return (
-      <InputGroup>
-        {/*
-          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
-        <TextInput
-          name={id}
-          id={id}
-          type="search"
-          aria-label={`${category.title} filter`}
-          onChange={onInputChange}
-          value={inputValue}
-          placeholder={category.placeholderText}
-          onKeyDown={onInputKeyDown}
-        />
-        <Button
-          variant={ButtonVariant.control}
-          aria-label="search button for search input"
-          onClick={onInputSubmit}
-        >
-          <SearchIcon />
-        </Button>
-      </InputGroup>
-    );
-  }
-  return null;
-};
-
-const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
+export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
   filterCategories,
   filterValues,
   setFilterValues,
@@ -127,7 +54,9 @@ const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
 
   const clearAllFilters = () => console.log('clearAllFilters!'); // TODO
   const onClearFilter = () => console.log('onClearFilter'); // TODO
-  const onFilterChange = () => console.log('onFilterChange'); // TODO
+
+  const setFilterValue = (category: IFilterCategory, newValue: FilterValue) =>
+    setFilterValues({ ...filterValues, [category.key]: newValue });
 
   const currentFilterCategory = filterCategories.find(
     category => category.key === currentCategoryKey
@@ -146,7 +75,6 @@ const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
               }
               isOpen={isCategoryDropdownOpen}
               dropdownItems={filterCategories.map(category => (
-                // TODO properties for row property name and title
                 <DropdownItem key={category.key} onClick={() => onCategorySelect(category)}>
                   {category.title}
                 </DropdownItem>
@@ -157,11 +85,15 @@ const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
             <DataToolbarFilter
               key={category.key}
               chips={filterValues[category.key]}
-              deleteChip={onClearFilter}
+              deleteChip={onClearFilter} // TODO is this one value or all of a category?
               categoryName={category.title}
               showToolbarItem={currentFilterCategory.key === category.key}
             >
-              <FilterControl category={category} value={filterValues[category.key]} />
+              <FilterControl
+                category={category}
+                value={filterValues[category.key]}
+                setValue={newValue => setFilterValue(category, newValue)}
+              />
             </DataToolbarFilter>
           ))}
         </DataToolbarToggleGroup>
@@ -169,5 +101,3 @@ const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
     </DataToolbar>
   );
 };
-
-export default FilterToolbar;

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -56,8 +56,6 @@ export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
     setIsCategoryDropdownOpen(false);
   };
 
-  const onClearFilter = (category, chip) => console.log('onClearFilter', { category, chip }); // TODO
-
   const setFilterValue = (category: IFilterCategory, newValue: FilterValue) =>
     setFilterValues({ ...filterValues, [category.key]: newValue });
 
@@ -85,19 +83,13 @@ export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
             />
           </DataToolbarItem>
           {filterCategories.map(category => (
-            <DataToolbarFilter
+            <FilterControl
               key={category.key}
-              chips={filterValues[category.key] || []}
-              deleteChip={onClearFilter} // TODO is this one value or all of a category?
-              categoryName={category.title}
+              category={category}
+              filterValue={filterValues[category.key]}
+              setFilterValue={newValue => setFilterValue(category, newValue)}
               showToolbarItem={currentFilterCategory.key === category.key}
-            >
-              <FilterControl
-                category={category}
-                filterValue={filterValues[category.key]}
-                setFilterValue={newValue => setFilterValue(category, newValue)}
-              />
-            </DataToolbarFilter>
+            />
           ))}
         </DataToolbarToggleGroup>
       </DataToolbarContent>

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -43,7 +43,7 @@ export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
   filterCategories,
   filterValues,
   setFilterValues,
-}) => {
+}: IFilterToolbarProps) => {
   const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
   const [currentCategoryKey, setCurrentCategoryKey] = useState(filterCategories[0].key);
 

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -91,8 +91,8 @@ export const FilterToolbar: React.FunctionComponent<IFilterToolbarProps> = ({
             >
               <FilterControl
                 category={category}
-                value={filterValues[category.key]}
-                setValue={newValue => setFilterValue(category, newValue)}
+                filterValue={filterValues[category.key]}
+                setFilterValue={newValue => setFilterValue(category, newValue)}
               />
             </DataToolbarFilter>
           ))}

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -27,6 +27,8 @@ const SearchFilterControl: React.FunctionComponent<ISearchFilterControlProps> = 
     setInputValue((filterValue && filterValue[0]) || '');
   }, [filterValue]);
 
+  const onFilterSubmit = () => setFilterValue(inputValue ? [inputValue] : []);
+
   const id = `${category.key}-input`;
   return (
     <DataToolbarFilter
@@ -48,13 +50,13 @@ const SearchFilterControl: React.FunctionComponent<ISearchFilterControlProps> = 
           placeholder={category.placeholderText}
           onKeyDown={(event: React.KeyboardEvent) => {
             if (event.key && event.key !== 'Enter') return;
-            setFilterValue([inputValue]);
+            onFilterSubmit();
           }}
         />
         <Button
           variant={ButtonVariant.control}
           aria-label="search button for search input"
-          onClick={() => setFilterValue([inputValue])}
+          onClick={onFilterSubmit}
         >
           <SearchIcon />
         </Button>

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -12,7 +12,7 @@ const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   const [inputValue, setInputValue] = useState((filterValue && filterValue[0]) || '');
   // Update it if it changes externally
   useEffect(() => {
-    setInputValue(filterValue);
+    setInputValue((filterValue && filterValue[0]) || '');
   }, [filterValue]);
 
   const id = `${category.key}-input`;
@@ -26,7 +26,7 @@ const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
         type="search"
         aria-label={`${category.title} filter`}
         onChange={setInputValue}
-        value={inputValue}
+        value={inputValue as string}
         placeholder={category.placeholderText}
         onKeyDown={(event: React.KeyboardEvent) => {
           if (event.key && event.key !== 'Enter') return;

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -1,40 +1,42 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { InputGroup, TextInput, Button, ButtonVariant } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { IFilterControlProps } from './FilterControl';
 
 const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   category,
-  value,
-  setValue,
+  filterValue,
+  setFilterValue,
 }: IFilterControlProps) => {
-  const [inputValue, setInputValue] = useState('');
-  const onInputSubmit = () => console.log('onInputSubmit');
-  const onInputChange = () => console.log('onInputChange');
-  const onInputKeyDown = () => {
-    onInputSubmit();
-    console.log('onInputKeyDown');
-  };
+  // Keep internal copy of value until submitted by user
+  const [inputValue, setInputValue] = useState(filterValue);
+  // Update it if it changes externally
+  useEffect(() => {
+    setInputValue(filterValue);
+  }, [filterValue]);
 
   const id = `${category.key}-input`;
   return (
     <InputGroup>
       {/*
-          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
+        // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
       <TextInput
         name={id}
         id={id}
         type="search"
         aria-label={`${category.title} filter`}
-        onChange={onInputChange}
+        onChange={setInputValue}
         value={inputValue}
         placeholder={category.placeholderText}
-        onKeyDown={onInputKeyDown}
+        onKeyDown={(event: React.KeyboardEvent) => {
+          if (event.key && event.key !== 'Enter') return;
+          setFilterValue(inputValue);
+        }}
       />
       <Button
         variant={ButtonVariant.control}
         aria-label="search button for search input"
-        onClick={onInputSubmit}
+        onClick={() => setFilterValue(inputValue)}
       >
         <SearchIcon />
       </Button>

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { InputGroup, TextInput, Button, ButtonVariant } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { IFilterControlProps } from './FilterControl';
+
+const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
+  category,
+  value,
+  setValue,
+}) => {
+  const [inputValue, setInputValue] = useState('');
+  const onInputSubmit = () => console.log('onInputSubmit');
+  const onInputChange = () => console.log('onInputChange');
+  const onInputKeyDown = () => {
+    onInputSubmit();
+    console.log('onInputKeyDown');
+  };
+
+  const id = `${category.key}-input`;
+  return (
+    <InputGroup>
+      {/*
+          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
+      <TextInput
+        name={id}
+        id={id}
+        type="search"
+        aria-label={`${category.title} filter`}
+        onChange={onInputChange}
+        value={inputValue}
+        placeholder={category.placeholderText}
+        onKeyDown={onInputKeyDown}
+      />
+      <Button
+        variant={ButtonVariant.control}
+        aria-label="search button for search input"
+        onClick={onInputSubmit}
+      >
+        <SearchIcon />
+      </Button>
+    </InputGroup>
+  );
+};
+
+export default SearchFilterControl;

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -7,7 +7,7 @@ const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   category,
   value,
   setValue,
-}) => {
+}: IFilterControlProps) => {
   const [inputValue, setInputValue] = useState('');
   const onInputSubmit = () => console.log('onInputSubmit');
   const onInputChange = () => console.log('onInputChange');

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -8,13 +8,18 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { IFilterControlProps } from './FilterControl';
+import { ISearchFilterCategory } from './FilterToolbar';
 
-const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
+export interface ISearchFilterControlProps extends IFilterControlProps {
+  category: ISearchFilterCategory;
+}
+
+const SearchFilterControl: React.FunctionComponent<ISearchFilterControlProps> = ({
   category,
   filterValue,
   setFilterValue,
   showToolbarItem,
-}: IFilterControlProps) => {
+}: ISearchFilterControlProps) => {
   // Keep internal copy of value until submitted by user
   const [inputValue, setInputValue] = useState((filterValue && filterValue[0]) || '');
   // Update it if it changes externally
@@ -32,7 +37,7 @@ const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
     >
       <InputGroup>
         {/*
-        // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
+          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
           name={id}
           id={id}

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -9,7 +9,7 @@ const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   setFilterValue,
 }: IFilterControlProps) => {
   // Keep internal copy of value until submitted by user
-  const [inputValue, setInputValue] = useState(filterValue);
+  const [inputValue, setInputValue] = useState((filterValue && filterValue[0]) || '');
   // Update it if it changes externally
   useEffect(() => {
     setInputValue(filterValue);
@@ -30,13 +30,13 @@ const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
         placeholder={category.placeholderText}
         onKeyDown={(event: React.KeyboardEvent) => {
           if (event.key && event.key !== 'Enter') return;
-          setFilterValue(inputValue);
+          setFilterValue([inputValue]);
         }}
       />
       <Button
         variant={ButtonVariant.control}
         aria-label="search button for search input"
-        onClick={() => setFilterValue(inputValue)}
+        onClick={() => setFilterValue([inputValue])}
       >
         <SearchIcon />
       </Button>

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -1,5 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { InputGroup, TextInput, Button, ButtonVariant } from '@patternfly/react-core';
+import {
+  DataToolbarFilter,
+  InputGroup,
+  TextInput,
+  Button,
+  ButtonVariant,
+} from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { IFilterControlProps } from './FilterControl';
 
@@ -7,6 +13,7 @@ const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   category,
   filterValue,
   setFilterValue,
+  showToolbarItem,
 }: IFilterControlProps) => {
   // Keep internal copy of value until submitted by user
   const [inputValue, setInputValue] = useState((filterValue && filterValue[0]) || '');
@@ -17,30 +24,37 @@ const SearchFilterControl: React.FunctionComponent<IFilterControlProps> = ({
 
   const id = `${category.key}-input`;
   return (
-    <InputGroup>
-      {/*
+    <DataToolbarFilter
+      chips={filterValue || []}
+      deleteChip={() => setFilterValue([])}
+      categoryName={category.title}
+      showToolbarItem={showToolbarItem}
+    >
+      <InputGroup>
+        {/*
         // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
-      <TextInput
-        name={id}
-        id={id}
-        type="search"
-        aria-label={`${category.title} filter`}
-        onChange={setInputValue}
-        value={inputValue as string}
-        placeholder={category.placeholderText}
-        onKeyDown={(event: React.KeyboardEvent) => {
-          if (event.key && event.key !== 'Enter') return;
-          setFilterValue([inputValue]);
-        }}
-      />
-      <Button
-        variant={ButtonVariant.control}
-        aria-label="search button for search input"
-        onClick={() => setFilterValue([inputValue])}
-      >
-        <SearchIcon />
-      </Button>
-    </InputGroup>
+        <TextInput
+          name={id}
+          id={id}
+          type="search"
+          aria-label={`${category.title} filter`}
+          onChange={setInputValue}
+          value={inputValue}
+          placeholder={category.placeholderText}
+          onKeyDown={(event: React.KeyboardEvent) => {
+            if (event.key && event.key !== 'Enter') return;
+            setFilterValue([inputValue]);
+          }}
+        />
+        <Button
+          variant={ButtonVariant.control}
+          aria-label="search button for search input"
+          onClick={() => setFilterValue([inputValue])}
+        >
+          <SearchIcon />
+        </Button>
+      </InputGroup>
+    </DataToolbarFilter>
   );
 };
 

--- a/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
@@ -6,7 +6,7 @@ const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   category,
   value,
   setValue,
-}) => {
+}: IFilterControlProps) => {
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
   const onFilterSelect = () => console.log('onFilterSelect');
 

--- a/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Select, SelectOption } from '@patternfly/react-core';
+import { Select, SelectOption, SelectOptionObject } from '@patternfly/react-core';
 import { IFilterControlProps } from './FilterControl';
 
 const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
@@ -8,14 +8,30 @@ const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   setFilterValue,
 }: IFilterControlProps) => {
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
-  const onFilterSelect = () => console.log('onFilterSelect');
+
+  const getOptionKeyFromOptionValue = (optionValue: string | SelectOptionObject) =>
+    category.selectOptions.find(optionProps => optionProps.value === optionValue).key;
+  const getOptionValueFromOptionKey = (optionKey: string) =>
+    category.selectOptions.find(optionProps => optionProps.key === optionKey).value;
+
+  const onFilterSelect = (event: React.SyntheticEvent, value: string | SelectOptionObject) => {
+    const optionKey = getOptionKeyFromOptionValue(value);
+    // Currently this implements single-select, multiple-select is also a design option.
+    // If we need multi-select filters in the future we can add that support here.
+    // https://www.patternfly.org/v4/design-guidelines/usage-and-behavior/filters#attribute-value-textbox-filters
+    setFilterValue([optionKey]);
+    setIsFilterDropdownOpen(false);
+  };
+
+  // Select expects "selections" to be an array of the "value" props from the relevant optionProps
+  const selections = filterValue ? filterValue.map(getOptionValueFromOptionKey) : null;
 
   return (
     <Select
       aria-label={category.title}
       onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
-      onSelect={onFilterSelect} // TODO ???
-      selections={filterValue}
+      selections={selections}
+      onSelect={onFilterSelect}
       isExpanded={isFilterDropdownOpen}
       placeholderText="Any"
     >

--- a/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
@@ -4,8 +4,8 @@ import { IFilterControlProps } from './FilterControl';
 
 const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   category,
-  value,
-  setValue,
+  filterValue,
+  setFilterValue,
 }: IFilterControlProps) => {
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
   const onFilterSelect = () => console.log('onFilterSelect');
@@ -15,7 +15,7 @@ const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
       aria-label={category.title}
       onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
       onSelect={onFilterSelect} // TODO ???
-      selections={value}
+      selections={filterValue}
       isExpanded={isFilterDropdownOpen}
       placeholderText="Any"
     >

--- a/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { Select, SelectOption } from '@patternfly/react-core';
+import { IFilterControlProps } from './FilterControl';
+
+const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
+  category,
+  value,
+  setValue,
+}) => {
+  const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
+  const onFilterSelect = () => console.log('onFilterSelect');
+
+  return (
+    <Select
+      aria-label={category.title}
+      onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
+      onSelect={onFilterSelect} // TODO ???
+      selections={value}
+      isExpanded={isFilterDropdownOpen}
+      placeholderText="Any"
+    >
+      {category.selectOptions.map(optionProps => (
+        <SelectOption {...optionProps} />
+      ))}
+    </Select>
+  );
+};
+
+export default SelectFilterControl;

--- a/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
@@ -1,20 +1,30 @@
 import React, { useState } from 'react';
-import { Select, SelectOption, SelectOptionObject } from '@patternfly/react-core';
+import {
+  DataToolbarFilter,
+  Select,
+  SelectOption,
+  SelectOptionObject,
+} from '@patternfly/react-core';
 import { IFilterControlProps } from './FilterControl';
 
 const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
   category,
   filterValue,
   setFilterValue,
+  showToolbarItem,
 }: IFilterControlProps) => {
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
 
   const getOptionKeyFromOptionValue = (optionValue: string | SelectOptionObject) =>
     category.selectOptions.find(optionProps => optionProps.value === optionValue).key;
+  const getChipFromOptionValue = (optionValue: string | SelectOptionObject) =>
+    optionValue.toString();
+  const getOptionKeyFromChip = (chip: string) =>
+    category.selectOptions.find(optionProps => optionProps.value.toString() === chip).key;
   const getOptionValueFromOptionKey = (optionKey: string) =>
     category.selectOptions.find(optionProps => optionProps.key === optionKey).value;
 
-  const onFilterSelect = (event: React.SyntheticEvent, value: string | SelectOptionObject) => {
+  const onFilterSelect = (value: string | SelectOptionObject) => {
     const optionKey = getOptionKeyFromOptionValue(value);
     // Currently this implements single-select, multiple-select is also a design option.
     // If we need multi-select filters in the future we can add that support here.
@@ -22,23 +32,36 @@ const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
     setFilterValue([optionKey]);
     setIsFilterDropdownOpen(false);
   };
+  const onFilterClear = (chip: string) => {
+    const optionKey = getOptionKeyFromChip(chip);
+    const newValue = filterValue ? filterValue.filter(val => val !== optionKey) : [];
+    setFilterValue(newValue.length > 0 ? newValue : null);
+  };
 
   // Select expects "selections" to be an array of the "value" props from the relevant optionProps
   const selections = filterValue ? filterValue.map(getOptionValueFromOptionKey) : null;
+  const chips = selections ? selections.map(getChipFromOptionValue) : [];
 
   return (
-    <Select
-      aria-label={category.title}
-      onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
-      selections={selections}
-      onSelect={onFilterSelect}
-      isExpanded={isFilterDropdownOpen}
-      placeholderText="Any"
+    <DataToolbarFilter
+      chips={chips}
+      deleteChip={(_, chip) => onFilterClear(chip as string)}
+      categoryName={category.title}
+      showToolbarItem={showToolbarItem}
     >
-      {category.selectOptions.map(optionProps => (
-        <SelectOption {...optionProps} />
-      ))}
-    </Select>
+      <Select
+        aria-label={category.title}
+        onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
+        selections={selections}
+        onSelect={(_, value) => onFilterSelect(value)}
+        isExpanded={isFilterDropdownOpen}
+        placeholderText="Any"
+      >
+        {category.selectOptions.map(optionProps => (
+          <SelectOption {...optionProps} />
+        ))}
+      </Select>
+    </DataToolbarFilter>
   );
 };
 

--- a/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
@@ -6,13 +6,18 @@ import {
   SelectOptionObject,
 } from '@patternfly/react-core';
 import { IFilterControlProps } from './FilterControl';
+import { ISelectFilterCategory } from './FilterToolbar';
 
-const SelectFilterControl: React.FunctionComponent<IFilterControlProps> = ({
+export interface ISelectFilterControlProps extends IFilterControlProps {
+  category: ISelectFilterCategory;
+}
+
+const SelectFilterControl: React.FunctionComponent<ISelectFilterControlProps> = ({
   category,
   filterValue,
   setFilterValue,
   showToolbarItem,
-}: IFilterControlProps) => {
+}: ISelectFilterControlProps) => {
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
 
   const getOptionKeyFromOptionValue = (optionValue: string | SelectOptionObject) =>

--- a/src/app/common/components/FilterToolbar/index.ts
+++ b/src/app/common/components/FilterToolbar/index.ts
@@ -1,2 +1,1 @@
 export * from './FilterToolbar';
-export * from './FilterControl';

--- a/src/app/common/components/FilterToolbar/index.ts
+++ b/src/app/common/components/FilterToolbar/index.ts
@@ -1,0 +1,2 @@
+export * from './FilterToolbar';
+export * from './FilterControl';

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -24,7 +24,7 @@ export const useSortState = (items: object[], sortKeys: string[]) => {
     setSortBy({ index, direction });
   };
 
-  const sortedItems = items.sort((a: object, b: object) => {
+  const sortedItems = [...items].sort((a: object, b: object) => {
     const { index, direction } = sortBy;
     const key = sortKeys[index];
     if (a[key] < b[key]) return direction === SortByDirection.asc ? -1 : 1;

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -1,5 +1,21 @@
 import { useState } from 'react';
 import { PaginationProps } from '@patternfly/react-core';
+import { IFilterValues } from '../components/FilterToolbar';
+
+export const useFilterState = (items: any[]) => {
+  const [filterValues, setFilterValues] = useState<IFilterValues>({});
+
+  const filteredItems = items.filter(item =>
+    Object.keys(filterValues).every(categoryKey => {
+      const values = filterValues[categoryKey];
+      if (!values || values.length === 0) return true;
+      const itemValue = item[categoryKey];
+      return values.every(filterValue => !itemValue || itemValue.indexOf(filterValue) !== -1);
+    })
+  );
+
+  return { filterValues, setFilterValues, filteredItems };
+};
 
 export const usePaginationState = (items: any[], initialItemsPerPage: number) => {
   const [currentPageNumber, setCurrentPageNumber] = useState(1);

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { PaginationProps } from '@patternfly/react-core';
 import { IFilterValues } from '../components/FilterToolbar';
+import { ISortBy, SortByDirection } from '@patternfly/react-table';
 
-export const useFilterState = (items: any[]) => {
+export const useFilterState = (items: object[]) => {
   const [filterValues, setFilterValues] = useState<IFilterValues>({});
 
   const filteredItems = items.filter(item =>
@@ -17,20 +18,37 @@ export const useFilterState = (items: any[]) => {
   return { filterValues, setFilterValues, filteredItems };
 };
 
+export const useSortState = (items: object[], sortKeys: string[]) => {
+  const [sortBy, setSortBy] = useState<ISortBy>({});
+  const onSort = (event: React.SyntheticEvent, index: number, direction: SortByDirection) => {
+    setSortBy({ index, direction });
+  };
+
+  const sortedItems = items.sort((a: object, b: object) => {
+    const { index, direction } = sortBy;
+    const key = sortKeys[index];
+    if (a[key] < b[key]) return direction === SortByDirection.asc ? -1 : 1;
+    if (a[key] > b[key]) return direction === SortByDirection.asc ? 1 : -1;
+    return 0;
+  });
+
+  return { sortBy, onSort, sortedItems };
+};
+
 export const usePaginationState = (items: any[], initialItemsPerPage: number) => {
-  const [currentPageNumber, setCurrentPageNumber] = useState(1);
+  const [pageNumber, setPageNumber] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(initialItemsPerPage);
 
-  const pageStartIndex = (currentPageNumber - 1) * itemsPerPage;
+  const pageStartIndex = (pageNumber - 1) * itemsPerPage;
   const currentPageItems = items.slice(pageStartIndex, pageStartIndex + itemsPerPage);
 
   const paginationProps: PaginationProps = {
     itemCount: items.length,
     perPage: itemsPerPage,
-    page: currentPageNumber,
-    onSetPage: (event, pageNumber) => setCurrentPageNumber(pageNumber),
+    page: pageNumber,
+    onSetPage: (event, pageNumber) => setPageNumber(pageNumber),
     onPerPageSelect: (event, perPage) => setItemsPerPage(perPage),
   };
 
-  return { currentPageItems, paginationProps };
+  return { currentPageItems, setPageNumber, paginationProps };
 };

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -3,7 +3,7 @@ import { PaginationProps } from '@patternfly/react-core';
 import { IFilterValues } from '../components/FilterToolbar';
 import { ISortBy, SortByDirection } from '@patternfly/react-table';
 
-export const useFilterState = (items: object[]) => {
+export const useFilterState = (items: any[]) => {
   const [filterValues, setFilterValues] = useState<IFilterValues>({});
 
   const filteredItems = items.filter(item =>
@@ -18,13 +18,13 @@ export const useFilterState = (items: object[]) => {
   return { filterValues, setFilterValues, filteredItems };
 };
 
-export const useSortState = (items: object[], sortKeys: string[]) => {
+export const useSortState = (items: any[], sortKeys: string[]) => {
   const [sortBy, setSortBy] = useState<ISortBy>({});
   const onSort = (event: React.SyntheticEvent, index: number, direction: SortByDirection) => {
     setSortBy({ index, direction });
   };
 
-  const sortedItems = [...items].sort((a: object, b: object) => {
+  const sortedItems = [...items].sort((a: any, b: any) => {
     const { index, direction } = sortBy;
     const key = sortKeys[index];
     if (a[key] < b[key]) return direction === SortByDirection.asc ? -1 : 1;

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -51,7 +51,7 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
   const { filterValues, setFilterValues, filteredItems } = useFilterState(sourceClusterNamespaces);
   const { sortBy, onSort, sortedItems } = useSortState(filteredItems, sortKeys);
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
-  useEffect(() => setPageNumber(1), [sortBy]);
+  useEffect(() => setPageNumber(1), [filterValues, sortBy]);
 
   const rows = currentPageItems.map(namespace => ({
     cells: [namespace.name, namespace.podCount, namespace.pvcCount, namespace.serviceCount],

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../../common/components/FilterToolbar';
 
 interface INamespaceTableProps
-  extends Pick<IOtherProps, 'isEdit' | 'sourceClusterNamespaces'>,
+  extends Pick<IOtherProps, 'sourceClusterNamespaces'>,
     Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
 
 const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
@@ -67,7 +67,7 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
     let newSelected;
     if (rowIndex === -1) {
       if (isSelected) {
-        newSelected = sourceClusterNamespaces.map(namespace => namespace.name); // Select all
+        newSelected = filteredItems.map(namespace => namespace.name); // Select all (filtered)
       } else {
         newSelected = []; // Deselect all
       }

--- a/src/app/plan/components/Wizard/ResourceSelectForm.tsx
+++ b/src/app/plan/components/Wizard/ResourceSelectForm.tsx
@@ -16,23 +16,17 @@ import SimpleSelect from '../../../common/components/SimpleSelect';
 
 interface IResourceSelectFormProps
   extends Pick<
-    IOtherProps,
-    | 'clusterList'
-    | 'fetchNamespacesRequest'
-    | 'isEdit'
-    | 'isFetchingNamespaceList'
-    | 'sourceClusterNamespaces'
-    | 'storageList'
+      IOtherProps,
+      | 'clusterList'
+      | 'fetchNamespacesRequest'
+      | 'isEdit'
+      | 'isFetchingNamespaceList'
+      | 'sourceClusterNamespaces'
+      | 'storageList'
     >,
-    Pick<FormikProps<IFormValues>, 
-    | 'setFieldTouched'
-    | 'setFieldValue' 
-    | 'touched'
-    | 'values'
-    > 
-    {
-      errors: any;
-    }
+    Pick<FormikProps<IFormValues>, 'setFieldTouched' | 'setFieldValue' | 'touched' | 'values'> {
+  errors: any;
+}
 
 const ResourceSelectForm: React.FunctionComponent<IResourceSelectFormProps> = ({
   clusterList,
@@ -59,18 +53,26 @@ const ResourceSelectForm: React.FunctionComponent<IResourceSelectFormProps> = ({
 
   if (clusterList.length) {
     srcClusterOptions = clusterList
-      .filter(cluster => cluster.MigCluster.metadata.name !== values.targetCluster && cluster.ClusterStatus.hasReadyCondition)
-      .map(cluster => cluster.MigCluster.metadata.name)
+      .filter(
+        cluster =>
+          cluster.MigCluster.metadata.name !== values.targetCluster &&
+          cluster.ClusterStatus.hasReadyCondition
+      )
+      .map(cluster => cluster.MigCluster.metadata.name);
 
     targetClusterOptions = clusterList
-      .filter(cluster => cluster.MigCluster.metadata.name !== values.sourceCluster && cluster.ClusterStatus.hasReadyCondition)
-      .map(cluster => cluster.MigCluster.metadata.name)
+      .filter(
+        cluster =>
+          cluster.MigCluster.metadata.name !== values.sourceCluster &&
+          cluster.ClusterStatus.hasReadyCondition
+      )
+      .map(cluster => cluster.MigCluster.metadata.name);
   }
 
   if (storageList.length) {
     storageOptions = storageList
       .filter(storage => storage.StorageStatus.hasReadyCondition)
-      .map(storage => storage.MigStorage.metadata.name)
+      .map(storage => storage.MigStorage.metadata.name);
   }
 
   const handleStorageChange = value => {
@@ -178,7 +180,6 @@ const ResourceSelectForm: React.FunctionComponent<IResourceSelectFormProps> = ({
           setFieldValue={setFieldValue}
           values={values}
           sourceClusterNamespaces={sourceClusterNamespaces}
-          isEdit={isEdit}
         />
       )}
     </Grid>

--- a/src/app/plan/components/Wizard/VolumesForm.tsx
+++ b/src/app/plan/components/Wizard/VolumesForm.tsx
@@ -12,6 +12,7 @@ import {
   Alert,
 } from '@patternfly/react-core';
 import StatusIcon from '../../../common/components/StatusIcon';
+import { IPlanPersistentVolume } from './types';
 
 const styles = require('./VolumesTable.module');
 
@@ -146,17 +147,22 @@ const VolumesForm: React.FunctionComponent<IVolumesFormProps> = ({
     );
   }
 
-  const updatePersistentVolumes = (pvIndex: number, newValues: { type: string }) => {
+  const updatePersistentVolumes = (
+    currentPV: IPlanPersistentVolume,
+    newValues: { type: string }
+  ) => {
     if (currentPlan !== null && values.persistentVolumes) {
       const newPVs = [...values.persistentVolumes];
-      newPVs[pvIndex] = { ...newPVs[pvIndex], ...newValues };
+      const matchingPV = values.persistentVolumes.find(pv => pv === currentPV);
+      const pvIndex = values.persistentVolumes.indexOf(matchingPV);
+      newPVs[pvIndex] = { ...matchingPV, ...newValues };
       // TODO this should only store selections, we should inherit the rest from currentPlan.spec.persistentVolumes
       setFieldValue('persistentVolumes', newPVs);
     }
   };
 
-  const onTypeChange = (pvIndex: number, value: string) =>
-    updatePersistentVolumes(pvIndex, { type: value });
+  const onTypeChange = (currentPV: IPlanPersistentVolume, value: string) =>
+    updatePersistentVolumes(currentPV, { type: value });
 
   return (
     <VolumesTable

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -70,7 +70,54 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     { title: 'Details' },
   ];
 
-  const rows = persistentVolumes.map((pv, pvIndex) => {
+  const filterCategories: FilterCategory[] = [
+    {
+      key: 'name',
+      title: 'PV name',
+      type: FilterType.search,
+      placeholderText: 'Filter by PV name...',
+    },
+    {
+      key: 'claim',
+      title: 'Claim',
+      type: FilterType.search,
+      placeholderText: 'Filter by claim...',
+    },
+    {
+      key: 'project',
+      title: 'Namespace',
+      type: FilterType.search,
+      placeholderText: 'Filter by namespace...',
+    },
+    {
+      key: 'storageClass',
+      title: 'Storage class',
+      type: FilterType.search,
+      placeholderText: 'Filter by storage class...',
+    },
+    {
+      key: 'type',
+      title: 'Migration type',
+      type: FilterType.select,
+      selectOptions: [
+        { key: 'copy', value: 'Copy' },
+        { key: 'move', value: 'Move' },
+      ],
+    },
+  ];
+
+  const [filterValues, setFilterValues] = useState<IFilterValues>({});
+
+  const filteredPersistentVolumes = persistentVolumes.filter(rowObject =>
+    Object.keys(filterValues).every(categoryKey => {
+      const values = filterValues[categoryKey];
+      if (!values || values.length === 0) return true;
+      const rowValue = rowObject[categoryKey];
+      return values.every(filterValue => !rowValue || rowValue.indexOf(filterValue) !== -1);
+    })
+  );
+
+  const rows = filteredPersistentVolumes.map((pv, pvIndex) => {
     const matchingPVResource = pvResourceList.find(pvResource => pvResource.name === pv.name);
     const migrationTypeOptions = pv.supportedActions.map(
       (action: string) =>
@@ -129,44 +176,6 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
       ],
     };
   });
-
-  const filterCategories: FilterCategory[] = [
-    {
-      key: 'name',
-      title: 'PV name',
-      type: FilterType.search,
-      placeholderText: 'Filter by PV name...',
-    },
-    {
-      key: 'claim',
-      title: 'Claim',
-      type: FilterType.search,
-      placeholderText: 'Filter by claim...',
-    },
-    {
-      key: 'namespace',
-      title: 'Namespace',
-      type: FilterType.search,
-      placeholderText: 'Filter by namespace...',
-    },
-    {
-      key: 'storageClass',
-      title: 'Storage class',
-      type: FilterType.search,
-      placeholderText: 'Filter by storage class...',
-    },
-    {
-      key: 'type',
-      title: 'Migration type',
-      type: FilterType.select,
-      selectOptions: [
-        { key: 'copy', value: 'Copy' },
-        { key: 'move', value: 'Move' },
-      ],
-    },
-  ];
-
-  const [filterValues, setFilterValues] = useState<IFilterValues>({});
 
   const { currentPageItems, paginationProps } = usePaginationState(rows, 10);
 

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -18,22 +18,7 @@ import {
   SelectOptionObject,
   Level,
   LevelItem,
-  DataToolbar,
-  DataToolbarContent,
-  DataToolbarToggleGroup,
-  DataToolbarItem,
-  DataToolbarFilter,
-  Dropdown,
-  DropdownToggle,
-  DropdownItem,
-  InputGroup,
-  Select,
-  SelectOption,
-  SelectOptionProps,
-  TextInput,
-  ButtonVariant,
 } from '@patternfly/react-core';
-import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import { Table, TableVariant, TableHeader, TableBody } from '@patternfly/react-table';
 import ReactJson from 'react-json-view';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
@@ -41,6 +26,10 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import SimpleSelect from '../../../common/components/SimpleSelect';
 import { usePaginationState } from '../../../common/duck/hooks';
 import { IFormValues, IOtherProps } from './WizardContainer';
+import FilterToolbar, {
+  IFilterCategory,
+  FilterType,
+} from '../../../common/components/FilterToolbar';
 
 const styles = require('./VolumesTable.module');
 
@@ -140,24 +129,6 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
 
   ////////////////////////////////////////////////////////////////////////////////
 
-  enum FilterType {
-    select = 'select',
-    search = 'search',
-  }
-
-  interface IFilterCategory {
-    key: string;
-    title: string;
-    type: FilterType;
-    selectOptions?: SelectOptionProps[]; // TODO only if select type?
-    placeholderText?: string; // TODO only if select type?
-  }
-
-  interface IFilterControlProps {
-    category: IFilterCategory;
-    value: any; // TODO type this... SelectProps.selections? string? array?
-  }
-
   const filterCategories: IFilterCategory[] = [
     {
       key: 'one',
@@ -188,129 +159,13 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
       placeholderText: 'Filter by three...',
     },
   ];
-  const [currentCategoryKey, setCurrentCategoryKey] = useState(filterCategories[0].key);
-  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
+
   const [filterValues, setFilterValues] = useState([]);
-
-  const onCategorySelect = category => {
-    setCurrentCategoryKey(category.key);
-    setIsCategoryDropdownOpen(false);
-  };
-
-  const clearAllFilters = () => console.log('clearAllFilters!'); // TODO
-  const onClearFilter = () => console.log('onClearFilter'); // TODO
-  const onFilterChange = () => console.log('onFilterChange'); // TODO
-
-  const currentFilterCategory = filterCategories.find(
-    category => category.key === currentCategoryKey
-  );
-
-  const FilterControl: React.FunctionComponent<IFilterControlProps> = ({ category, value }) => {
-    const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
-    // @ts-ignore
-    const onFilterSelect = () => console.log('onFilterSelect', arguments);
-
-    // TODO split into sub components?
-
-    const [inputValue, setInputValue] = useState('');
-
-    const onInputSubmit = () => console.log('TODO');
-
-    // @ts-ignore
-    const onInputChange = () => console.log('onInputChange', arguments);
-
-    const onInputKeyDown = () => {
-      onInputSubmit();
-      // @ts-ignore
-      console.log('onInputKeyDown', arguments);
-    };
-
-    if (category.type === FilterType.select) {
-      return (
-        <Select
-          aria-label={category.title}
-          onToggle={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
-          onSelect={onFilterSelect} // TODO ???
-          selections={value}
-          isExpanded={isFilterDropdownOpen}
-          placeholderText="Any"
-        >
-          {category.selectOptions.map(optionProps => (
-            <SelectOption {...optionProps} />
-          ))}
-        </Select>
-      );
-    }
-    if (category.type === FilterType.search) {
-      const id = `${category.key}-input`;
-      return (
-        <InputGroup>
-          {/*
-            // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
-          <TextInput
-            name={id}
-            id={id}
-            type="search"
-            aria-label={`${category.title} filter`}
-            onChange={onInputChange}
-            value={inputValue}
-            placeholder={category.placeholderText}
-            onKeyDown={onInputKeyDown}
-          />
-          <Button
-            variant={ButtonVariant.control}
-            aria-label="search button for search input"
-            onClick={onInputSubmit}
-          >
-            <SearchIcon />
-          </Button>
-        </InputGroup>
-      );
-    }
-    return null;
-  };
-
-  const filterToolbar = (
-    <DataToolbar id="pv-table-filter-toolbar" clearAllFilters={clearAllFilters}>
-      <DataToolbarContent>
-        <DataToolbarToggleGroup variant="filter-group" toggleIcon={<FilterIcon />} breakpoint="xl">
-          <DataToolbarItem>
-            <Dropdown
-              toggle={
-                <DropdownToggle onToggle={() => setIsCategoryDropdownOpen(!isCategoryDropdownOpen)}>
-                  <FilterIcon /> {currentFilterCategory.title}
-                </DropdownToggle>
-              }
-              isOpen={isCategoryDropdownOpen}
-              dropdownItems={filterCategories.map(category => (
-                // TODO properties for row property name and title
-                <DropdownItem key={category.key} onClick={() => onCategorySelect(category)}>
-                  {category.title}
-                </DropdownItem>
-              ))}
-            />
-          </DataToolbarItem>
-          {filterCategories.map(category => (
-            <DataToolbarFilter
-              key={category.key}
-              chips={filterValues[category.key]}
-              deleteChip={onClearFilter}
-              categoryName={category.title}
-              showToolbarItem={currentFilterCategory.key === category.key}
-            >
-              <FilterControl category={category} value={filterValues[category.key]} />
-            </DataToolbarFilter>
-          ))}
-        </DataToolbarToggleGroup>
-      </DataToolbarContent>
-    </DataToolbar>
-  );
-
-  const { currentPageItems, paginationProps } = usePaginationState(rows, 10);
 
   ////////////////////////////////////////////////////////////////////////////////
 
-  // TODO: filters
+  const { currentPageItems, paginationProps } = usePaginationState(rows, 10);
+
   // TODO: sorting
 
   return (
@@ -322,7 +177,13 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
       </GridItem>
       <GridItem>
         <Level>
-          <LevelItem>{filterToolbar}</LevelItem>
+          <LevelItem>
+            <FilterToolbar
+              filterCategories={filterCategories}
+              filterValues={filterValues}
+              setFilterValues={setFilterValues}
+            />
+          </LevelItem>
           <LevelItem>
             <Pagination widgetId="pv-table-pagination-top" {...paginationProps} />
           </LevelItem>

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -28,7 +28,7 @@ import { usePaginationState } from '../../../common/duck/hooks';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import {
   FilterToolbar,
-  IFilterCategory,
+  FilterCategory,
   FilterType,
   IFilterValues,
 } from '../../../common/components/FilterToolbar';
@@ -131,7 +131,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
 
   ////////////////////////////////////////////////////////////////////////////////
 
-  const filterCategories: IFilterCategory[] = [
+  const filterCategories: FilterCategory[] = [
     {
       key: 'one',
       title: 'One',

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import {
   TextContent,
   Text,
@@ -19,20 +19,12 @@ import {
   Level,
   LevelItem,
 } from '@patternfly/react-core';
-import {
-  Table,
-  TableVariant,
-  TableHeader,
-  TableBody,
-  sortable,
-  SortByDirection,
-  ISortBy,
-} from '@patternfly/react-table';
+import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
 import ReactJson from 'react-json-view';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import SimpleSelect from '../../../common/components/SimpleSelect';
-import { useFilterState, usePaginationState } from '../../../common/duck/hooks';
+import { useFilterState, useSortState, usePaginationState } from '../../../common/duck/hooks';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import {
   FilterToolbar,
@@ -76,6 +68,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     { title: 'Migration type', transforms: [sortable] },
     { title: 'Details' },
   ];
+  const sortKeys = ['name', 'claim', 'project', 'storageClass', 'size', 'type'];
   const filterCategories: FilterCategory[] = [
     {
       key: 'name',
@@ -111,22 +104,11 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
       ],
     },
   ];
-  const sortKeys = ['name', 'claim', 'project', 'storageClass', 'size', 'type'];
 
   const { filterValues, setFilterValues, filteredItems } = useFilterState(persistentVolumes);
-
-  const [sortBy, setSortBy] = useState<ISortBy>({});
-  const onSort = (event: React.SyntheticEvent, index: number, direction: SortByDirection) =>
-    setSortBy({ index, direction });
-  const sortedItems = filteredItems.sort((a, b) => {
-    const { index, direction } = sortBy;
-    const key = sortKeys[index];
-    if (a[key] < b[key]) return direction === SortByDirection.asc ? -1 : 1;
-    if (a[key] > b[key]) return direction === SortByDirection.asc ? 1 : -1;
-    return 0;
-  });
-
-  const { currentPageItems, paginationProps } = usePaginationState(sortedItems, 10);
+  const { sortBy, onSort, sortedItems } = useSortState(filteredItems, sortKeys);
+  const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
+  useEffect(() => setPageNumber(1), [sortBy]);
 
   const rows = currentPageItems.map(pv => {
     const matchingPVResource = pvResourceList.find(pvResource => pvResource.name === pv.name);

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -30,6 +30,7 @@ import {
   FilterToolbar,
   IFilterCategory,
   FilterType,
+  IFilterValues,
 } from '../../../common/components/FilterToolbar';
 
 const styles = require('./VolumesTable.module');
@@ -161,7 +162,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     },
   ];
 
-  const [filterValues, setFilterValues] = useState({});
+  const [filterValues, setFilterValues] = useState<IFilterValues>({});
 
   ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -26,7 +26,8 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import SimpleSelect from '../../../common/components/SimpleSelect';
 import { usePaginationState } from '../../../common/duck/hooks';
 import { IFormValues, IOtherProps } from './WizardContainer';
-import FilterToolbar, {
+import {
+  FilterToolbar,
   IFilterCategory,
   FilterType,
 } from '../../../common/components/FilterToolbar';

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -16,7 +16,19 @@ import {
   Pagination,
   PaginationVariant,
   SelectOptionObject,
+  Level,
+  LevelItem,
+  DataToolbar,
+  DataToolbarContent,
+  DataToolbarToggleGroup,
+  DataToolbarItem,
+  DataToolbarFilter,
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  InputGroup,
 } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
 import { Table, TableVariant, TableHeader, TableBody } from '@patternfly/react-table';
 import ReactJson from 'react-json-view';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
@@ -121,7 +133,67 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     };
   });
 
+  const [isCategoryDropdownOpen] = useState(false);
+  const clearAllFilters = () => console.log('clearAllFilters!');
+  const onCategorySelect = () => console.log('onCategorySelect!');
+  const onCategoryToggle = () => console.log('onCategoryToggle!');
+  const onClearFilter = () => console.log('onClearFilter');
+  const filterCategories = [
+    {
+      key: 'one',
+      title: 'One',
+    },
+    {
+      key: 'two',
+      title: 'Two',
+    },
+    {
+      key: 'three',
+      title: 'Three',
+    },
+  ];
+  const currentFilterCategory = filterCategories[0];
+  const filterChips = [];
+
+  const filterToolbar = (
+    <DataToolbar id="pv-table-filter-toolbar" clearAllFilters={clearAllFilters}>
+      <DataToolbarContent>
+        <DataToolbarToggleGroup variant="filter-group" toggleIcon={<FilterIcon />} breakpoint="xl">
+          <DataToolbarItem>
+            <Dropdown // TODO use SimpleSelect instead? change it so it can use children?
+              onSelect={onCategorySelect}
+              toggle={
+                <DropdownToggle onToggle={onCategoryToggle}>
+                  <FilterIcon /> {currentFilterCategory.title}
+                </DropdownToggle>
+              }
+              isOpen={isCategoryDropdownOpen}
+              dropdownItems={filterCategories.map(category => (
+                // TODO properties for row property name and title
+                <DropdownItem key={category.key}>{category.title}</DropdownItem>
+              ))}
+            />
+          </DataToolbarItem>
+          {filterCategories.map(category => (
+            <DataToolbarFilter
+              key={category.key}
+              chips={filterChips[category.key]}
+              deleteChip={onClearFilter}
+              categoryName={category.title}
+              showToolbarItem={currentFilterCategory.key === category.key}
+            >
+              <InputGroup>TODO</InputGroup>
+            </DataToolbarFilter>
+          ))}
+        </DataToolbarToggleGroup>
+      </DataToolbarContent>
+    </DataToolbar>
+  );
+
   const { currentPageItems, paginationProps } = usePaginationState(rows, 10);
+
+  // TODO: filters
+  // TODO: sorting
 
   return (
     <Grid gutter="md">
@@ -131,7 +203,12 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
         </TextContent>
       </GridItem>
       <GridItem>
-        <Pagination widgetId="pv-table-pagination-top" {...paginationProps} />
+        <Level>
+          <LevelItem>{filterToolbar}</LevelItem>
+          <LevelItem>
+            <Pagination widgetId="pv-table-pagination-top" {...paginationProps} />
+          </LevelItem>
+        </Level>
         <Table
           aria-label="Persistent volumes table"
           variant={TableVariant.compact}

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -31,6 +31,7 @@ import {
   FilterCategory,
   FilterType,
   IFilterValues,
+  OptionPropsWithKey,
 } from '../../../common/components/FilterToolbar';
 
 const styles = require('./VolumesTable.module');
@@ -129,42 +130,43 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     };
   });
 
-  ////////////////////////////////////////////////////////////////////////////////
-
   const filterCategories: FilterCategory[] = [
     {
-      key: 'one',
-      title: 'One',
+      key: 'name',
+      title: 'PV name',
+      type: FilterType.search,
+      placeholderText: 'Filter by PV name...',
+    },
+    {
+      key: 'claim',
+      title: 'Claim',
+      type: FilterType.search,
+      placeholderText: 'Filter by claim...',
+    },
+    {
+      key: 'namespace',
+      title: 'Namespace',
+      type: FilterType.search,
+      placeholderText: 'Filter by namespace...',
+    },
+    {
+      key: 'storageClass',
+      title: 'Storage class',
+      type: FilterType.search,
+      placeholderText: 'Filter by storage class...',
+    },
+    {
+      key: 'type',
+      title: 'Migration type',
       type: FilterType.select,
       selectOptions: [
-        // TODO generate from data with helper
-        {
-          key: 'a',
-          value: 'A',
-        },
-        {
-          key: 'b',
-          value: 'B',
-        },
+        { key: 'copy', value: 'Copy' },
+        { key: 'move', value: 'Move' },
       ],
-    },
-    {
-      key: 'two',
-      title: 'Two',
-      type: FilterType.search,
-      placeholderText: 'Filter by two...',
-    },
-    {
-      key: 'three',
-      title: 'Three',
-      type: FilterType.search,
-      placeholderText: 'Filter by three...',
     },
   ];
 
   const [filterValues, setFilterValues] = useState<IFilterValues>({});
-
-  ////////////////////////////////////////////////////////////////////////////////
 
   const { currentPageItems, paginationProps } = usePaginationState(rows, 10);
 

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -158,19 +158,6 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     value: any; // TODO type this... SelectProps.selections? string? array?
   }
 
-  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
-  const [currentCategoryIndex, setCurrentCategoryIndex] = useState(0);
-  const [filterValues, setFilterValues] = useState([]);
-
-  // @ts-ignore
-  const clearAllFilters = () => console.log('clearAllFilters!', arguments);
-  // @ts-ignore
-  const onCategorySelect = () => console.log('onCategorySelect!', arguments);
-  // @ts-ignore
-  const onClearFilter = () => console.log('onClearFilter', arguments);
-
-  const onFilterChange = () => console.log('TODO');
-
   const filterCategories: IFilterCategory[] = [
     {
       key: 'one',
@@ -187,20 +174,36 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
           value: 'B',
         },
       ],
-      placeholderText: 'Filter by one...',
     },
     {
       key: 'two',
       title: 'Two',
       type: FilterType.search,
+      placeholderText: 'Filter by two...',
     },
     {
       key: 'three',
       title: 'Three',
       type: FilterType.search,
+      placeholderText: 'Filter by three...',
     },
   ];
-  const currentFilterCategory = filterCategories[currentCategoryIndex];
+  const [currentCategoryKey, setCurrentCategoryKey] = useState(filterCategories[0].key);
+  const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = useState(false);
+  const [filterValues, setFilterValues] = useState([]);
+
+  const onCategorySelect = category => {
+    setCurrentCategoryKey(category.key);
+    setIsCategoryDropdownOpen(false);
+  };
+
+  const clearAllFilters = () => console.log('clearAllFilters!'); // TODO
+  const onClearFilter = () => console.log('onClearFilter'); // TODO
+  const onFilterChange = () => console.log('onFilterChange'); // TODO
+
+  const currentFilterCategory = filterCategories.find(
+    category => category.key === currentCategoryKey
+  );
 
   const FilterControl: React.FunctionComponent<IFilterControlProps> = ({ category, value }) => {
     const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
@@ -273,7 +276,6 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
         <DataToolbarToggleGroup variant="filter-group" toggleIcon={<FilterIcon />} breakpoint="xl">
           <DataToolbarItem>
             <Dropdown
-              onSelect={onCategorySelect}
               toggle={
                 <DropdownToggle onToggle={() => setIsCategoryDropdownOpen(!isCategoryDropdownOpen)}>
                   <FilterIcon /> {currentFilterCategory.title}
@@ -282,7 +284,9 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
               isOpen={isCategoryDropdownOpen}
               dropdownItems={filterCategories.map(category => (
                 // TODO properties for row property name and title
-                <DropdownItem key={category.key}>{category.title}</DropdownItem>
+                <DropdownItem key={category.key} onClick={() => onCategorySelect(category)}>
+                  {category.title}
+                </DropdownItem>
               ))}
             />
           </DataToolbarItem>

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -108,7 +108,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
   const { filterValues, setFilterValues, filteredItems } = useFilterState(persistentVolumes);
   const { sortBy, onSort, sortedItems } = useSortState(filteredItems, sortKeys);
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
-  useEffect(() => setPageNumber(1), [sortBy]);
+  useEffect(() => setPageNumber(1), [filterValues, sortBy]);
 
   const rows = currentPageItems.map(pv => {
     const matchingPVResource = pvResourceList.find(pvResource => pvResource.name === pv.name);

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -161,7 +161,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     },
   ];
 
-  const [filterValues, setFilterValues] = useState([]);
+  const [filterValues, setFilterValues] = useState({});
 
   ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   TextContent,
   Text,
@@ -59,16 +59,6 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
   persistentVolumes,
   onTypeChange,
 }: IVolumesTableProps) => {
-  const columns = [
-    { title: 'PV name' },
-    { title: 'Claim' },
-    { title: 'Namespace' },
-    { title: 'Storage class' },
-    { title: 'Size' },
-    { title: 'Migration type' },
-    { title: 'Details' },
-  ];
-
   const filterCategories: FilterCategory[] = [
     {
       key: 'name',
@@ -104,9 +94,18 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
       ],
     },
   ];
-
   const { filterValues, setFilterValues, filteredItems } = useFilterState(persistentVolumes);
   const { currentPageItems, paginationProps } = usePaginationState(filteredItems, 10);
+
+  const columns = [
+    { title: 'PV name' },
+    { title: 'Claim' },
+    { title: 'Namespace' },
+    { title: 'Storage class' },
+    { title: 'Size' },
+    { title: 'Migration type' },
+    { title: 'Details' },
+  ];
 
   const rows = currentPageItems.map(pv => {
     const matchingPVResource = pvResourceList.find(pvResource => pvResource.name === pv.name);

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -1,4 +1,4 @@
-import { withFormik, FormikProps } from 'formik';
+import { withFormik } from 'formik';
 import WizardComponent from './WizardComponent';
 import { PlanActions } from '../../duck/actions';
 import planSelectors from '../../duck/selectors';
@@ -11,7 +11,7 @@ export interface IFormValues {
   sourceCluster: string;
   targetCluster: string;
   selectedStorage: string;
-  selectedNamespaces: any[];
+  selectedNamespaces: string[];
   persistentVolumes: any[]; // TODO replace this with selections-only version after refactor
   pvStorageClassAssignment: any; 
 }


### PR DESCRIPTION
Closes #794.

This PR adds filtering and sorting controls to the tables in steps 2 and 3 of the plan wizard.

I'm adding a new common component `FilterToolbar` based on the usage example of `DataToolbar` here: https://www.patternfly.org/v4/documentation/react/demos/filtertabledemo . That demo involves a ton of boilerplate, is written as a class component, and is very coupled to the specific filter categories in the demo. Since we already need this in two tables and it's not terribly complex to abstract out, I rewrote the demo with hooks as `FilterToolbar`, which can be used for arbitrary filter categories. I'm planning to contribute it back to PatternFly eventually if possible.

I also added two new common hooks, `useFilterState` and `useSortState`, to make it easier to manage the state for these things. I chain them together with `usePaginationState` so each table's items are first filtered, then sorted, then paginated, before being mapped into row objects and passed into `<Table>`. I have a small `useEffect` line after this chain which makes sure the pagination will reset to page 1 when the sort or filters change.

Reusing this stuff to add sorting/filtering to any tables in the future should be easy peasy.

# Before
<img width="1068" alt="Screenshot 2020-04-13 01 17 51" src="https://user-images.githubusercontent.com/811963/79094227-dbe90e80-7d24-11ea-9c28-06064aa1d431.png">
<img width="1074" alt="Screenshot 2020-04-13 01 18 12" src="https://user-images.githubusercontent.com/811963/79094230-ddb2d200-7d24-11ea-82df-0402fea65fee.png">


# After
<img width="1072" alt="Screenshot 2020-04-13 01 14 58" src="https://user-images.githubusercontent.com/811963/79094242-e2778600-7d24-11ea-98f1-373e855fe3ff.png">
<img width="1075" alt="Screenshot 2020-04-13 01 15 33" src="https://user-images.githubusercontent.com/811963/79094246-e60b0d00-7d24-11ea-9dba-bf17ac8ddbca.png">

With a sort and a filter applied:
<img width="1070" alt="Screenshot 2020-04-13 01 16 20" src="https://user-images.githubusercontent.com/811963/79094250-e86d6700-7d24-11ea-9a18-0ca1c556adfc.png">
