### PR TITLE
Convert Storage class table (now Copy options) to PF, add claims and namespaces columns, other UX fixes

### DIFF
--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -28,6 +28,7 @@ export interface IBasicFilterCategory {
   key: string;
   title: string;
   type: FilterType; // If we want to support arbitrary filter types, this could be a React node that consumes context instead of an enum
+  getItemValue?: (item: any) => any;
 }
 
 export interface ISelectFilterCategory extends IBasicFilterCategory {

--- a/src/app/common/components/TableEmptyState.tsx
+++ b/src/app/common/components/TableEmptyState.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  Flex,
+  FlexItem,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateIconProps,
+  Title,
+  EmptyStateBody,
+  Button,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
+
+export interface ITableEmptyStateProps {
+  icon?: EmptyStateIconProps['icon'];
+  titleText?: string;
+  bodyText?: string;
+  onClearFiltersClick?: () => void;
+}
+
+const TableEmptyState: React.FunctionComponent<ITableEmptyStateProps> = ({
+  icon = SearchIcon,
+  titleText = 'No results found',
+  bodyText = 'No results match the filter criteria. Remove filters or clear all filters to show results.',
+  onClearFiltersClick,
+}: ITableEmptyStateProps) => (
+  <Flex className={flex.justifyContentCenter}>
+    <FlexItem>
+      <EmptyState variant={EmptyStateVariant.small}>
+        <EmptyStateIcon icon={icon} />
+        <Title headingLevel="h5" size="lg">
+          {titleText}
+        </Title>
+        <EmptyStateBody>{bodyText}</EmptyStateBody>
+        {onClearFiltersClick && (
+          <Button variant="link" onClick={onClearFiltersClick}>
+            Clear all filters
+          </Button>
+        )}
+      </EmptyState>
+    </FlexItem>
+  </Flex>
+);
+
+export default TableEmptyState;

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -17,7 +17,7 @@ export const useFilterState = (items: any[], filterCategories: FilterCategory[])
       if (filterCategory.getItemValue) {
         itemValue = filterCategory.getItemValue(item);
       }
-      return values.every(filterValue => !itemValue || itemValue.indexOf(filterValue) !== -1);
+      return values.every(filterValue => itemValue && itemValue.indexOf(filterValue) !== -1);
     })
   );
 

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -17,7 +17,12 @@ export const useFilterState = (items: any[], filterCategories: FilterCategory[])
       if (filterCategory.getItemValue) {
         itemValue = filterCategory.getItemValue(item);
       }
-      return values.every(filterValue => itemValue && itemValue.indexOf(filterValue) !== -1);
+      return values.every(filterValue => {
+        if (!itemValue) return false;
+        const lowerCaseItemValue = String(itemValue).toLowerCase();
+        const lowerCaseFilterValue = String(filterValue).toLowerCase();
+        return lowerCaseItemValue.indexOf(lowerCaseFilterValue) !== -1;
+      });
     })
   );
 

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -3,6 +3,8 @@ import { PaginationProps } from '@patternfly/react-core';
 import { IFilterValues } from '../components/FilterToolbar';
 import { ISortBy, SortByDirection } from '@patternfly/react-table';
 
