### PR TITLE
Hooks edit fix: fixes typo causing service account/namespace to be cleared

### DIFF
--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -588,7 +588,7 @@ export function updateMigHook(
       ? migHook.srcServiceAccountName
       : currentServiceAccount;
   }
-  if (migHook.clusterType === HooksClusterType.Source) {
+  if (migHook.clusterType === HooksClusterType.Destination) {
     executionNamespaceUpdated = migHook.destServiceAccountNamespace !== currentExecutionNamespace;
     executionNamespaceValue = executionNamespaceUpdated
       ? migHook.destServiceAccountNamespace


### PR DESCRIPTION
Closes https://bugzilla.redhat.com/show_bug.cgi?id=1829494