### PR TITLE
Use generateName for MigStorage Secrets

### DIFF
--- a/src/app/storage/duck/sagas.ts
+++ b/src/app/storage/duck/sagas.ts
@@ -160,14 +160,14 @@ function* addStorageRequest(action) {
     const alreadyExists = getResults.reduce((exists, res) => {
       return res && res.status === 200
         ? [
-            ...exists, 
-            { 
-              kind: res.value.data.kind, 
-              name: 
+            ...exists,
+            {
+              kind: res.value.data.kind,
+              name:
                 res.value.data.items && res.value.data.items.length > 0
-                ? res.value.data.items[0].metadata.name
-                : res.value.data.metadata.name
-            }
+                  ? res.value.data.items[0].metadata.name
+                  : res.value.data.metadata.name,
+            },
           ]
         : exists;
     }, []);
@@ -198,14 +198,14 @@ function* addStorageRequest(action) {
 
     if (storageSecretAddResult.status === 201) {
       storageAddResults.push(storageSecretAddResult);
-      
+
       Object.assign(migStorage.spec.backupStorageConfig.credsSecretRef, {
-        name: storageSecretAddResult.data.metadata.name, 
+        name: storageSecretAddResult.data.metadata.name,
         namespace: storageSecretAddResult.data.metadata.namespace,
       });
 
       Object.assign(migStorage.spec.volumeSnapshotConfig.credsSecretRef, {
-        name: storageSecretAddResult.data.metadata.name, 
+        name: storageSecretAddResult.data.metadata.name,
         namespace: storageSecretAddResult.data.metadata.namespace,
       });
 
@@ -426,7 +426,13 @@ function* updateStorageRequest(action) {
     );
 
     // Pushing a request fn to delay the call until its yielded in a batch at same time
-    updatePromises.push(() => client.patch(secretResource, currentStorage.MigStorage.spec.backupStorageConfig.credsSecretRef.name, updatedSecret));
+    updatePromises.push(() =>
+      client.patch(
+        secretResource,
+        currentStorage.MigStorage.spec.backupStorageConfig.credsSecretRef.name,
+        updatedSecret
+      )
+    );
   }
 
   try {

--- a/src/app/storage/duck/sagas.ts
+++ b/src/app/storage/duck/sagas.ts
@@ -172,8 +172,6 @@ function* addStorageRequest(action) {
         : exists;
     }, []);
 
-    console.log(alreadyExists);
-
     if (alreadyExists.length > 0) {
       throw new Error(
         alreadyExists.reduce((msg, v) => {

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -4,6 +4,7 @@ import {
   HooksImageType,
 } from '../../app/home/pages/PlansPage/components/Wizard/HooksFormComponent';
 import { IMigPlan } from '../../app/plan/duck/types';
+import { MigResourceKind } from './mig';
 
 export function createTokenSecret(
   name: string,
@@ -292,6 +293,10 @@ export function createStorageSecret(
         metadata: {
           generateName: `${name}-`,
           namespace,
+          labels: {
+            createdForResourceType: MigResourceKind.MigStorage,
+            createdForResource: `${name}`,
+          },
         },
         type: 'Opaque',
       };
@@ -307,6 +312,10 @@ export function createStorageSecret(
         metadata: {
           generateName: `${name}-`,
           namespace,
+          labels: {
+            createdForResourceType: MigResourceKind.MigStorage,
+            createdForResource: `${name}`,
+          },
         },
         type: 'Opaque',
       };
@@ -322,6 +331,10 @@ export function createStorageSecret(
         metadata: {
           generateName: `${name}-`,
           namespace,
+          labels: {
+            createdForResourceType: MigResourceKind.MigStorage,
+            createdForResource: `${name}`,
+          },
         },
         type: 'Opaque',
       };

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -4,7 +4,6 @@ import {
   HooksImageType,
 } from '../../app/home/pages/PlansPage/components/Wizard/HooksFormComponent';
 import { IMigPlan } from '../../app/plan/duck/types';
-import { MigResourceKind } from './mig';
 
 export function createTokenSecret(
   name: string,

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -293,10 +293,6 @@ export function createStorageSecret(
         metadata: {
           generateName: `${name}-`,
           namespace,
-          labels: {
-            createdForResourceType: MigResourceKind.MigStorage,
-            createdForResource: `${name}`,
-          },
         },
         type: 'Opaque',
       };
@@ -312,10 +308,6 @@ export function createStorageSecret(
         metadata: {
           generateName: `${name}-`,
           namespace,
-          labels: {
-            createdForResourceType: MigResourceKind.MigStorage,
-            createdForResource: `${name}`,
-          },
         },
         type: 'Opaque',
       };
@@ -331,10 +323,6 @@ export function createStorageSecret(
         metadata: {
           generateName: `${name}-`,
           namespace,
-          labels: {
-            createdForResourceType: MigResourceKind.MigStorage,
-            createdForResource: `${name}`,
-          },
         },
         type: 'Opaque',
       };

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -290,7 +290,7 @@ export function createStorageSecret(
         },
         kind: 'Secret',
         metadata: {
-          name,
+          generateName: `${name}-`,
           namespace,
         },
         type: 'Opaque',
@@ -305,7 +305,7 @@ export function createStorageSecret(
         },
         kind: 'Secret',
         metadata: {
-          name,
+          generateName: `${name}-`,
           namespace,
         },
         type: 'Opaque',
@@ -320,7 +320,7 @@ export function createStorageSecret(
         },
         kind: 'Secret',
         metadata: {
-          name,
+          generateName: `${name}-`,
           namespace,
         },
         type: 'Opaque',


### PR DESCRIPTION
Fixes #908 

Uses `generateName` instead of `name` for Secret referenced by MigStorage.



