### PR TITLE
Update DNS1123 error message to be object-agnostic

### DIFF
--- a/src/app/common/duck/utils.ts
+++ b/src/app/common/duck/utils.ts
@@ -40,9 +40,9 @@ export const handleSelfSignedCertError = (failedUrl: string, dispatch: any) => {
 };
 
 const DNS1123Error = (value) => {
-  return `Invalid character: "${value}". Plan names must be DNS-1123 label compliant, starting and
-    ending with a lowercase alphanumeric character and containing only lowercase alphanumeric
-    characters, "." or "-".`;
+  return `Invalid character: "${value}". Name must be DNS-1123 label compliant, starting and ending
+    with a lowercase alphanumeric character and containing only lowercase alphanumeric characters, "."
+    or "-".`;
 };
 
 const testDNS1123 = (value) => DNS1123Validator.test(value);


### PR DESCRIPTION
Error message must be generic as it's used by several components

![invalid-plan](https://user-images.githubusercontent.com/1901741/80527052-0d541200-8994-11ea-9778-1d7c843bc755.png)