+// TODO these could be given generic types to avoid using `any` (https://www.typescriptlang.org/docs/handbook/generics.html)
+
 export const useFilterState = (items: any[]) => {
   const [filterValues, setFilterValues] = useState<IFilterValues>({});
 
@@ -18,7 +20,7 @@ export const useFilterState = (items: any[]) => {
   return { filterValues, setFilterValues, filteredItems };
 };
 
-export const useSortState = (items: any[], sortKeys: string[]) => {
+export const useSortState = (items: any[], getSortValues: (item: any) => string[]) => {
   const [sortBy, setSortBy] = useState<ISortBy>({});
   const onSort = (event: React.SyntheticEvent, index: number, direction: SortByDirection) => {
     setSortBy({ index, direction });
@@ -26,9 +28,10 @@ export const useSortState = (items: any[], sortKeys: string[]) => {
 
   const sortedItems = [...items].sort((a: any, b: any) => {
     const { index, direction } = sortBy;
-    const key = sortKeys[index];
-    if (a[key] < b[key]) return direction === SortByDirection.asc ? -1 : 1;
-    if (a[key] > b[key]) return direction === SortByDirection.asc ? 1 : -1;
+    const aValue = getSortValues(a)[index];
+    const bValue = getSortValues(b)[index];
+    if (aValue < bValue) return direction === SortByDirection.asc ? -1 : 1;
+    if (aValue > bValue) return direction === SortByDirection.asc ? 1 : -1;
     return 0;
   });
 

--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -1,18 +1,22 @@
 import { useState } from 'react';
 import { PaginationProps } from '@patternfly/react-core';
-import { IFilterValues } from '../components/FilterToolbar';
+import { IFilterValues, FilterCategory } from '../components/FilterToolbar';
 import { ISortBy, SortByDirection } from '@patternfly/react-table';
 
 // TODO these could be given generic types to avoid using `any` (https://www.typescriptlang.org/docs/handbook/generics.html)
 
-export const useFilterState = (items: any[]) => {
+export const useFilterState = (items: any[], filterCategories: FilterCategory[]) => {
   const [filterValues, setFilterValues] = useState<IFilterValues>({});
 
   const filteredItems = items.filter(item =>
     Object.keys(filterValues).every(categoryKey => {
       const values = filterValues[categoryKey];
       if (!values || values.length === 0) return true;
-      const itemValue = item[categoryKey];
+      const filterCategory = filterCategories.find(category => category.key === categoryKey);
+      let itemValue = item[categoryKey];
+      if (filterCategory.getItemValue) {
+        itemValue = filterCategory.getItemValue(item);
+      }
       return values.every(filterValue => !itemValue || itemValue.indexOf(filterValue) !== -1);
     })
   );

--- a/src/app/common/duck/utils.ts
+++ b/src/app/common/duck/utils.ts
@@ -2,22 +2,26 @@ import { push } from 'connected-react-router';
 import { AuthActions } from '../../auth/duck/actions';
 
 const DNS1123Validator = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
-const URLValidator =
-  /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
+const URLValidator = /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
 
-const IPValidator = (value) => {
+const IPValidator = value => {
   const blocks = value.split('.');
-  return blocks.length === 4 && blocks.map((block, index) => {
-    const ipValue = Number(block);
-    if (index === 0) {
-      return ipValue >= 1 && ipValue < 256;
-    } else {
-      return ipValue >= 0 && ipValue < 256;
-    }
-  }).every(Boolean);
+  return (
+    blocks.length === 4 &&
+    blocks
+      .map((block, index) => {
+        const ipValue = Number(block);
+        if (index === 0) {
+          return ipValue >= 1 && ipValue < 256;
+        } else {
+          return ipValue >= 0 && ipValue < 256;
+        }
+      })
+      .every(Boolean)
+  );
 };
 
-export const isSelfSignedCertError = (err) => {
+export const isSelfSignedCertError = err => {
   const e = err.toJSON();
   // HACK: Doing our best to determine whether or not the
   // error was produced due to a self signed cert error.
@@ -25,7 +29,7 @@ export const isSelfSignedCertError = (err) => {
   return !e.code && e.message === 'Network Error';
 };
 
-export const isTimeoutError = (err) => {
+export const isTimeoutError = err => {
   const e = err.toJSON();
   return e.code && e.code === 206;
 };
@@ -34,7 +38,6 @@ export const handleSelfSignedCertError = (failedUrl: string, dispatch: any) => {
   dispatch(AuthActions.certErrorOccurred(failedUrl));
   dispatch(push('/cert-error'));
 };
-
 
 const DNS1123Error = value => {
   return `Invalid value: "${value}" for a DNS-1123 subdomain with regex' +
@@ -45,6 +48,14 @@ const testDNS1123 = value => DNS1123Validator.test(value);
 
 const testURL = value => URLValidator.test(value) || IPValidator(value);
 
+export const capitalize = (s: string) => {
+  if (s.charAt(0)) {
+    return `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
+  } else {
+    return s;
+  }
+};
+
 export default {
   testDNS1123,
   DNS1123Error,
@@ -52,4 +63,5 @@ export default {
   isTimeoutError,
   handleSelfSignedCertError,
   testURL,
+  capitalize,
 };

--- a/src/app/plan/components/Wizard/CopyOptionsForm.tsx
+++ b/src/app/plan/components/Wizard/CopyOptionsForm.tsx
@@ -2,23 +2,23 @@ import React, { useEffect } from 'react';
 import { FormikProps } from 'formik';
 import { isEmpty } from 'lodash';
 import { IFormValues, IOtherProps } from './WizardContainer';
-import StorageClassTable from './StorageClassTable';
+import CopyOptionsTable from './CopyOptionsTable';
 import { IPlanPersistentVolume } from './types';
 
 export const pvStorageClassAssignmentKey = 'pvStorageClassAssignment';
 export const pvCopyMethodAssignmentKey = 'pvCopyMethodAssignment';
 
-interface IStorageClassFormProps
+interface ICopyOptionsFormProps
   extends Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isFetchingPVList'>,
     Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
 
-const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
+const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
   clusterList,
   currentPlan,
   isFetchingPVList,
   setFieldValue,
   values,
-}: IStorageClassFormProps) => {
+}: ICopyOptionsFormProps) => {
   const migPlanPvs = currentPlan.spec.persistentVolumes;
 
   const destCluster = clusterList.find(
@@ -79,7 +79,7 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
   };
 
   return (
-    <StorageClassTable
+    <CopyOptionsTable
       isFetchingPVList={isFetchingPVList}
       currentPlan={currentPlan}
       persistentVolumes={
@@ -95,4 +95,4 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
     />
   );
 };
-export default StorageClassForm;
+export default CopyOptionsForm;

--- a/src/app/plan/components/Wizard/CopyOptionsTable.tsx
+++ b/src/app/plan/components/Wizard/CopyOptionsTable.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Bullseye,
   EmptyState,
+  EmptyStateVariant,
   Title,
   Grid,
   GridItem,
@@ -16,6 +17,7 @@ import {
   SelectOptionObject,
 } from '@patternfly/react-core';
 import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useFilterState, useSortState, usePaginationState } from '../../../common/duck/hooks';
 import { IFormValues, IOtherProps } from './WizardContainer';
@@ -27,6 +29,7 @@ import {
   FilterType,
   FilterToolbar,
 } from '../../../common/components/FilterToolbar';
+import TableEmptyState from '../../../common/components/TableEmptyState';
 
 interface ICopyOptionsTableProps
   extends Pick<IOtherProps, 'isFetchingPVList' | 'currentPlan'>,
@@ -62,7 +65,7 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
   if (isFetchingPVList) {
     return (
       <Bullseye>
-        <EmptyState variant="small">
+        <EmptyState variant={EmptyStateVariant.small}>
           <div className="pf-c-empty-state__icon">
             <Spinner size="xl" />
           </div>
@@ -78,7 +81,6 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
     { title: 'PV name', transforms: [sortable] },
     { title: 'Claim', transforms: [sortable] },
     { title: 'Namespace', transforms: [sortable] },
-    { title: 'Migration type', transforms: [sortable] },
     { title: 'Copy method', transforms: [sortable] },
     { title: 'Target storage class', transforms: [sortable] },
   ];
@@ -86,7 +88,6 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
     pv.name,
     pv.claim,
     pv.project,
-    pv.type,
     copyMethodToString(pvCopyMethodAssignment[pv.name]),
     storageClassToString(pvStorageClassAssignment[pv.name]),
   ];
@@ -162,9 +163,6 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
         pv.claim,
         pv.project,
         {
-          title: capitalize(pv.type),
-        },
-        {
           title: (
             <SimpleSelect
               aria-label="Select copy method"
@@ -194,6 +192,17 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
     };
   });
 
+  const tableEmptyState =
+    persistentVolumes.length > 0 ? (
+      <TableEmptyState onClearFiltersClick={() => setFilterValues({})} />
+    ) : (
+      <TableEmptyState
+        icon={InfoCircleIcon}
+        titleText="No PVs selected for Copy"
+        bodyText="Select Next to continue."
+      />
+    );
+
   return (
     <Grid gutter="md">
       <GridItem>
@@ -216,17 +225,21 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
             <Pagination widgetId="storage-class-table-pagination-top" {...paginationProps} />
           </LevelItem>
         </Level>
-        <Table
-          aria-label="Storage class selections table"
-          variant={TableVariant.compact}
-          cells={columns}
-          rows={rows}
-          sortBy={sortBy}
-          onSort={onSort}
-        >
-          <TableHeader />
-          <TableBody />
-        </Table>
+        {rows.length > 0 ? (
+          <Table
+            aria-label="Storage class selections table"
+            variant={TableVariant.compact}
+            cells={columns}
+            rows={rows}
+            sortBy={sortBy}
+            onSort={onSort}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        ) : (
+          tableEmptyState
+        )}
         <Pagination
           widgetId="storage-class-table-pagination-bottom"
           variant={PaginationVariant.bottom}

--- a/src/app/plan/components/Wizard/CopyOptionsTable.tsx
+++ b/src/app/plan/components/Wizard/CopyOptionsTable.tsx
@@ -28,7 +28,7 @@ import {
   FilterToolbar,
 } from '../../../common/components/FilterToolbar';
 
-interface IStorageClassTableProps
+interface ICopyOptionsTableProps
   extends Pick<IOtherProps, 'isFetchingPVList' | 'currentPlan'>,
     Pick<IFormValues, 'persistentVolumes' | 'pvStorageClassAssignment' | 'pvCopyMethodAssignment'> {
   storageClasses: IClusterStorageClass[];
@@ -49,7 +49,7 @@ const copyMethodToString = (copyMethod: string) => {
   return copyMethod && capitalize(copyMethod);
 };
 
-const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
+const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
   isFetchingPVList,
   currentPlan,
   persistentVolumes,
@@ -58,7 +58,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
   storageClasses,
   onStorageClassChange,
   onCopyMethodChange,
-}: IStorageClassTableProps) => {
+}: ICopyOptionsTableProps) => {
   if (isFetchingPVList) {
     return (
       <Bullseye>
@@ -238,4 +238,4 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
   );
 };
 
-export default StorageClassTable;
+export default CopyOptionsTable;

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -86,7 +86,7 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
     <React.Fragment>
       <GridItem>
         <TextContent className={spacing.mtMd}>
-          <Text component={TextVariants.p}>Select projects to be migrated:</Text>
+          <Text component={TextVariants.p}>Select projects to be migrated</Text>
         </TextContent>
       </GridItem>
       <GridItem>

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -20,6 +20,7 @@ import {
   FilterCategory,
   FilterType,
 } from '../../../common/components/FilterToolbar';
+import TableEmptyState from '../../../common/components/TableEmptyState';
 
 interface INamespaceTableProps
   extends Pick<IOtherProps, 'sourceClusterNamespaces'>,
@@ -110,19 +111,23 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
             <Pagination widgetId="namespace-table-pagination-top" {...paginationProps} />
           </LevelItem>
         </Level>
-        <Table
-          aria-label="Projects table"
-          variant={TableVariant.compact}
-          cells={columns}
-          rows={rows}
-          sortBy={sortBy}
-          onSort={onSort}
-          onSelect={onSelect}
-          canSelectAll
-        >
-          <TableHeader />
-          <TableBody />
-        </Table>
+        {rows.length > 0 ? (
+          <Table
+            aria-label="Projects table"
+            variant={TableVariant.compact}
+            cells={columns}
+            rows={rows}
+            sortBy={sortBy}
+            onSort={onSort}
+            onSelect={onSelect}
+            canSelectAll
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        ) : (
+          <TableEmptyState onClearFiltersClick={() => setFilterValues({})} />
+        )}
         <Level>
           <LevelItem>
             <TextContent>

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -38,8 +38,13 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
     { title: 'PV claims', transforms: [sortable] },
     { title: 'Services', transforms: [sortable] },
   ];
-  // Column 0 has the checkboxes, sort keys need to be indexed from 1
-  const sortKeys = [null, 'name', 'podCount', 'pvcCount', 'serviceCount'];
+  const getSortValues = namespace => [
+    null, // Column 0 has the checkboxes, sort values need to be indexed from 1
+    namespace.name,
+    namespace.podCount,
+    namespace.pvcCount,
+    namespace.serviceCount,
+  ];
   const filterCategories: FilterCategory[] = [
     {
       key: 'name',
@@ -49,7 +54,7 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
     },
   ];
   const { filterValues, setFilterValues, filteredItems } = useFilterState(sourceClusterNamespaces);
-  const { sortBy, onSort, sortedItems } = useSortState(filteredItems, sortKeys);
+  const { sortBy, onSort, sortedItems } = useSortState(filteredItems, getSortValues);
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
   useEffect(() => setPageNumber(1), [filterValues, sortBy]);
 

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -53,7 +53,10 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = ({
       placeholderText: 'Filter by name...',
     },
   ];
-  const { filterValues, setFilterValues, filteredItems } = useFilterState(sourceClusterNamespaces);
+  const { filterValues, setFilterValues, filteredItems } = useFilterState(
+    sourceClusterNamespaces,
+    filterCategories
+  );
   const { sortBy, onSort, sortedItems } = useSortState(filteredItems, getSortValues);
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
   useEffect(() => setPageNumber(1), [filterValues, sortBy]);

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -1,52 +1,27 @@
 import React from 'react';
-import {
-  Grid,
-  GridItem,
-  Text,
-  TextContent,
-  TextVariants
-} from '@patternfly/react-core';
 import { FormikProps } from 'formik';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import StorageClassTable from './StorageClassTable';
 
 interface IStorageClassFormProps
-  extends Pick<
-    IOtherProps,
-    | 'clusterList'
-    | 'currentPlan'
-    | 'isEdit'
-    | 'isFetchingPVList'
-    >,
+  extends Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isFetchingPVList'>,
     Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
 
 const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
   clusterList,
   currentPlan,
-  isEdit,
   isFetchingPVList,
   setFieldValue,
   values,
-}: IStorageClassFormProps) => { 
+}: IStorageClassFormProps) => {
   return (
-    <Grid gutter="md">
-      <GridItem>
-        <TextContent>
-          <Text component={TextVariants.p}>
-            Select storage class for copied PVs:
-          </Text>
-        </TextContent>
-      </GridItem>
-      <GridItem>
-        <StorageClassTable
-          isFetchingPVList={isFetchingPVList}
-          setFieldValue={setFieldValue}
-          values={values}
-          currentPlan={currentPlan}
-          clusterList={clusterList}
-        />
-      </GridItem>
-    </Grid>
+    <StorageClassTable
+      isFetchingPVList={isFetchingPVList}
+      setFieldValue={setFieldValue}
+      values={values}
+      currentPlan={currentPlan}
+      clusterList={clusterList}
+    />
   );
 };
 export default StorageClassForm;

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -25,7 +25,7 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
     c => c.MigCluster.metadata.name === currentPlan.spec.destMigClusterRef.name
   );
 
-  const storageClassOptions = (destCluster && destCluster.MigCluster.spec.storageClasses) || [];
+  const storageClasses = (destCluster && destCluster.MigCluster.spec.storageClasses) || [];
 
   // Build a pv => assignedStorageClass table, defaulting to the controller suggestion
   useEffect(() => {
@@ -33,7 +33,7 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
       let pvStorageClassAssignment = {};
       if (migPlanPvs) {
         pvStorageClassAssignment = migPlanPvs.reduce((assignedScs, pv) => {
-          const suggestedStorageClass = storageClassOptions.find(
+          const suggestedStorageClass = storageClasses.find(
             sc => sc.name === pv.selection.storageClass
           );
           assignedScs[pv.name] = suggestedStorageClass ? suggestedStorageClass : '';
@@ -61,7 +61,7 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
   }, []);
 
   const onStorageClassChange = (currentPV: IPlanPersistentVolume, value: string) => {
-    const newSc = storageClassOptions.find(sc => sc.name === value) || '';
+    const newSc = storageClasses.find(sc => sc.name === value) || '';
     const updatedAssignment = {
       ...values.pvStorageClassAssignment,
       [currentPV.name]: newSc,
@@ -89,7 +89,7 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
       }
       pvStorageClassAssignment={values.pvStorageClassAssignment}
       pvCopyMethodAssignment={values.pvCopyMethodAssignment}
-      storageClassOptions={storageClassOptions}
+      storageClasses={storageClasses}
       onStorageClassChange={onStorageClassChange}
       onCopyMethodChange={onCopyMethodChange}
     />

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -1,7 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FormikProps } from 'formik';
+import { isEmpty } from 'lodash';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import StorageClassTable from './StorageClassTable';
+import { IPlanPersistentVolume } from './types';
+
+export const pvStorageClassAssignmentKey = 'pvStorageClassAssignment';
+export const pvCopyMethodAssignmentKey = 'pvCopyMethodAssignment';
 
 interface IStorageClassFormProps
   extends Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isFetchingPVList'>,
@@ -14,13 +19,79 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
   setFieldValue,
   values,
 }: IStorageClassFormProps) => {
+  const migPlanPvs = currentPlan.spec.persistentVolumes;
+
+  const destCluster = clusterList.find(
+    c => c.MigCluster.metadata.name === currentPlan.spec.destMigClusterRef.name
+  );
+
+  const storageClassOptions = (destCluster && destCluster.MigCluster.spec.storageClasses) || [];
+
+  // Build a pv => assignedStorageClass table, defaulting to the controller suggestion
+  useEffect(() => {
+    if (!values.pvStorageClassAssignment || isEmpty(values.pvStorageClassAssignment)) {
+      let pvStorageClassAssignment = {};
+      if (migPlanPvs) {
+        pvStorageClassAssignment = migPlanPvs.reduce((assignedScs, pv) => {
+          const suggestedStorageClass = storageClassOptions.find(
+            sc => sc.name === pv.selection.storageClass
+          );
+          assignedScs[pv.name] = suggestedStorageClass ? suggestedStorageClass : '';
+          return assignedScs;
+        }, {});
+      }
+      setFieldValue(pvStorageClassAssignmentKey, pvStorageClassAssignment);
+    }
+    if (!values.pvCopyMethodAssignment || isEmpty(values.pvCopyMethodAssignment)) {
+      let pvCopyMethodAssignment = {};
+      if (migPlanPvs) {
+        pvCopyMethodAssignment = migPlanPvs.reduce((assignedCms, pv) => {
+          const supportedCopyMethods = pv.supported.copyMethods || [];
+          const suggestedCopyMethod = supportedCopyMethods.find(
+            cm => cm === pv.selection.copyMethod
+          );
+          assignedCms[pv.name] = suggestedCopyMethod
+            ? suggestedCopyMethod
+            : supportedCopyMethods[0];
+          return assignedCms;
+        }, {});
+      }
+      setFieldValue(pvCopyMethodAssignmentKey, pvCopyMethodAssignment);
+    }
+  }, []);
+
+  const persistentVolumes = values.persistentVolumes.length
+    ? values.persistentVolumes.filter(v => v.type === 'copy')
+    : [];
+
+  const onStorageClassChange = (currentPV: IPlanPersistentVolume, value: string) => {
+    const newSc = storageClassOptions.find(sc => sc.name === value) || '';
+    const updatedAssignment = {
+      ...values.pvStorageClassAssignment,
+      [currentPV.name]: newSc,
+    };
+    setFieldValue(pvStorageClassAssignmentKey, updatedAssignment);
+  };
+
+  const onCopyMethodChange = (currentPV: IPlanPersistentVolume, value: string) => {
+    const newCm = currentPV.supported.copyMethods.find(cm => cm === value);
+    const updatedAssignment = {
+      ...values.pvCopyMethodAssignment,
+      [currentPV.name]: newCm,
+    };
+    setFieldValue(pvCopyMethodAssignmentKey, updatedAssignment);
+  };
+
   return (
     <StorageClassTable
       isFetchingPVList={isFetchingPVList}
-      setFieldValue={setFieldValue}
-      values={values}
       currentPlan={currentPlan}
-      clusterList={clusterList}
+      filteredPersistentVolumes={persistentVolumes}
+      pvStorageClassAssignment={values.pvStorageClassAssignment}
+      pvCopyMethodAssignment={values.pvCopyMethodAssignment}
+      storageClassOptions={storageClassOptions}
+      onStorageClassChange={onStorageClassChange}
+      onCopyMethodChange={onCopyMethodChange}
     />
   );
 };

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -60,10 +60,6 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
     }
   }, []);
 
-  const persistentVolumes = values.persistentVolumes.length
-    ? values.persistentVolumes.filter(v => v.type === 'copy')
-    : [];
-
   const onStorageClassChange = (currentPV: IPlanPersistentVolume, value: string) => {
     const newSc = storageClassOptions.find(sc => sc.name === value) || '';
     const updatedAssignment = {
@@ -86,7 +82,11 @@ const StorageClassForm: React.FunctionComponent<IStorageClassFormProps> = ({
     <StorageClassTable
       isFetchingPVList={isFetchingPVList}
       currentPlan={currentPlan}
-      filteredPersistentVolumes={persistentVolumes}
+      persistentVolumes={
+        values.persistentVolumes.length
+          ? values.persistentVolumes.filter(v => v.type === 'copy')
+          : []
+      }
       pvStorageClassAssignment={values.pvStorageClassAssignment}
       pvCopyMethodAssignment={values.pvCopyMethodAssignment}
       storageClassOptions={storageClassOptions}

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -211,7 +211,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
                 Cell: row => {
                   const currentStorageClass = values.pvStorageClassAssignment[row.original.name];
                   const storageClassOptionsWithNone = storageClassOptions.map(sc => {
-                    return { value: sc.name, label: sc.name + ':' + sc.provisioner };
+                    return { value: sc.name, label: `${sc.name}:${sc.provisioner}` };
                   });
                   storageClassOptionsWithNone.push({ value: '', label: 'None' });
                   return (
@@ -221,7 +221,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
                       name="storageClasses"
                       value={{
                         label: currentStorageClass
-                          ? currentStorageClass.name + ':' + currentStorageClass.provisioner
+                          ? `${currentStorageClass.name}:${currentStorageClass.provisioner}`
                           : 'None',
                         value: currentStorageClass ? currentStorageClass.name : '',
                       }}

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -38,6 +38,12 @@ interface OptionWithValue extends SelectOptionObject {
 const storageClassToString = (storageClass: IClusterStorageClass) =>
   storageClass && `${storageClass.name}:${storageClass.provisioner}`;
 
+const copyMethodToString = (copyMethod: string) => {
+  if (copyMethod === 'filesystem') return 'Filesystem copy';
+  if (copyMethod === 'snapshot') return 'Volume snapshot';
+  return copyMethod && capitalize(copyMethod);
+};
+
 const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
   isFetchingPVList,
   currentPlan,
@@ -76,7 +82,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
     pv.claim,
     pv.project,
     pv.type,
-    pvCopyMethodAssignment[pv.name],
+    copyMethodToString(pvCopyMethodAssignment[pv.name]),
     storageClassToString(pvStorageClassAssignment[pv.name]),
   ];
   // TODO filterCategories
@@ -93,7 +99,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
     const copyMethodOptions: OptionWithValue[] = currentPV.supported.copyMethods.map(
       (copyMethod: string) => ({
         value: copyMethod,
-        toString: () => capitalize(copyMethod),
+        toString: () => copyMethodToString(copyMethod),
       })
     );
 

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -13,6 +13,7 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { FormikProps } from 'formik';
+import { isEmpty } from 'lodash';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 
@@ -58,7 +59,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
 
   // Build a pv => assignedStorageClass table, defaulting to the controller suggestion
   useEffect(() => {
-    if (!values.pvStorageClassAssignment) {
+    if (!values.pvStorageClassAssignment || isEmpty(values.pvStorageClassAssignment)) {
       let pvStorageClassAssignment = {};
       if (migPlanPvs) {
         pvStorageClassAssignment = migPlanPvs.reduce((assignedScs, pv) => {
@@ -71,17 +72,22 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
       }
       setFieldValue(pvStorageClassAssignmentKey, pvStorageClassAssignment);
     }
-    // TODO should this only happen if (!values.pvCopyMethodAssignment), like above?
-    let pvCopyMethodAssignment = {};
-    if (migPlanPvs) {
-      pvCopyMethodAssignment = migPlanPvs.reduce((assignedCms, pv) => {
-        const supportedCopyMethods = pv.supported.copyMethods || [];
-        const suggestedCopyMethod = supportedCopyMethods.find(cm => cm === pv.selection.copyMethod);
-        assignedCms[pv.name] = suggestedCopyMethod ? suggestedCopyMethod : supportedCopyMethods[0];
-        return assignedCms;
-      }, {});
+    if (!values.pvCopyMethodAssignment || isEmpty(values.pvCopyMethodAssignment)) {
+      let pvCopyMethodAssignment = {};
+      if (migPlanPvs) {
+        pvCopyMethodAssignment = migPlanPvs.reduce((assignedCms, pv) => {
+          const supportedCopyMethods = pv.supported.copyMethods || [];
+          const suggestedCopyMethod = supportedCopyMethods.find(
+            cm => cm === pv.selection.copyMethod
+          );
+          assignedCms[pv.name] = suggestedCopyMethod
+            ? suggestedCopyMethod
+            : supportedCopyMethods[0];
+          return assignedCms;
+        }, {});
+      }
+      setFieldValue(pvCopyMethodAssignmentKey, pvCopyMethodAssignment);
     }
-    setFieldValue(pvCopyMethodAssignmentKey, pvCopyMethodAssignment);
   }, []);
 
   const rows = values.persistentVolumes.length

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -45,6 +45,9 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
     );
   }
 
+  // TODO move all this stuff up into StorageClassForm, only handle render logic in here
+  // TODO log the form values on this and on master, make sure we're not screwing up any of this init stuff
+
   const migPlanPvs = currentPlan.spec.persistentVolumes;
 
   const destCluster = clusterList.find(
@@ -54,7 +57,6 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
   const storageClassOptions = destCluster.MigCluster.spec.storageClasses || [];
 
   // Build a pv => assignedStorageClass table, defaulting to the controller suggestion
-  // TODO can we avoid this initialize-on-mount behavior?
   useEffect(() => {
     if (!values.pvStorageClassAssignment) {
       let pvStorageClassAssignment = {};
@@ -117,6 +119,9 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
     fontSize: '14px',
   };
 
+  // TODO do we need to guard against null rows here?
+  // TODO convert to PF table, add sorting, filtering, pagination
+  // TODO add columns based on Vince's mockups (excluding Verify copy, until next PR)
   if (rows !== null) {
     return (
       <Grid gutter="md">
@@ -173,7 +178,6 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
                 width: 500,
                 style: { overflow: 'visible' },
                 Cell: row => {
-                  const migPlanPvs = currentPlan.spec.persistentVolumes;
                   const currentPV = migPlanPvs.find(pv => pv.name === row.original.name);
                   const currentCopyMethod = values.pvCopyMethodAssignment[row.original.name];
 

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -136,7 +136,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
       <Grid gutter="md">
         <GridItem>
           <TextContent>
-            <Text component={TextVariants.p}>Select storage class for copied PVs:</Text>
+            <Text component={TextVariants.p}>Select target storage class for copied PVs</Text>
           </TextContent>
         </GridItem>
         <GridItem>

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -112,8 +112,11 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
     {
       key: 'copyMethod',
       title: 'Copy method',
-      type: FilterType.search,
-      placeholderText: 'Filter by copy method...',
+      type: FilterType.select,
+      selectOptions: [
+        { key: 'filesystem', value: 'Filesystem copy' },
+        { key: 'snapshot', value: 'Volume snapshot' },
+      ],
       getItemValue: pv => copyMethodToString(pvCopyMethodAssignment[pv.name]),
     },
     {

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -22,6 +22,11 @@ import { IFormValues, IOtherProps } from './WizardContainer';
 import { IPlanPersistentVolume, IClusterStorageClass } from './types';
 import { capitalize } from '../../../common/duck/utils';
 import SimpleSelect from '../../../common/components/SimpleSelect';
+import {
+  FilterCategory,
+  FilterType,
+  FilterToolbar,
+} from '../../../common/components/FilterToolbar';
 
 interface IStorageClassTableProps
   extends Pick<IOtherProps, 'isFetchingPVList' | 'currentPlan'>,
@@ -85,10 +90,42 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
     copyMethodToString(pvCopyMethodAssignment[pv.name]),
     storageClassToString(pvStorageClassAssignment[pv.name]),
   ];
-  // TODO filterCategories
+  const filterCategories: FilterCategory[] = [
+    {
+      key: 'name',
+      title: 'PV name',
+      type: FilterType.search,
+      placeholderText: 'Filter by PV name...',
+    },
+    {
+      key: 'claim',
+      title: 'Claim',
+      type: FilterType.search,
+      placeholderText: 'Filter by claim...',
+    },
+    {
+      key: 'project',
+      title: 'Namespace',
+      type: FilterType.search,
+      placeholderText: 'Filter by namespace...',
+    },
+    // TODO how to manage these derived keys in filters
+    /*{
+      key: '???',
+      title: 'Copy method',
+      type: FilterType.search,
+      placeholderText: 'Filter by copy method...',
+    },
+    {
+      key: '???',
+      title: 'Target storage class',
+      type: FilterType.search,
+      placeholderText: 'Filter by target storage class...',
+    },*/
+  ];
 
-  // TODO useFilterState
-  const { sortBy, onSort, sortedItems } = useSortState(persistentVolumes, getSortValues);
+  const { filterValues, setFilterValues, filteredItems } = useFilterState(persistentVolumes);
+  const { sortBy, onSort, sortedItems } = useSortState(filteredItems, getSortValues);
   const { currentPageItems, paginationProps } = usePaginationState(sortedItems, 10);
 
   const rows = currentPageItems.map(pv => {
@@ -164,7 +201,13 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
         </GridItem>
         <GridItem>
           <Level>
-            <LevelItem>TODO: filters</LevelItem>
+            <LevelItem>
+              <FilterToolbar
+                filterCategories={filterCategories}
+                filterValues={filterValues}
+                setFilterValues={setFilterValues}
+              />
+            </LevelItem>
             <LevelItem>
               <Pagination widgetId="storage-class-table-pagination-top" {...paginationProps} />
             </LevelItem>

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -109,22 +109,26 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
       type: FilterType.search,
       placeholderText: 'Filter by namespace...',
     },
-    // TODO how to manage these derived keys in filters
-    /*{
-      key: '???',
+    {
+      key: 'copyMethod',
       title: 'Copy method',
       type: FilterType.search,
       placeholderText: 'Filter by copy method...',
+      getItemValue: pv => copyMethodToString(pvCopyMethodAssignment[pv.name]),
     },
     {
-      key: '???',
+      key: 'targetStorageClass',
       title: 'Target storage class',
       type: FilterType.search,
       placeholderText: 'Filter by target storage class...',
-    },*/
+      getItemValue: pv => storageClassToString(pvStorageClassAssignment[pv.name]),
+    },
   ];
 
-  const { filterValues, setFilterValues, filteredItems } = useFilterState(persistentVolumes);
+  const { filterValues, setFilterValues, filteredItems } = useFilterState(
+    persistentVolumes,
+    filterCategories
+  );
   const { sortBy, onSort, sortedItems } = useSortState(filteredItems, getSortValues);
   const { currentPageItems, paginationProps } = usePaginationState(sortedItems, 10);
 

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import ReactTable from 'react-table';
 import 'react-table/react-table.css';
 import Select from 'react-select';
@@ -30,88 +30,6 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
   setFieldValue,
   values,
 }: IStorageClassTableForm) => {
-  const [rows, setRows] = useState([]);
-  const [storageClassOptions, setStorageClassOptions] = useState([]);
-  const [pvStorageClassAssignment, setPvStorageClassAssignment] = useState({});
-  const [pvCopyMethodAssignment, setPvCopyMethodAssignment] = useState({});
-
-  const handleStorageClassChange = (row, option) => {
-    const pvName = row.original.name;
-    const selectedScName = option.value;
-    let newSc;
-    if (selectedScName === '') {
-      newSc = '';
-    } else {
-      newSc = storageClassOptions.find(sc => sc.name === selectedScName);
-    }
-    const updatedAssignment = {
-      ...pvStorageClassAssignment,
-      [pvName]: newSc,
-    };
-
-    setPvStorageClassAssignment(updatedAssignment);
-    setFieldValue(pvStorageClassAssignmentKey, updatedAssignment);
-  };
-
-  const handleCopyMethodChange = (selectedPV, option) => {
-    const pvName = selectedPV.name;
-    const selectedCmName = option.value;
-    const newCm = selectedPV.supported.copyMethods.find(cm => cm === selectedCmName);
-    const updatedAssignment = {
-      ...pvCopyMethodAssignment,
-      [pvName]: newCm,
-    };
-
-    setPvCopyMethodAssignment(updatedAssignment);
-    setFieldValue(pvCopyMethodAssignmentKey, updatedAssignment);
-  };
-
-  useEffect(() => {
-    const migPlanPvs = currentPlan.spec.persistentVolumes;
-
-    const destCluster = clusterList.find(
-      c => c.MigCluster.metadata.name === currentPlan.spec.destMigClusterRef.name
-    );
-
-    const destStorageClasses = destCluster.MigCluster.spec.storageClasses || [];
-
-    setStorageClassOptions(destStorageClasses);
-    // Build a pv => assignedStorageClass table, defaulting to the controller suggestion
-    let initialAssignedScs;
-    if (values.pvStorageClassAssignment) {
-      setPvStorageClassAssignment(values.pvStorageClassAssignment);
-    } else {
-      initialAssignedScs = migPlanPvs ? migPlanPvs.reduce((assignedScs, pv) => {
-        const suggestedStorageClass = destStorageClasses.find(sc =>
-          sc.name === pv.selection.storageClass
-        );
-        assignedScs[pv.name] = suggestedStorageClass ? suggestedStorageClass : '';
-        return assignedScs;
-      }, {}) : {};
-      setPvStorageClassAssignment(initialAssignedScs);
-      setFieldValue(pvStorageClassAssignmentKey, initialAssignedScs);
-    }
-
-
-    const initialAssignedCms = migPlanPvs ? migPlanPvs.reduce((assignedCms, pv) => {
-      const supportedCopyMethods = pv.supported.copyMethods || [];
-
-      const suggestedCopyMethod = supportedCopyMethods.find(cm =>
-        cm === pv.selection.copyMethod
-      );
-
-      assignedCms[pv.name] = suggestedCopyMethod ? suggestedCopyMethod : supportedCopyMethods[0];
-      return assignedCms;
-    }, {}) : {};
-
-    setPvCopyMethodAssignment(initialAssignedCms);
-    setFieldValue(pvCopyMethodAssignmentKey, initialAssignedCms);
-
-    if (values.persistentVolumes.length) {
-      setRows(values.persistentVolumes.filter(v => v.type === 'copy'));
-    }
-  }, [isFetchingPVList]); // Only re-run the effect if fetching value changes
-
   if (isFetchingPVList) {
     return (
       <Bullseye>
@@ -126,6 +44,74 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
       </Bullseye>
     );
   }
+
+  const migPlanPvs = currentPlan.spec.persistentVolumes;
+
+  const destCluster = clusterList.find(
+    c => c.MigCluster.metadata.name === currentPlan.spec.destMigClusterRef.name
+  );
+
+  const storageClassOptions = destCluster.MigCluster.spec.storageClasses || [];
+
+  // Build a pv => assignedStorageClass table, defaulting to the controller suggestion
+  // TODO can we avoid this initialize-on-mount behavior?
+  useEffect(() => {
+    if (!values.pvStorageClassAssignment) {
+      let pvStorageClassAssignment = {};
+      if (migPlanPvs) {
+        pvStorageClassAssignment = migPlanPvs.reduce((assignedScs, pv) => {
+          const suggestedStorageClass = storageClassOptions.find(
+            sc => sc.name === pv.selection.storageClass
+          );
+          assignedScs[pv.name] = suggestedStorageClass ? suggestedStorageClass : '';
+          return assignedScs;
+        }, {});
+      }
+      setFieldValue(pvStorageClassAssignmentKey, pvStorageClassAssignment);
+    }
+    // TODO should this only happen if (!values.pvCopyMethodAssignment), like above?
+    let pvCopyMethodAssignment = {};
+    if (migPlanPvs) {
+      pvCopyMethodAssignment = migPlanPvs.reduce((assignedCms, pv) => {
+        const supportedCopyMethods = pv.supported.copyMethods || [];
+        const suggestedCopyMethod = supportedCopyMethods.find(cm => cm === pv.selection.copyMethod);
+        assignedCms[pv.name] = suggestedCopyMethod ? suggestedCopyMethod : supportedCopyMethods[0];
+        return assignedCms;
+      }, {});
+    }
+    setFieldValue(pvCopyMethodAssignmentKey, pvCopyMethodAssignment);
+  }, []);
+
+  const rows = values.persistentVolumes.length
+    ? values.persistentVolumes.filter(v => v.type === 'copy')
+    : [];
+
+  const handleStorageClassChange = (row, option) => {
+    const pvName = row.original.name;
+    const selectedScName = option.value;
+    let newSc;
+    if (selectedScName === '') {
+      newSc = '';
+    } else {
+      newSc = storageClassOptions.find(sc => sc.name === selectedScName);
+    }
+    const updatedAssignment = {
+      ...values.pvStorageClassAssignment,
+      [pvName]: newSc,
+    };
+    setFieldValue(pvStorageClassAssignmentKey, updatedAssignment);
+  };
+
+  const handleCopyMethodChange = (selectedPV, option) => {
+    const pvName = selectedPV.name;
+    const selectedCmName = option.value;
+    const newCm = selectedPV.supported.copyMethods.find(cm => cm === selectedCmName);
+    const updatedAssignment = {
+      ...values.pvCopyMethodAssignment,
+      [pvName]: newCm,
+    };
+    setFieldValue(pvCopyMethodAssignmentKey, updatedAssignment);
+  };
 
   const tableStyle = {
     fontSize: '14px',
@@ -189,7 +175,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
                 Cell: row => {
                   const migPlanPvs = currentPlan.spec.persistentVolumes;
                   const currentPV = migPlanPvs.find(pv => pv.name === row.original.name);
-                  const currentCopyMethod = pvCopyMethodAssignment[row.original.name];
+                  const currentCopyMethod = values.pvCopyMethodAssignment[row.original.name];
 
                   const copyMethodOptionsMapped = currentPV.supported.copyMethods.map(cm => {
                     return { value: cm, label: cm };
@@ -223,7 +209,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
                 width: 500,
                 style: { overflow: 'visible' },
                 Cell: row => {
-                  const currentStorageClass = pvStorageClassAssignment[row.original.name];
+                  const currentStorageClass = values.pvStorageClassAssignment[row.original.name];
                   const storageClassOptionsWithNone = storageClassOptions.map(sc => {
                     return { value: sc.name, label: sc.name + ':' + sc.provisioner };
                   });

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -65,12 +65,16 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
 
   const columns = [
     { title: 'PV name', transforms: [sortable] },
+    { title: 'Claim', transforms: [sortable] },
+    { title: 'Namespace', transforms: [sortable] },
     { title: 'Migration type', transforms: [sortable] },
     { title: 'Copy method', transforms: [sortable] },
-    { title: 'Storage class', transforms: [sortable] },
+    { title: 'Target storage class', transforms: [sortable] },
   ];
   const getSortValues = pv => [
     pv.name,
+    pv.claim,
+    pv.project,
     pv.type,
     pvCopyMethodAssignment[pv.name],
     storageClassToString(pvStorageClassAssignment[pv.name]),
@@ -105,6 +109,8 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
     return {
       cells: [
         pv.name,
+        pv.claim,
+        pv.project,
         {
           title: capitalize(pv.type),
         },

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -191,54 +191,48 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
     };
   });
 
-  // TODO add columns based on Vince's mockups (excluding Verify copy, until next PR)
-  if (rows.length > 0) {
-    return (
-      <Grid gutter="md">
-        <GridItem>
-          <TextContent>
-            <Text component={TextVariants.p}>
-              For each persistent volume to be copied, select a copy method and target storage
-              class.
-            </Text>
-          </TextContent>
-        </GridItem>
-        <GridItem>
-          <Level>
-            <LevelItem>
-              <FilterToolbar
-                filterCategories={filterCategories}
-                filterValues={filterValues}
-                setFilterValues={setFilterValues}
-              />
-            </LevelItem>
-            <LevelItem>
-              <Pagination widgetId="storage-class-table-pagination-top" {...paginationProps} />
-            </LevelItem>
-          </Level>
-          <Table
-            aria-label="Storage class selections table"
-            variant={TableVariant.compact}
-            cells={columns}
-            rows={rows}
-            sortBy={sortBy}
-            onSort={onSort}
-          >
-            <TableHeader />
-            <TableBody />
-          </Table>
-          <Pagination
-            widgetId="storage-class-table-pagination-bottom"
-            variant={PaginationVariant.bottom}
-            className={spacing.mtMd}
-            {...paginationProps}
-          />
-        </GridItem>
-      </Grid>
-    );
-  } else {
-    return <div />;
-  }
+  return (
+    <Grid gutter="md">
+      <GridItem>
+        <TextContent>
+          <Text component={TextVariants.p}>
+            For each persistent volume to be copied, select a copy method and target storage class.
+          </Text>
+        </TextContent>
+      </GridItem>
+      <GridItem>
+        <Level>
+          <LevelItem>
+            <FilterToolbar
+              filterCategories={filterCategories}
+              filterValues={filterValues}
+              setFilterValues={setFilterValues}
+            />
+          </LevelItem>
+          <LevelItem>
+            <Pagination widgetId="storage-class-table-pagination-top" {...paginationProps} />
+          </LevelItem>
+        </Level>
+        <Table
+          aria-label="Storage class selections table"
+          variant={TableVariant.compact}
+          cells={columns}
+          rows={rows}
+          sortBy={sortBy}
+          onSort={onSort}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <Pagination
+          widgetId="storage-class-table-pagination-bottom"
+          variant={PaginationVariant.bottom}
+          className={spacing.mtMd}
+          {...paginationProps}
+        />
+      </GridItem>
+    </Grid>
+  );
 };
 
 export default StorageClassTable;

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -6,6 +6,11 @@ import {
   Bullseye,
   EmptyState,
   Title,
+  Grid,
+  GridItem,
+  TextContent,
+  Text,
+  TextVariants,
 } from '@patternfly/react-core';
 import { FormikProps } from 'formik';
 import { IFormValues, IOtherProps } from './WizardContainer';
@@ -15,12 +20,7 @@ export const pvStorageClassAssignmentKey = 'pvStorageClassAssignment';
 export const pvCopyMethodAssignmentKey = 'pvCopyMethodAssignment';
 
 interface IStorageClassTableForm
-  extends Pick<
-    IOtherProps,
-    | 'clusterList'
-    | 'currentPlan'
-    | 'isFetchingPVList'
-    >,
+  extends Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isFetchingPVList'>,
     Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
 
 const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
@@ -42,9 +42,7 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
     if (selectedScName === '') {
       newSc = '';
     } else {
-      newSc = storageClassOptions.find(sc =>
-        sc.name === selectedScName
-      );
+      newSc = storageClassOptions.find(sc => sc.name === selectedScName);
     }
     const updatedAssignment = {
       ...pvStorageClassAssignment,
@@ -135,122 +133,123 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableForm> = ({
 
   if (rows !== null) {
     return (
-      <React.Fragment>
-        <ReactTable
-          style={tableStyle}
-          data={rows}
-          columns={[
-            {
-              Header: () => (
-                <div
-                  style={{
-                    textAlign: 'left',
-                    fontWeight: 600,
-                  }}
-                >
-                  PV Name
-                </div>
-              ),
-              accessor: 'name',
-              width: 180,
-            },
-            {
-              Header: () => (
-                <div
-                  style={{
-                    textAlign: 'left',
-                    fontWeight: 600,
-                  }}
-                >
-                  Type
-                </div>
-              ),
-              accessor: 'type',
-              width: 180,
-            },
-            {
-              Header: () => (
-                <div
-                  style={{
-                    textAlign: 'left',
-                    fontWeight: 600,
-                  }}
-                >
-                  Copy Method
-                </div>
-              ),
-              accessor: '',
-              width: 500,
-              style: { overflow: 'visible' },
-              Cell: row => {
-                const migPlanPvs = currentPlan.spec.persistentVolumes;
-                const currentPV = migPlanPvs.find(pv => pv.name === row.original.name);
-                const currentCopyMethod = pvCopyMethodAssignment[row.original.name];
+      <Grid gutter="md">
+        <GridItem>
+          <TextContent>
+            <Text component={TextVariants.p}>Select storage class for copied PVs:</Text>
+          </TextContent>
+        </GridItem>
+        <GridItem>
+          <ReactTable
+            style={tableStyle}
+            data={rows}
+            columns={[
+              {
+                Header: () => (
+                  <div
+                    style={{
+                      textAlign: 'left',
+                      fontWeight: 600,
+                    }}
+                  >
+                    PV Name
+                  </div>
+                ),
+                accessor: 'name',
+                width: 180,
+              },
+              {
+                Header: () => (
+                  <div
+                    style={{
+                      textAlign: 'left',
+                      fontWeight: 600,
+                    }}
+                  >
+                    Type
+                  </div>
+                ),
+                accessor: 'type',
+                width: 180,
+              },
+              {
+                Header: () => (
+                  <div
+                    style={{
+                      textAlign: 'left',
+                      fontWeight: 600,
+                    }}
+                  >
+                    Copy Method
+                  </div>
+                ),
+                accessor: '',
+                width: 500,
+                style: { overflow: 'visible' },
+                Cell: row => {
+                  const migPlanPvs = currentPlan.spec.persistentVolumes;
+                  const currentPV = migPlanPvs.find(pv => pv.name === row.original.name);
+                  const currentCopyMethod = pvCopyMethodAssignment[row.original.name];
 
-                const copyMethodOptionsMapped = currentPV.supported.copyMethods.map(cm => {
-                  return { value: cm, label: cm };
-                });
-                return (
-                  <Select
-                    onChange={(option) => handleCopyMethodChange(currentPV, option)}
-                    options={
-                      copyMethodOptionsMapped
-                    }
-                    name="copyMethods"
-                    value={{
-                      label: currentCopyMethod ?
-                        currentCopyMethod : 'None',
-                      value: currentCopyMethod ?
-                        currentCopyMethod : '',
-                    }}
-                    placeholder="Select a copy method..."
-                  />
-                );
+                  const copyMethodOptionsMapped = currentPV.supported.copyMethods.map(cm => {
+                    return { value: cm, label: cm };
+                  });
+                  return (
+                    <Select
+                      onChange={option => handleCopyMethodChange(currentPV, option)}
+                      options={copyMethodOptionsMapped}
+                      name="copyMethods"
+                      value={{
+                        label: currentCopyMethod ? currentCopyMethod : 'None',
+                        value: currentCopyMethod ? currentCopyMethod : '',
+                      }}
+                      placeholder="Select a copy method..."
+                    />
+                  );
+                },
               },
-            },
-            {
-              Header: () => (
-                <div
-                  style={{
-                    textAlign: 'left',
-                    fontWeight: 600,
-                  }}
-                >
-                  Storage Class
-                </div>
-              ),
-              accessor: 'storageClass',
-              width: 500,
-              style: { overflow: 'visible' },
-              Cell: row => {
-                const currentStorageClass = pvStorageClassAssignment[row.original.name];
-                const storageClassOptionsWithNone = storageClassOptions.map(sc => {
-                  return { value: sc.name, label: sc.name + ':' + sc.provisioner };
-                });
-                storageClassOptionsWithNone.push({ value: '', label: 'None' });
-                return (
-                  <Select
-                    onChange={(option) => handleStorageClassChange(row, option)}
-                    options={
-                      storageClassOptionsWithNone
-                    }
-                    name="storageClasses"
-                    value={{
-                      label: currentStorageClass ?
-                        currentStorageClass.name + ':' + currentStorageClass.provisioner : 'None',
-                      value: currentStorageClass ?
-                        currentStorageClass.name : '',
+              {
+                Header: () => (
+                  <div
+                    style={{
+                      textAlign: 'left',
+                      fontWeight: 600,
                     }}
-                    placeholder="Select a storage class..."
-                  />
-                );
+                  >
+                    Storage Class
+                  </div>
+                ),
+                accessor: 'storageClass',
+                width: 500,
+                style: { overflow: 'visible' },
+                Cell: row => {
+                  const currentStorageClass = pvStorageClassAssignment[row.original.name];
+                  const storageClassOptionsWithNone = storageClassOptions.map(sc => {
+                    return { value: sc.name, label: sc.name + ':' + sc.provisioner };
+                  });
+                  storageClassOptionsWithNone.push({ value: '', label: 'None' });
+                  return (
+                    <Select
+                      onChange={option => handleStorageClassChange(row, option)}
+                      options={storageClassOptionsWithNone}
+                      name="storageClasses"
+                      value={{
+                        label: currentStorageClass
+                          ? currentStorageClass.name + ':' + currentStorageClass.provisioner
+                          : 'None',
+                        value: currentStorageClass ? currentStorageClass.name : '',
+                      }}
+                      placeholder="Select a storage class..."
+                    />
+                  );
+                },
               },
-            },
-          ]}
-          defaultPageSize={5}
-          className="-striped -highlight"
-        />
-      </React.Fragment>
+            ]}
+            defaultPageSize={5}
+            className="-striped -highlight"
+          />
+        </GridItem>
+      </Grid>
     );
   } else {
     return <div />;

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -144,7 +144,10 @@ const StorageClassTable: React.FunctionComponent<IStorageClassTableProps> = ({
       <Grid gutter="md">
         <GridItem>
           <TextContent>
-            <Text component={TextVariants.p}>Select target storage class for copied PVs</Text>
+            <Text component={TextVariants.p}>
+              For each persistent volume to be copied, select a copy method and target storage
+              class.
+            </Text>
           </TextContent>
         </GridItem>
         <GridItem>

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../../common/components/FilterToolbar';
 import { IPlanPersistentVolume } from './types';
 import { capitalize } from '../../../common/duck/utils';
+import TableEmptyState from '../../../common/components/TableEmptyState';
 
 const styles = require('./VolumesTable.module');
 
@@ -184,17 +185,21 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
             <Pagination widgetId="pv-table-pagination-top" {...paginationProps} />
           </LevelItem>
         </Level>
-        <Table
-          aria-label="Persistent volumes table"
-          variant={TableVariant.compact}
-          cells={columns}
-          rows={rows}
-          sortBy={sortBy}
-          onSort={onSort}
-        >
-          <TableHeader />
-          <TableBody />
-        </Table>
+        {rows.length > 0 ? (
+          <Table
+            aria-label="Persistent volumes table"
+            variant={TableVariant.compact}
+            cells={columns}
+            rows={rows}
+            sortBy={sortBy}
+            onSort={onSort}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        ) : (
+          <TableEmptyState onClearFiltersClick={() => setFilterValues({})} />
+        )}
         <Pagination
           widgetId="pv-table-pagination-bottom"
           variant={PaginationVariant.bottom}

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -105,13 +105,10 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
 
   const rows = currentPageItems.map(pv => {
     const matchingPVResource = pvResourceList.find(pvResource => pvResource.name === pv.name);
-    const migrationTypeOptions = pv.supportedActions.map(
-      (action: string) =>
-        ({
-          value: action,
-          toString: () => capitalize(action),
-        } as OptionWithValue)
-    );
+    const migrationTypeOptions: OptionWithValue[] = pv.supportedActions.map((action: string) => ({
+      value: action,
+      toString: () => capitalize(action),
+    }));
     return {
       cells: [
         pv.name,
@@ -129,7 +126,6 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
               placeholderText={null}
             />
           ),
-          key: pv.type,
         },
         {
           title: (

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -32,6 +32,7 @@ import {
   FilterType,
 } from '../../../common/components/FilterToolbar';
 import { IPlanPersistentVolume } from './types';
+import { capitalize } from '../../../common/duck/utils';
 
 const styles = require('./VolumesTable.module');
 
@@ -44,14 +45,6 @@ interface IVolumesTableProps
 interface OptionWithValue extends SelectOptionObject {
   value: string;
 }
-
-const capitalize = (s: string) => {
-  if (s.charAt(0)) {
-    return `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
-  } else {
-    return s;
-  }
-};
 
 const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
   isFetchingPVResources,
@@ -169,8 +162,6 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
       ],
     };
   });
-
-  // TODO: sorting
 
   return (
     <Grid gutter="md">

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -98,7 +98,10 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     },
   ];
 
-  const { filterValues, setFilterValues, filteredItems } = useFilterState(persistentVolumes);
+  const { filterValues, setFilterValues, filteredItems } = useFilterState(
+    persistentVolumes,
+    filterCategories
+  );
   const { sortBy, onSort, sortedItems } = useSortState(filteredItems, getSortValues);
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
   useEffect(() => setPageNumber(1), [filterValues, sortBy]);

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -163,7 +163,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     <Grid gutter="md">
       <GridItem>
         <TextContent>
-          <Text component={TextVariants.p}>Choose to move or copy persistent volumes:</Text>
+          <Text component={TextVariants.p}>Choose to move or copy persistent volumes</Text>
         </TextContent>
       </GridItem>
       <GridItem>

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -61,7 +61,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     { title: 'Migration type', transforms: [sortable] },
     { title: 'Details' },
   ];
-  const sortKeys = ['name', 'claim', 'project', 'storageClass', 'size', 'type'];
+  const getSortValues = pv => [pv.name, pv.claim, pv.project, pv.storageClass, pv.size, pv.type];
   const filterCategories: FilterCategory[] = [
     {
       key: 'name',
@@ -99,7 +99,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
   ];
 
   const { filterValues, setFilterValues, filteredItems } = useFilterState(persistentVolumes);
-  const { sortBy, onSort, sortedItems } = useSortState(filteredItems, sortKeys);
+  const { sortBy, onSort, sortedItems } = useSortState(filteredItems, getSortValues);
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
   useEffect(() => setPageNumber(1), [filterValues, sortBy]);
 

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -163,7 +163,9 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     <Grid gutter="md">
       <GridItem>
         <TextContent>
-          <Text component={TextVariants.p}>Choose to move or copy persistent volumes</Text>
+          <Text component={TextVariants.p}>
+            Choose to move or copy persistent volumes associated with selected namespaces.
+          </Text>
         </TextContent>
       </GridItem>
       <GridItem>

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -164,7 +164,6 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
           component: (
             <WizardStepContainer title="Storage class">
               <StorageClassForm
-                isEdit={isEdit}
                 values={values}
                 setFieldValue={setFieldValue}
                 currentPlan={currentPlan}
@@ -256,7 +255,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
           isFullWidth
           isCompactNav
           className={styles.wizardModifier}
-          onSubmit={(event) => event.preventDefault()}
+          onSubmit={event => event.preventDefault()}
         />
       )}
     </React.Fragment>

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -160,9 +160,9 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
         },
         {
           id: stepId.StorageClass,
-          name: 'Storage class',
+          name: 'Copy options',
           component: (
-            <WizardStepContainer title="Storage class">
+            <WizardStepContainer title="Copy options">
               <StorageClassForm
                 values={values}
                 setFieldValue={setFieldValue}

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -3,7 +3,7 @@ import { Wizard } from '@patternfly/react-core';
 import GeneralForm from './GeneralForm';
 import ResourceSelectForm from './ResourceSelectForm';
 import VolumesForm from './VolumesForm';
-import StorageClassForm from './StorageClassForm';
+import CopyOptionsForm from './CopyOptionsForm';
 import ResultsStep from './ResultsStep';
 import { PollingContext } from '../../../home/duck/context';
 import { FormikProps } from 'formik';
@@ -163,7 +163,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
           name: 'Copy options',
           component: (
             <WizardStepContainer title="Copy options">
-              <StorageClassForm
+              <CopyOptionsForm
                 values={values}
                 setFieldValue={setFieldValue}
                 currentPlan={currentPlan}

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -4,7 +4,12 @@ import { PlanActions } from '../../duck/actions';
 import planSelectors from '../../duck/selectors';
 import { connect } from 'react-redux';
 import utils from '../../../common/duck/utils';
-import { IPlan, IPlanPersistentVolume, IPersistentVolumeResource, ISourceClusterNamespace } from './types';
+import {
+  IPlan,
+  IPlanPersistentVolume,
+  IPersistentVolumeResource,
+  ISourceClusterNamespace,
+} from './types';
 import { ICurrentPlanStatus } from '../../duck/reducers';
 export interface IFormValues {
   planName: string;
@@ -13,7 +18,15 @@ export interface IFormValues {
   selectedStorage: string;
   selectedNamespaces: string[];
   persistentVolumes: any[]; // TODO replace this with selections-only version after refactor
-  pvStorageClassAssignment: any; 
+  pvStorageClassAssignment: {
+    [key: string]: {
+      name: string;
+      provisioner: string;
+    };
+  };
+  pvCopyMethodAssignment: {
+    [key: string]: string;
+  };
 }
 
 // TODO add more specific types instead of using `any`
@@ -63,7 +76,8 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
       selectedNamespaces: [],
       selectedStorage: null,
       persistentVolumes: [],
-      pvStorageClassAssignment: [],
+      pvStorageClassAssignment: {},
+      pvCopyMethodAssignment: {},
     };
     if (editPlanObj && isEdit) {
       values.planName = editPlanObj.metadata.name || '';

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -9,6 +9,7 @@ import {
   IPlanPersistentVolume,
   IPersistentVolumeResource,
   ISourceClusterNamespace,
+  ICluster,
 } from './types';
 import { ICurrentPlanStatus } from '../../duck/reducers';
 export interface IFormValues {
@@ -31,7 +32,10 @@ export interface IFormValues {
 
 // TODO add more specific types instead of using `any`
 export interface IOtherProps {
-  clusterList: any[];
+  clusterList: {
+    MigCluster: ICluster;
+    [key: string]: any;
+  }[];
   planList: any[];
   storageList: any[];
   isFetchingPVList: boolean;

--- a/src/app/plan/components/Wizard/types.ts
+++ b/src/app/plan/components/Wizard/types.ts
@@ -1,17 +1,18 @@
-// TODO add other properties used by components in this wizard, possibly move this somewhere more common
-// Maybe in the future we can somehow generate types like these from the CRDs in mig-controller?
+// TODO: Add other properties used by components in this wizard, possibly move this somewhere more common
+//       If we remove the `[key: string]: any;` lines, missing property types will surface elsewhere as errors
 
 export interface IPlanPersistentVolume {
   name: string;
   pvc: {
     namespace: string;
     name: string;
-    [key: string]: any; // Allow additional unknown properties on each of these
+    [key: string]: any; // Allow additional unknown properties on each of these for now
   };
   storageClass?: string;
   capacity: string;
   supported: {
     actions: string[];
+    copyMethods: string[];
     [key: string]: any;
   };
   selection?: {
@@ -39,4 +40,21 @@ export interface ISourceClusterNamespace {
   podCount: number;
   pvcCount: number;
   serviceCount: number;
+}
+
+export interface IClusterStorageClass {
+  name: string;
+  provisioner: string;
+}
+
+export interface ICluster {
+  metadata: {
+    name: string;
+    [key: string]: any;
+  };
+  spec: {
+    storageClasses: IClusterStorageClass[];
+    [key: string]: any;
+  };
+  [key: string]: any;
 }

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -1,5 +1,5 @@
-import { pvStorageClassAssignmentKey } from '../../app/plan/components/Wizard/StorageClassForm';
-import { pvCopyMethodAssignmentKey } from '../../app/plan/components/Wizard/StorageClassForm';
+import { pvStorageClassAssignmentKey } from '../../app/plan/components/Wizard/CopyOptionsForm';
+import { pvCopyMethodAssignmentKey } from '../../app/plan/components/Wizard/CopyOptionsForm';
 
 export function createTokenSecret(name: string, namespace: string, rawToken: string, createdForResourceType: string, createdForResource: string) {
   // btoa => to base64, atob => from base64

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -1,5 +1,5 @@
-import { pvStorageClassAssignmentKey } from '../../app/plan/components/Wizard/StorageClassTable';
-import { pvCopyMethodAssignmentKey } from '../../app/plan/components/Wizard/StorageClassTable';
+import { pvStorageClassAssignmentKey } from '../../app/plan/components/Wizard/StorageClassForm';
+import { pvCopyMethodAssignmentKey } from '../../app/plan/components/Wizard/StorageClassForm';
 
 export function createTokenSecret(name: string, namespace: string, rawToken: string, createdForResourceType: string, createdForResource: string) {
   // btoa => to base64, atob => from base64


### PR DESCRIPTION
Closes #587
Closes #773
Fixes #804

This PR renames the StorageClassForm and StorageClassTable to CopyOptionsForm and CopyOptionsTable, to match [Vince's mockups](https://docs.google.com/presentation/d/1hlP8wjzsO_9c9ri2rIz7o2kuIQvmKCNUhoQxTnUkHr0/edit#slide=id.g7f12813776_1_8). It adds Claim and Namespace columns, updates text to match the mockups, and converts the table to PF using the same sorting/filtering/pagination abstractions I wrote in https://github.com/konveyor/mig-ui/pull/776 and https://github.com/konveyor/mig-ui/pull/803.

In the process of rewriting the form and table components, I gave them the same treatment as the last 2 wizard steps (moved non-presentational logic out of the table component, removed redundant state, flattened unnecessary useEffect logic into render logic). While doing this I saw that the condition for setting recommended storage class settings would always be false (#804), so I fixed it in 6782c71 .

Since the copy options and storage class columns have values that don't come directly from the PV object (they perform lookups), I needed to enhance the `useFilterState` and `useSortState` hooks so they can take functions rather than string keys for determining the value to match/sort by. `useFilterState` now takes the `filterCategories` as an argument, and a filter category can optionally have a `getItemValue` function in it (if omitted, the category key will be used as before). The `useSortState` hook takes a `getSortValues` function instead of a `sortKeys` array.

I also changed the filter logic so rows will not match a filter if they have a null/undefined value for the selected field (so that "Target storage class: None" doesn't match every filter) and so that search filters are case insensitive.

This PR does not include the Verify copy column, that will be in a separate PR to address https://github.com/konveyor/mig-ui/issues/788.

# Before
![Screenshot 2020-04-15 19 44 46](https://user-images.githubusercontent.com/811963/79399831-64002b80-7f52-11ea-813d-180113dbca50.png)

# After
<img width="1345" alt="Screenshot 2020-04-16 12 54 51" src="https://user-images.githubusercontent.com/811963/79484520-c18f8900-7fe1-11ea-96b5-7dbc6f78213b.png">
