### PR TITLE
Plan name validation

### DIFF
--- a/src/app/common/duck/utils.ts
+++ b/src/app/common/duck/utils.ts
@@ -2,6 +2,7 @@ import { push } from 'connected-react-router';
 import { AuthActions } from '../../auth/duck/actions';
 
 const DNS1123Validator = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+const NameValidator = /^[a-z0-9]([a-z0-9]*\-?[a-z0-9])*[a-z0-9]?$/;
 const URLValidator =
   /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
 
@@ -35,21 +36,28 @@ export const handleSelfSignedCertError = (failedUrl: string, dispatch: any) => {
   dispatch(push('/cert-error'));
 };
 
-
 const DNS1123Error = value => {
   return `Invalid value: "${value}" for a DNS-1123 subdomain with regex' +
     '"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"`;
 };
 
+const nameError = (value) => {
+  return `Invalid name: "${value}" must start and end with an alphanumeric character and can contain '-'`;
+};
+
 const testDNS1123 = value => DNS1123Validator.test(value);
+
+const testName = value => NameValidator.test(value);
 
 const testURL = value => URLValidator.test(value) || IPValidator(value);
 
 export default {
-  testDNS1123,
   DNS1123Error,
+  nameError,
   isSelfSignedCertError,
   isTimeoutError,
   handleSelfSignedCertError,
+  testDNS1123,
+  testName,
   testURL,
 };

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -13,7 +13,7 @@ export interface IFormValues {
   selectedStorage: string;
   selectedNamespaces: string[];
   persistentVolumes: any[]; // TODO replace this with selections-only version after refactor
-  pvStorageClassAssignment: any; 
+  pvStorageClassAssignment: any;
 }
 
 // TODO add more specific types instead of using `any`
@@ -84,8 +84,8 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
 
     if (!values.planName) {
       errors.planName = 'Required';
-    } else if (!utils.testDNS1123(values.planName)) {
-      errors.planName = utils.DNS1123Error(values.planName);
+    } else if (!utils.testName(values.planName)) {
+      errors.planName = utils.nameError(values.planName);
     }
     if (!values.sourceCluster) {
       errors.sourceCluster = 'Required';


### PR DESCRIPTION
* Adds testName and nameError to utils
* Validate Plan name (Wizard) using testName

A Plan name is not a DNS name and can't allow double dashes.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1823830