### PR TITLE
Add "Verify copy" checkbox column to copy options table

### DIFF
--- a/src/app/plan/components/Wizard/CopyOptionsForm.tsx
+++ b/src/app/plan/components/Wizard/CopyOptionsForm.tsx
@@ -5,10 +5,6 @@ import { IFormValues, IOtherProps } from './WizardContainer';
 import CopyOptionsTable from './CopyOptionsTable';
 import { IPlanPersistentVolume } from './types';
 
-export const pvStorageClassAssignmentKey = 'pvStorageClassAssignment';
-export const pvCopyMethodAssignmentKey = 'pvCopyMethodAssignment';
-export const pvVerifyFlagAssignmentKey = 'pvVerifyFlagAssignment';
-
 interface ICopyOptionsFormProps
   extends Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isFetchingPVList'>,
     Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
@@ -43,7 +39,7 @@ const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
           };
         }, {});
       }
-      setFieldValue(pvStorageClassAssignmentKey, pvStorageClassAssignment);
+      setFieldValue('pvStorageClassAssignment', pvStorageClassAssignment);
     }
     if (!values.pvCopyMethodAssignment || isEmpty(values.pvCopyMethodAssignment)) {
       let pvCopyMethodAssignment = {};
@@ -59,7 +55,7 @@ const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
           };
         }, {});
       }
-      setFieldValue(pvCopyMethodAssignmentKey, pvCopyMethodAssignment);
+      setFieldValue('pvCopyMethodAssignment', pvCopyMethodAssignment);
     }
     if (!values.pvVerifyFlagAssignment || isEmpty(values.pvVerifyFlagAssignment)) {
       let pvVerifyFlagAssignment = {};
@@ -72,7 +68,7 @@ const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
           {}
         );
       }
-      setFieldValue(pvVerifyFlagAssignmentKey, pvVerifyFlagAssignment);
+      setFieldValue('pvVerifyFlagAssignment', pvVerifyFlagAssignment);
     }
   }, []);
 
@@ -82,7 +78,7 @@ const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
       ...values.pvStorageClassAssignment,
       [currentPV.name]: newSc,
     };
-    setFieldValue(pvStorageClassAssignmentKey, updatedAssignment);
+    setFieldValue('pvStorageClassAssignment', updatedAssignment);
   };
 
   const onVerifyFlagChange = (currentPV: IPlanPersistentVolume, value: boolean) => {
@@ -90,7 +86,7 @@ const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
       ...values.pvVerifyFlagAssignment,
       [currentPV.name]: value,
     };
-    setFieldValue(pvVerifyFlagAssignmentKey, updatedAssignment);
+    setFieldValue('pvVerifyFlagAssignment', updatedAssignment);
   };
 
   const onCopyMethodChange = (currentPV: IPlanPersistentVolume, value: string) => {
@@ -99,7 +95,7 @@ const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
       ...values.pvCopyMethodAssignment,
       [currentPV.name]: newCm,
     };
