### PR TITLE
Plan Wizard: Give focus to plan name

### DIFF
--- a/src/app/plan/components/Wizard/GeneralForm.tsx
+++ b/src/app/plan/components/Wizard/GeneralForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { FormikProps, FormikActions, FormikState } from 'formik';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import { Form, FormGroup, Grid, GridItem, TextInput } from '@patternfly/react-core';
@@ -24,9 +24,14 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   touched,
   values,
 }: IGeneralFormProps) => {
+  const inputRef = useRef(null);
   const onHandleChange = (val, e) => {
     handleChange(e);
   };
+
+  useEffect(() => {
+    inputRef.current.focus();
+  });
 
   return (
     <Form>
@@ -43,6 +48,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
 
             <TextInput
+              ref={inputRef}
               onChange={(val, e) => onHandleChange(val, e)}
               onInput={() => setFieldTouched('planName', true, true)}
               onBlur={handleBlur}

--- a/src/app/plan/components/Wizard/GeneralForm.tsx
+++ b/src/app/plan/components/Wizard/GeneralForm.tsx
@@ -31,7 +31,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
 
   useEffect(() => {
     inputRef.current.focus();
-  });
+  }, []);
 
   return (
     <Form>


### PR DESCRIPTION
Provides autofocus to input field after rendering using `useRef`.