-    setFieldValue(pvCopyMethodAssignmentKey, updatedAssignment);
+    setFieldValue('pvCopyMethodAssignment', updatedAssignment);
   };
 
   return (

--- a/src/app/plan/components/Wizard/CopyOptionsTable.tsx
+++ b/src/app/plan/components/Wizard/CopyOptionsTable.tsx
@@ -17,9 +17,11 @@ import {
   SelectOptionObject,
   Checkbox,
   Flex,
+  Tooltip,
+  TooltipPosition,
 } from '@patternfly/react-core';
 import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { InfoCircleIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import { useFilterState, useSortState, usePaginationState } from '../../../common/duck/hooks';
@@ -97,11 +99,22 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
     {
       title: (
         <React.Fragment>
-          Verify copy
-          <em>(?)</em>
+          Verify copy{' '}
+          <Tooltip
+            position={TooltipPosition.top}
+            isContentLeftAligned
+            content={
+              <div>
+                Checksum verification is available for PVs that will be copied using a filesystem
+                copy method. Note that selecting this option will greatly reduce the copy
+                performance. See the product documentation for more information.
+              </div>
+            }
+          >
+            <QuestionCircleIcon />
+          </Tooltip>
         </React.Fragment>
       ),
-      transforms: [sortable],
     },
     { title: 'Target storage class', transforms: [sortable] },
   ];

--- a/src/app/plan/components/Wizard/CopyOptionsTable.tsx
+++ b/src/app/plan/components/Wizard/CopyOptionsTable.tsx
@@ -26,7 +26,7 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import { useFilterState, useSortState, usePaginationState } from '../../../common/duck/hooks';
 import { IFormValues, IOtherProps } from './WizardContainer';
-import { IPlanPersistentVolume, IClusterStorageClass } from './types';
+import { IPlanPersistentVolume, IClusterStorageClass, PvCopyMethod } from './types';
 import { capitalize } from '../../../common/duck/utils';
 import SimpleSelect from '../../../common/components/SimpleSelect';
 import {
@@ -58,7 +58,7 @@ interface OptionWithValue extends SelectOptionObject {
 const storageClassToString = (storageClass: IClusterStorageClass) =>
   storageClass && `${storageClass.name}:${storageClass.provisioner}`;
 
-const copyMethodToString = (copyMethod: string) => {
+const copyMethodToString = (copyMethod: PvCopyMethod) => {
   if (copyMethod === 'filesystem') return 'Filesystem copy';
   if (copyMethod === 'snapshot') return 'Volume snapshot';
   return copyMethod && capitalize(copyMethod);
@@ -177,7 +177,7 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
     const currentStorageClass = pvStorageClassAssignment[pv.name];
 
     const copyMethodOptions: OptionWithValue[] = currentPV.supported.copyMethods.map(
-      (copyMethod: string) => ({
+      (copyMethod: PvCopyMethod) => ({
         value: copyMethod,
         toString: () => copyMethodToString(copyMethod),
       })
@@ -191,6 +191,8 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
       })),
       noneOption,
     ];
+
+    const isVerifyCopyAllowed = pvCopyMethodAssignment[pv.name] === 'filesystem';
 
     return {
       cells: [
@@ -212,7 +214,8 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
           title: (
             <Flex className={flex.justifyContentCenter}>
               <Checkbox
-                isChecked={pvVerifyFlagAssignment[pv.name]}
+                isChecked={isVerifyCopyAllowed && pvVerifyFlagAssignment[pv.name]}
+                isDisabled={!isVerifyCopyAllowed}
                 onChange={checked => onVerifyFlagChange(currentPV, checked)}
                 aria-label={`Verify copy for PV ${pv.name}`}
                 id={`verify-pv-${pv.name}`}

--- a/src/app/plan/components/Wizard/CopyOptionsTable.tsx
+++ b/src/app/plan/components/Wizard/CopyOptionsTable.tsx
@@ -15,10 +15,13 @@ import {
   Pagination,
   PaginationVariant,
   SelectOptionObject,
+  Checkbox,
+  Flex,
 } from '@patternfly/react-core';
 import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import { useFilterState, useSortState, usePaginationState } from '../../../common/duck/hooks';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import { IPlanPersistentVolume, IClusterStorageClass } from './types';
@@ -33,9 +36,16 @@ import TableEmptyState from '../../../common/components/TableEmptyState';
 
 interface ICopyOptionsTableProps
   extends Pick<IOtherProps, 'isFetchingPVList' | 'currentPlan'>,
-    Pick<IFormValues, 'persistentVolumes' | 'pvStorageClassAssignment' | 'pvCopyMethodAssignment'> {
+    Pick<
+      IFormValues,
+      | 'persistentVolumes'
+      | 'pvStorageClassAssignment'
+      | 'pvVerifyFlagAssignment'
+      | 'pvCopyMethodAssignment'
+    > {
   storageClasses: IClusterStorageClass[];
   onStorageClassChange: (currentPV: IPlanPersistentVolume, value: string) => void;
+  onVerifyFlagChange: (currentPV: IPlanPersistentVolume, value: boolean) => void;
   onCopyMethodChange: (currentPV: IPlanPersistentVolume, value: string) => void;
 }
 
@@ -57,9 +67,11 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
   currentPlan,
   persistentVolumes,
   pvStorageClassAssignment,
+  pvVerifyFlagAssignment,
   pvCopyMethodAssignment,
   storageClasses,
   onStorageClassChange,
+  onVerifyFlagChange,
   onCopyMethodChange,
 }: ICopyOptionsTableProps) => {
   if (isFetchingPVList) {
@@ -82,6 +94,15 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
     { title: 'Claim', transforms: [sortable] },
     { title: 'Namespace', transforms: [sortable] },
     { title: 'Copy method', transforms: [sortable] },
+    {
+      title: (
+        <React.Fragment>
+          Verify copy
+          <em>(?)</em>
+        </React.Fragment>
+      ),
+      transforms: [sortable],
+    },
     { title: 'Target storage class', transforms: [sortable] },
   ];
   const getSortValues = pv => [
@@ -89,6 +110,7 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
     pv.claim,
     pv.project,
     copyMethodToString(pvCopyMethodAssignment[pv.name]),
+    pvVerifyFlagAssignment[pv.name],
     storageClassToString(pvStorageClassAssignment[pv.name]),
   ];
   const filterCategories: FilterCategory[] = [
@@ -171,6 +193,19 @@ const CopyOptionsTable: React.FunctionComponent<ICopyOptionsTableProps> = ({
               value={copyMethodOptions.find(option => option.value === currentCopyMethod)}
               placeholderText="Select a copy method..."
             />
+          ),
+        },
+        {
+          title: (
+            <Flex className={flex.justifyContentCenter}>
+              <Checkbox
+                isChecked={pvVerifyFlagAssignment[pv.name]}
+                onChange={checked => onVerifyFlagChange(currentPV, checked)}
+                aria-label={`Verify copy for PV ${pv.name}`}
+                id={`verify-pv-${pv.name}`}
+                name={`verify-pv-${pv.name}`}
+              />
+            </Flex>
           ),
         },
         {

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -20,13 +20,16 @@ export interface IFormValues {
   selectedNamespaces: string[];
   persistentVolumes: any[]; // TODO replace this with selections-only version after refactor
   pvStorageClassAssignment: {
-    [key: string]: {
+    [pvName: string]: {
       name: string;
       provisioner: string;
     };
   };
+  pvVerifyFlagAssignment: {
+    [pvName: string]: boolean;
+  };
   pvCopyMethodAssignment: {
-    [key: string]: string;
+    [pvName: string]: string;
   };
 }
 
@@ -81,6 +84,7 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
       selectedStorage: null,
       persistentVolumes: [],
       pvStorageClassAssignment: {},
+      pvVerifyFlagAssignment: {},
       pvCopyMethodAssignment: {},
     };
     if (editPlanObj && isEdit) {

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -10,6 +10,7 @@ import {
   IPersistentVolumeResource,
   ISourceClusterNamespace,
   ICluster,
+  PvCopyMethod,
 } from './types';
 import { ICurrentPlanStatus } from '../../duck/reducers';
 export interface IFormValues {
@@ -29,7 +30,7 @@ export interface IFormValues {
     [pvName: string]: boolean;
   };
   pvCopyMethodAssignment: {
-    [pvName: string]: string;
+    [pvName: string]: PvCopyMethod;
   };
 }
 

--- a/src/app/plan/components/Wizard/types.ts
+++ b/src/app/plan/components/Wizard/types.ts
@@ -1,6 +1,8 @@
 // TODO: Add other properties used by components in this wizard, possibly move this somewhere more common
 //       If we remove the `[key: string]: any;` lines, missing property types will surface elsewhere as errors
 
+export type PvCopyMethod = 'filesystem' | 'snapshot';
+
 export interface IPlanPersistentVolume {
   name: string;
   pvc: {
@@ -12,13 +14,13 @@ export interface IPlanPersistentVolume {
   capacity: string;
   supported: {
     actions: string[];
-    copyMethods: string[];
+    copyMethods: PvCopyMethod[];
     [key: string]: any;
   };
   selection?: {
     action: string;
     storageClass: string;
-    copyMethod: string;
+    copyMethod: PvCopyMethod;
     verify: boolean;
     [key: string]: any;
   };

--- a/src/app/plan/components/Wizard/types.ts
+++ b/src/app/plan/components/Wizard/types.ts
@@ -17,14 +17,30 @@ export interface IPlanPersistentVolume {
   };
   selection?: {
     action: string;
+    storageClass: string;
+    copyMethod: string;
+    verify: boolean;
     [key: string]: any;
   };
   [key: string]: any;
 }
 
+export interface INameNamespaceRef {
+  name: string;
+  namespace: string;
+}
+
 export interface IPlan {
+  apiVersion: string;
+  kind: string;
+  metadata: INameNamespaceRef;
   spec: {
     persistentVolumes?: IPlanPersistentVolume[];
+    migStorageRef?: INameNamespaceRef;
+    srcMigClusterRef?: INameNamespaceRef;
+    destMigClusterRef?: INameNamespaceRef;
+    namespaces?: string[];
+    closed?: boolean;
     [key: string]: any;
   };
   [key: string]: any;

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -1,5 +1,7 @@
-import { pvStorageClassAssignmentKey } from '../../app/plan/components/Wizard/CopyOptionsForm';
+import { pvStorageClassAssignmentKey, pvVerifyFlagAssignmentKey } from '../../app/plan/components/Wizard/CopyOptionsForm';
 import { pvCopyMethodAssignmentKey } from '../../app/plan/components/Wizard/CopyOptionsForm';
+import { IPlan } from '../../app/plan/components/Wizard/types';
+import { IFormValues } from '../../app/plan/components/Wizard/WizardContainer';
 
 export function createTokenSecret(name: string, namespace: string, rawToken: string, createdForResourceType: string, createdForResource: string) {
   // btoa => to base64, atob => from base64
@@ -382,7 +384,15 @@ export function createMigPlan(
   };
 }
 
-export function updateMigPlanFromValues(migPlan: any, planValues: any, isRerunPVDiscovery) {
+interface IPlanValues extends IFormValues {
+  planClosed?: boolean;
+}
+
+export function updateMigPlanFromValues(
+  migPlan: IPlan,
+  planValues: IPlanValues,
+  isRerunPVDiscovery: boolean
+) {
   const updatedSpec = Object.assign({}, migPlan.spec);
   if (planValues.selectedStorage) {
     updatedSpec.migStorageRef = {
@@ -415,6 +425,8 @@ export function updateMigPlanFromValues(migPlan: any, planValues: any, isRerunPV
           if (selectedCopyMethodObj) {
             v.selection.copyMethod = selectedCopyMethodObj;
           }
+
+          v.selection.verify = planValues.pvVerifyFlagAssignment[v.name];
 
           const selectedStorageClassObj = planValues[pvStorageClassAssignmentKey][v.name];
           if (selectedStorageClassObj) {

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -1,5 +1,3 @@
-import { pvStorageClassAssignmentKey, pvVerifyFlagAssignmentKey } from '../../app/plan/components/Wizard/CopyOptionsForm';
-import { pvCopyMethodAssignmentKey } from '../../app/plan/components/Wizard/CopyOptionsForm';
 import { IPlan } from '../../app/plan/components/Wizard/types';
 import { IFormValues } from '../../app/plan/components/Wizard/WizardContainer';
 
@@ -421,14 +419,14 @@ export function updateMigPlanFromValues(
         const userPv = planValues.persistentVolumes.find(upv => upv.name === v.name);
         if (userPv) {
           v.selection.action = userPv.type;
-          const selectedCopyMethodObj = planValues[pvCopyMethodAssignmentKey][v.name];
+          const selectedCopyMethodObj = planValues.pvCopyMethodAssignment[v.name];
           if (selectedCopyMethodObj) {
             v.selection.copyMethod = selectedCopyMethodObj;
           }
 
           v.selection.verify = planValues.pvVerifyFlagAssignment[v.name];
 
-          const selectedStorageClassObj = planValues[pvStorageClassAssignmentKey][v.name];
+          const selectedStorageClassObj = planValues.pvStorageClassAssignment[v.name];
           if (selectedStorageClassObj) {
             v.selection.storageClass = selectedStorageClassObj.name;
           } else {

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -419,12 +419,12 @@ export function updateMigPlanFromValues(
         const userPv = planValues.persistentVolumes.find(upv => upv.name === v.name);
         if (userPv) {
           v.selection.action = userPv.type;
-          const selectedCopyMethodObj = planValues.pvCopyMethodAssignment[v.name];
-          if (selectedCopyMethodObj) {
-            v.selection.copyMethod = selectedCopyMethodObj;
+          const selectedCopyMethod = planValues.pvCopyMethodAssignment[v.name];
+          if (selectedCopyMethod) {
+            v.selection.copyMethod = selectedCopyMethod;
           }
 
-          v.selection.verify = planValues.pvVerifyFlagAssignment[v.name];
+          v.selection.verify = selectedCopyMethod === 'filesystem' && planValues.pvVerifyFlagAssignment[v.name];
 
           const selectedStorageClassObj = planValues.pvStorageClassAssignment[v.name];
           if (selectedStorageClassObj) {


### PR DESCRIPTION
Closes https://github.com/konveyor/mig-ui/issues/788

This PR adds the "verify copy" column to the copy options table, which contains checkboxes for toggling the `selection.verify` flag on a PV object in a migplan (as introduced here: https://github.com/konveyor/mig-controller/pull/467/files#diff-b5bf739091eb4324846f3710ba26941eR69-R70). The checkbox will only be enabled for a row if "filesystem copy" is selected for that row's copy method. There is an info icon with a tooltip in the column header to explain it.

![Screenshot 2020-04-16 18 19 20](https://user-images.githubusercontent.com/811963/79512145-d0d8fb80-800e-11ea-9e93-c7e70271cdf7.png)

![Screenshot 2020-04-16 18 19 30](https://user-images.githubusercontent.com/811963/79512150-d33b5580-800e-11ea-9f70-bd18ea7f111e.png)
