### PR TITLE
Adds initial support to connect to token backend

### DIFF
--- a/src/app/AppComponent.tsx
+++ b/src/app/AppComponent.tsx
@@ -12,10 +12,12 @@ import { PollingContext } from './home/duck/context';
 import { StatusPollingInterval } from './common/duck/sagas';
 import { clusterSagas } from './cluster/duck';
 import { storageSagas } from './storage/duck';
+import { planSagas } from './plan/duck';
+import { tokenSagas } from './token/duck';
 import { ClusterActions } from './cluster/duck/actions';
 import { StorageActions } from './storage/duck/actions';
 import { PlanActions } from './plan/duck/actions';
-import planSagas from './plan/duck/sagas';
+import { TokenActions } from './token/duck/actions';
 import AlertModal from './common/components/AlertModal';
 import ErrorModal from './common/components/ErrorModal';
 import { ICluster } from './cluster/duck/types';
@@ -33,9 +35,12 @@ interface IProps {
   stopStoragePolling: () => void;
   startClusterPolling: (params) => void;
   stopClusterPolling: () => void;
+  startTokenPolling: (params) => void;
+  stopTokenPolling: () => void;
   updateClusters: (updatedClusters) => void;
   updateStorages: (updatedStorages) => void;
   updatePlans: (updatedPlans) => void;
+  updateTokens: (updatedTokens) => void;
   clusterList: ICluster[];
 }
 
@@ -52,9 +57,12 @@ const AppComponent: React.SFC<IProps> = ({
   stopStoragePolling,
   startClusterPolling,
   stopClusterPolling,
+  startTokenPolling,
+  stopTokenPolling,
   updateClusters,
   updateStorages,
   updatePlans,
+  updateTokens,
   clusterList,
 }) => {
   const handlePlanPoll = (response) => {
@@ -76,6 +84,14 @@ const AppComponent: React.SFC<IProps> = ({
   const handleStoragePoll = (response) => {
     if (response) {
       updateStorages(response.updatedStorages);
+      return true;
+    }
+    return false;
+  };
+
+  const handleTokenPoll = (response) => {
+    if (response) {
+      updateTokens(response.updatedTokens);
       return true;
     }
     return false;
@@ -120,6 +136,19 @@ const AppComponent: React.SFC<IProps> = ({
     startStoragePolling(storagePollParams);
   };
 
+  const startDefaultTokenPolling = () => {
+    const tokenPollParams = {
+      asyncFetch: tokenSagas.fetchTokensGenerator,
+      callback: handleTokenPoll,
+      delay: StatusPollingInterval,
+      retryOnFailure: true,
+      retryAfter: 5,
+      stopAfterRetries: 2,
+      pollName: 'token',
+    };
+    startTokenPolling(tokenPollParams);
+  };
+
   return (
     <React.Fragment>
       <AlertModal alertMessage={progressMessage} alertType="info" />
@@ -131,18 +160,22 @@ const AppComponent: React.SFC<IProps> = ({
           startDefaultClusterPolling: () => startDefaultClusterPolling(),
           startDefaultStoragePolling: () => startDefaultStoragePolling(),
           startDefaultPlanPolling: () => startDefaultPlanPolling(),
+          startDefaultTokenPolling: () => startDefaultTokenPolling(),
           stopClusterPolling: () => stopClusterPolling(),
           stopStoragePolling: () => stopStoragePolling(),
           stopPlanPolling: () => stopPlanPolling(),
+          stopTokenPolling: () => stopTokenPolling(),
           startAllDefaultPolling: () => {
             startDefaultClusterPolling();
             startDefaultStoragePolling();
             startDefaultPlanPolling();
+            startDefaultTokenPolling();
           },
           stopAllPolling: () => {
             stopClusterPolling();
             stopStoragePolling();
             stopPlanPolling();
+            stopTokenPolling();
           },
         }}
       >
@@ -183,8 +216,11 @@ export default connect(
     stopStoragePolling: () => dispatch(StorageActions.stopStoragePolling()),
     startClusterPolling: (params) => dispatch(ClusterActions.startClusterPolling(params)),
     stopClusterPolling: () => dispatch(ClusterActions.stopClusterPolling()),
+    startTokenPolling: (params) => dispatch(TokenActions.startTokenPolling(params)),
+    stopTokenPolling: () => dispatch(TokenActions.stopTokenPolling()),
     updateClusters: (updatedClusters) => dispatch(ClusterActions.updateClusters(updatedClusters)),
     updateStorages: (updatedStorages) => dispatch(StorageActions.updateStorages(updatedStorages)),
     updatePlans: (updatedPlans) => dispatch(PlanActions.updatePlans(updatedPlans)),
+    updateTokens: (updatedTokens) => dispatch(TokenActions.updateTokens(updatedTokens)),
   })
 )(AppComponent);

--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -4,7 +4,7 @@ import { IClusterClient } from '../../../client/client';
 import { MigResource, MigResourceKind } from '../../../client/resources';
 import { CoreNamespacedResource, CoreNamespacedResourceKind } from '../../../client/resources';
 import {
-  createTokenSecret,
+  createMigClusterSecret,
   createMigCluster,
   updateTokenSecret,
   getTokenSecretLabelSelector,
@@ -116,7 +116,7 @@ function* addClusterRequest(action) {
   const { clusterValues } = action;
   const client: IClusterClient = ClientFactory.cluster(state);
 
-  const tokenSecret = createTokenSecret(
+  const tokenSecret = createMigClusterSecret(
     clusterValues.name,
     migMeta.configNamespace,
     clusterValues.token,

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenForm.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenForm.tsx
@@ -22,11 +22,7 @@ import {
 import SimpleSelect from '../SimpleSelect';
 import utils from '../../duck/utils';
 import { ICluster } from '../../../cluster/duck/types';
-import {
-  ITokenFormValues,
-  TokenFieldKey,
-  TokenType,
- } from '../../../token/duck/types';
+import { ITokenFormValues, TokenFieldKey, TokenType } from '../../../token/duck/types';
 
 interface IOtherProps {
   addEditStatus: IAddEditStatus;

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenForm.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenForm.tsx
@@ -21,29 +21,17 @@ import {
 } from '../../add_edit_state';
 import SimpleSelect from '../SimpleSelect';
 import utils from '../../duck/utils';
-
-enum FieldKey {
-  name = 'name',
-  associatedClusterName = 'associatedClusterName',
-  tokenType = 'tokenType',
-  serviceAccountToken = 'serviceAccountToken',
-}
-
-enum TokenType {
-  oAuth = 'oAuth',
-  serviceAccount = 'serviceAccount',
-}
-
-interface ITokenFormValues {
-  [FieldKey.name]: string;
-  [FieldKey.associatedClusterName]: string;
-  [FieldKey.tokenType]: TokenType;
-  [FieldKey.serviceAccountToken]: string;
-}
+import { ICluster } from '../../../cluster/duck/types';
+import {
+  ITokenFormValues,
+  TokenFieldKey,
+  TokenType,
+ } from '../../../token/duck/types';
 
 interface IOtherProps {
   addEditStatus: IAddEditStatus;
   onAddEditSubmit: (values: ITokenFormValues) => void;
+  clusterList: ICluster[];
   onClose: () => void;
 }
 
@@ -60,9 +48,10 @@ const InnerAddEditTokenForm: React.FunctionComponent<
   setFieldTouched,
   setFieldValue,
   onClose,
+  clusterList,
 }: IOtherProps & FormikProps<ITokenFormValues>) => {
   const formikHandleChange = (_val, e) => handleChange(e);
-  const formikSetFieldTouched = (key: FieldKey) => () => setFieldTouched(key, true, true);
+  const formikSetFieldTouched = (key: TokenFieldKey) => () => setFieldTouched(key, true, true);
 
   const [oAuthResponseCode, setOAuthResponseCode] = useState<string>(null);
   const loginAttemptIdRef = useRef<string>();
@@ -97,23 +86,25 @@ const InnerAddEditTokenForm: React.FunctionComponent<
     return () => window.removeEventListener('storage', handleStorageChanged);
   }, []);
 
+  const clusterNames = clusterList.map((c) => c.MigCluster.metadata.name);
+
   return (
     <Form onSubmit={handleSubmit}>
       <FormGroup
         label="Name"
         isRequired
-        fieldId={FieldKey.name}
+        fieldId={TokenFieldKey.Name}
         helperTextInvalid={touched.name && errors.name}
         isValid={!(touched.name && errors.name)}
       >
         <TextInput
           onChange={formikHandleChange}
-          onInput={formikSetFieldTouched(FieldKey.name)}
+          onInput={formikSetFieldTouched(TokenFieldKey.Name)}
           onBlur={handleBlur}
           value={values.name}
-          name={FieldKey.name}
+          name={TokenFieldKey.Name}
           type="text"
-          id={FieldKey.name}
+          id={TokenFieldKey.Name}
           isDisabled={addEditStatus.mode === AddEditMode.Edit}
           isValid={!(touched.name && errors.name)}
         />
@@ -121,14 +112,14 @@ const InnerAddEditTokenForm: React.FunctionComponent<
       <FormGroup
         label="Associate with cluster"
         isRequired
-        fieldId={FieldKey.associatedClusterName}
+        fieldId={TokenFieldKey.AssociatedClusterName}
         helperTextInvalid={touched.associatedClusterName && errors.associatedClusterName}
         isValid={!(touched.associatedClusterName && errors.associatedClusterName)}
       >
         <SimpleSelect
-          id={FieldKey.associatedClusterName}
-          onChange={(selection) => setFieldValue(FieldKey.associatedClusterName, selection)}
-          options={['foo', 'bar', 'baz']} // NATODO
+          id={TokenFieldKey.AssociatedClusterName}
+          onChange={(selection) => setFieldValue(TokenFieldKey.AssociatedClusterName, selection)}
+          options={clusterNames}
           value={values.associatedClusterName}
           placeholderText="Select cluster..."
         />
@@ -136,16 +127,16 @@ const InnerAddEditTokenForm: React.FunctionComponent<
       <FormGroup
         label="Token type"
         isRequired
-        fieldId={FieldKey.tokenType}
+        fieldId={TokenFieldKey.TokenType}
         helperTextInvalid={touched.tokenType && errors.tokenType}
         isValid={!(touched.tokenType && errors.tokenType)}
       >
         <Radio
-          id={`${FieldKey.tokenType}-${TokenType.oAuth}`}
-          name={FieldKey.tokenType}
-          isChecked={values.tokenType === TokenType.oAuth}
+          id={`${TokenFieldKey.TokenType}-${TokenType.OAuth}`}
+          name={TokenFieldKey.TokenType}
+          isChecked={values.tokenType === TokenType.OAuth}
           onChange={(checked) => {
-            if (checked) setFieldValue(FieldKey.tokenType, TokenType.oAuth);
+            if (checked) setFieldValue(TokenFieldKey.TokenType, TokenType.OAuth);
           }}
           label="OAuth"
         />
@@ -160,7 +151,7 @@ const InnerAddEditTokenForm: React.FunctionComponent<
             variant="secondary"
             className={spacing.mtSm}
             onClick={onLogInClick}
-            isDisabled={values.tokenType !== TokenType.oAuth || !values.associatedClusterName}
+            isDisabled={values.tokenType !== TokenType.OAuth || !values.associatedClusterName}
           >
             Log in
           </Button>
@@ -173,31 +164,31 @@ const InnerAddEditTokenForm: React.FunctionComponent<
           )}
         </div>
         <Radio
-          id={`${FieldKey.tokenType}-${TokenType.serviceAccount}`}
-          name={FieldKey.tokenType}
-          isChecked={values.tokenType === TokenType.serviceAccount}
+          id={`${TokenFieldKey.TokenType}-${TokenType.ServiceAccount}`}
+          name={TokenFieldKey.TokenType}
+          isChecked={values.tokenType === TokenType.ServiceAccount}
           onChange={(checked) => {
-            if (checked) setFieldValue(FieldKey.tokenType, TokenType.serviceAccount);
+            if (checked) setFieldValue(TokenFieldKey.TokenType, TokenType.ServiceAccount);
           }}
           label="Service account"
         />
         <FormGroup
           className={`${spacing.mtMd} ${spacing.mbLg} ${spacing.mlLg}`}
-          fieldId={FieldKey.serviceAccountToken}
-          isRequired={values.tokenType === TokenType.serviceAccount}
+          fieldId={TokenFieldKey.ServiceAccountToken}
+          isRequired={values.tokenType === TokenType.ServiceAccount}
           helperText="Enter the token string."
           helperTextInvalid={touched.serviceAccountToken && errors.serviceAccountToken}
           isValid={!(touched.serviceAccountToken && errors.serviceAccountToken)}
         >
           <TextInput
             onChange={formikHandleChange}
-            onInput={formikSetFieldTouched(FieldKey.serviceAccountToken)}
+            onInput={formikSetFieldTouched(TokenFieldKey.ServiceAccountToken)}
             onBlur={handleBlur}
             value={values.serviceAccountToken}
-            name={FieldKey.serviceAccountToken}
+            name={TokenFieldKey.ServiceAccountToken}
             type="text"
-            id={FieldKey.serviceAccountToken}
-            isDisabled={values.tokenType !== TokenType.serviceAccount}
+            id={TokenFieldKey.ServiceAccountToken}
+            isDisabled={values.tokenType !== TokenType.ServiceAccount}
             isValid={!(touched.serviceAccountToken && errors.serviceAccountToken)}
           />
         </FormGroup>
@@ -223,11 +214,11 @@ const AddEditTokenForm = withFormik<IOtherProps, ITokenFormValues>({
     // NATODO initialize here from existing token for editing?
     name: '',
     associatedClusterName: '',
-    tokenType: TokenType.oAuth,
+    tokenType: TokenType.OAuth,
     serviceAccountToken: '',
   }),
   validate: (values: ITokenFormValues) => {
-    const errors: { [key in FieldKey]?: string } = {};
+    const errors: { [key in TokenFieldKey]?: string } = {};
     if (!values.name) {
       errors.name = 'Required';
     } else if (!utils.testDNS1123(values.name)) {
@@ -238,7 +229,7 @@ const AddEditTokenForm = withFormik<IOtherProps, ITokenFormValues>({
       errors.associatedClusterName = 'Required';
     }
 
-    if (values.tokenType === TokenType.serviceAccount && !values.serviceAccountToken) {
+    if (values.tokenType === TokenType.ServiceAccount && !values.serviceAccountToken) {
       errors.serviceAccountToken = 'Required';
     }
 

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
@@ -70,8 +70,7 @@ const mapStateToProps = (state: IReduxState) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  addToken: (tokenValues: ITokenFormValues) =>
-    dispatch(TokenActions.addTokenRequest(tokenValues))
+  addToken: (tokenValues: ITokenFormValues) => dispatch(TokenActions.addTokenRequest(tokenValues)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(AddEditTokenModal);

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
@@ -4,17 +4,24 @@ import { Modal } from '@patternfly/react-core';
 import { IAddEditStatus, AddEditMode } from '../../add_edit_state';
 import { PollingContext } from '../../../home/duck/context';
 import AddEditTokenForm from './AddEditTokenForm';
+import { ITokenFormValues } from '../../../token/duck/types';
 import { IReduxState } from '../../../../reducers';
+import { ICluster } from '../../../cluster/duck/types';
+import { TokenActions } from '../../../token/duck/actions';
 
 interface IAddEditTokenModalProps {
   addEditStatus: IAddEditStatus;
   isOpen: boolean;
   isPolling: boolean;
+  clusterList: ICluster[];
+  addToken: (tokenValues: ITokenFormValues) => void;
   onClose: () => void;
 }
 
 const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   addEditStatus,
+  addToken,
+  clusterList,
   isOpen,
   isPolling,
   onClose,
@@ -28,6 +35,11 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   });
 
   const modalTitle = addEditStatus.mode === AddEditMode.Edit ? 'Edit token' : 'Add token';
+
+  const handleAddEditSubmit = (tokenValues: ITokenFormValues) => {
+    // NATODO: Switch on add or edit, for now just add
+    addToken(tokenValues);
+  };
 
   return (
     <Modal
@@ -43,10 +55,8 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
     >
       <AddEditTokenForm
         addEditStatus={addEditStatus}
-        onAddEditSubmit={() => {
-          // NATODO
-          alert('NATODO: not yet implemented');
-        }}
+        clusterList={clusterList}
+        onAddEditSubmit={handleAddEditSubmit}
         onClose={onClose}
       />
     </Modal>
@@ -59,6 +69,9 @@ const mapStateToProps = (state: IReduxState) => ({
   clusterList: state.cluster.clusterList,
 });
 
-const mapDispatchToProps = (dispatch) => ({}); // NATODO wire up actions here
+const mapDispatchToProps = (dispatch) => ({
+  addToken: (tokenValues: ITokenFormValues) =>
+    dispatch(TokenActions.addTokenRequest(tokenValues))
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(AddEditTokenModal);

--- a/src/app/common/duck/sagas.ts
+++ b/src/app/common/duck/sagas.ts
@@ -1,8 +1,6 @@
 import { select, takeLatest, race, call, delay, take, put } from 'redux-saga/effects';
 import {
   AlertActions,
-  PollingActions,
-  PollingActionTypes,
   AlertActionTypes,
 } from '../../common/duck/actions';
 import { AuthActions } from '../../auth/duck/actions';
@@ -10,6 +8,7 @@ import { AuthActions } from '../../auth/duck/actions';
 import { PlanActionTypes, PlanActions } from '../../plan/duck/actions';
 import { StorageActionTypes, StorageActions } from '../../storage/duck/actions';
 import { ClusterActionTypes, ClusterActions } from '../../cluster/duck/actions';
+import { TokenActionTypes, TokenActions } from '../../token/duck/actions';
 import utils from '../../common/duck/utils';
 
 export const StatusPollingInterval = 4000;
@@ -37,6 +36,7 @@ function* poll(action) {
         yield put(PlanActions.stopPlanPolling());
         yield put(ClusterActions.stopClusterPolling());
         yield put(StorageActions.stopStoragePolling());
+        yield put(TokenActions.stopTokenPolling());
       }
       //TODO: Handle "secrets not found error" & any other fetch errors here
     }
@@ -61,6 +61,13 @@ function* watchClustersPolling() {
   while (true) {
     const action = yield take(ClusterActionTypes.CLUSTER_POLL_START);
     yield race([call(poll, action), take(ClusterActionTypes.CLUSTER_POLL_STOP)]);
+  }
+}
+
+function* watchTokenPolling() {
+  while (true) {
+    const action = yield take(TokenActionTypes.TOKEN_POLL_START);
+    yield race([call(poll, action), take(TokenActionTypes.TOKEN_POLL_STOP)]);
   }
 }
 
@@ -104,5 +111,6 @@ export default {
   watchStoragePolling,
   watchClustersPolling,
   watchPlanPolling,
+  watchTokenPolling,
   watchAlerts,
 };

--- a/src/app/common/duck/sagas.ts
+++ b/src/app/common/duck/sagas.ts
@@ -1,8 +1,5 @@
 import { select, takeLatest, race, call, delay, take, put } from 'redux-saga/effects';
-import {
-  AlertActions,
-  AlertActionTypes,
-} from '../../common/duck/actions';
+import { AlertActions, AlertActionTypes } from '../../common/duck/actions';
 import { AuthActions } from '../../auth/duck/actions';
 
 import { PlanActionTypes, PlanActions } from '../../plan/duck/actions';

--- a/src/app/home/pages/TokensPage/TokensPage.tsx
+++ b/src/app/home/pages/TokensPage/TokensPage.tsx
@@ -25,19 +25,16 @@ import AddEditTokenModal from '../../../common/components/AddEditTokenModal';
 interface ITokensPageBaseProps {
   tokenList: IToken[];
   clusterList: ICluster[];
-  //NATODO: implement loading state for tokens
-  // isFetchingInitialTokens: boolean;
+  isFetchingInitialTokens: boolean;
 }
 
 const TokensPageBase: React.FunctionComponent<ITokensPageBaseProps> = ({
   tokenList,
   clusterList,
+  isFetchingInitialTokens,
 }: //NATODO: implement loading state for tokens
-// isFetchingInitialTokens,
 ITokensPageBaseProps) => {
   const [isAddEditModalOpen, toggleAddEditModal] = useOpenModal(false);
-  //NATODO: implement loading state for tokens
-  const isFetchingInitialTokens = false;
 
   return (
     <>
@@ -87,33 +84,10 @@ ITokensPageBaseProps) => {
   );
 };
 
-// NATODO remove this when we have real data
-const fakeTokens = [
-  {
-    MigToken: {
-      apiVersion: '1.0',
-      kind: 'MigToken',
-      metadata: {
-        name: 'My Token',
-      },
-      spec: {
-        migClusterRef: { name: 'cluster-name', namespace: 'some-namespace' },
-        secretRef: { name: 'secret-name', namespace: 'some-namespace' },
-      },
-      status: {
-        observedDigest: 'foo',
-        type: 'OAuth',
-        expiresAt: '2020-06-08T20:55:53.825Z',
-      },
-    },
-  },
-];
-
 const mapStateToProps = (state: IReduxState) => ({
-  tokenList: fakeTokens, // NATODO pull real data from redux here
+  tokenList: state.token.tokenList,
   clusterList: clusterSelectors.getAllClusters(state),
-  //NATODO: implement loading state for tokens
-  // isFetchingInitialTokens: state.token.isFetchingInitialTokens,
+  isFetchingInitialTokens: state.token.isFetchingInitialTokens,
 });
 
 const mapDispatchToProps = (dispatch) => ({});

--- a/src/app/home/pages/TokensPage/TokensPage.tsx
+++ b/src/app/home/pages/TokensPage/TokensPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
+  Button,
   Bullseye,
   Card,
   PageSection,
@@ -12,7 +13,7 @@ import {
   Title,
   Spinner,
 } from '@patternfly/react-core';
-import { WrenchIcon } from '@patternfly/react-icons';
+import { WrenchIcon, AddCircleOIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import clusterSelectors from '../../../cluster/duck/selectors';
 import TokensTable from './components/TokensTable';
@@ -35,6 +36,34 @@ const TokensPageBase: React.FunctionComponent<ITokensPageBaseProps> = ({
 }: //NATODO: implement loading state for tokens
 ITokensPageBaseProps) => {
   const [isAddEditModalOpen, toggleAddEditModal] = useOpenModal(false);
+
+  const renderTokenCardBody = () => {
+    if (clusterList.length === 0) {
+      return (
+        <EmptyState variant="full">
+          <EmptyStateIcon icon={WrenchIcon} />
+          <Title size="lg">No clusters have been added</Title>
+          <TextContent className={spacing.mtMd}>
+            <Text component="p">
+              An administrator must add clusters for migration before you can add tokens. Contact
+              the cluster administrator for assistance.
+            </Text>
+          </TextContent>
+        </EmptyState>
+      );
+    } else if (tokenList.length === 0) {
+      return (
+        <EmptyState variant="full">
+          <EmptyStateIcon icon={AddCircleOIcon} />
+          <Title size="lg">Add token</Title>
+          <Button onClick={toggleAddEditModal} variant="primary">
+            Add token
+          </Button>
+        </EmptyState>
+      );
+    }
+    return <TokensTable tokenList={tokenList} toggleAddEditModal={toggleAddEditModal} />;
+  };
 
   return (
     <>
@@ -61,20 +90,7 @@ ITokensPageBaseProps) => {
           <Card>
             <CardBody>
               {/* NATODO add a TokenContext provider here when we wire up watchAddEditStatus */}
-              {!clusterList || !tokenList ? null : clusterList.length === 0 ? (
-                <EmptyState variant="full">
-                  <EmptyStateIcon icon={WrenchIcon} />
-                  <Title size="lg">No clusters have been added</Title>
-                  <TextContent className={spacing.mtMd}>
-                    <Text component="p">
-                      An administrator must add clusters for migration before you can add tokens.
-                      Contact the cluster administrator for assistance.
-                    </Text>
-                  </TextContent>
-                </EmptyState>
-              ) : (
-                <TokensTable tokenList={tokenList} toggleAddEditModal={toggleAddEditModal} />
-              )}
+              {renderTokenCardBody()}
               <AddEditTokenModal isOpen={isAddEditModalOpen} onClose={toggleAddEditModal} />
             </CardBody>
           </Card>

--- a/src/app/home/pages/TokensPage/helpers.ts
+++ b/src/app/home/pages/TokensPage/helpers.ts
@@ -15,7 +15,7 @@ export const getTokenInfo = (token: IToken) => {
     statusText: 'Loading...',
   };
 
-  if(token.MigToken.status) {
+  if (token.MigToken.status) {
     const expirationTimestamp = token.MigToken.status.expiresAt;
     const expirationMoment = moment(expirationTimestamp);
     const formattedExpiration = expirationMoment

--- a/src/app/home/pages/TokensPage/helpers.ts
+++ b/src/app/home/pages/TokensPage/helpers.ts
@@ -5,33 +5,44 @@ import { StatusType } from '../../../common/components/StatusIcon';
 const EXPIRATION_WARNING_THRESHOLD_HOURS = 1;
 
 export const getTokenInfo = (token: IToken) => {
-  const expirationTimestamp = token.MigToken.status.expiresAt;
-  const expirationMoment = moment(expirationTimestamp);
-  const formattedExpiration = expirationMoment
-    .tz(moment.tz.guess())
-    .format('DD MMM YYYY, hh:mm:ss A z');
-  const hoursUntilExpiration = expirationMoment.diff(moment(), 'hours', true);
-  let statusType: StatusType;
-  let statusText: string;
-  if (hoursUntilExpiration < 0) {
-    statusType = StatusType.ERROR;
-    statusText = 'Expired';
-  } else if (hoursUntilExpiration < EXPIRATION_WARNING_THRESHOLD_HOURS) {
-    statusType = StatusType.WARNING;
-    statusText = 'Expiring soon';
-  } else {
-    statusType = StatusType.OK;
-    statusText = 'OK';
-  }
-  return {
+  const retTokenInfo = {
     tokenName: token.MigToken.metadata.name,
-    type: token.MigToken.status.type,
-    expirationTimestamp,
-    formattedExpiration,
     associatedClusterName: token.MigToken.spec.migClusterRef.name,
-    statusType,
-    statusText,
+    type: 'Loading...',
+    expirationTimestamp: 'Loading...',
+    formattedExpiration: 'Loading...',
+    statusType: StatusType.OK,
+    statusText: 'Loading...',
   };
+
+  if(token.MigToken.status) {
+    const expirationTimestamp = token.MigToken.status.expiresAt;
+    const expirationMoment = moment(expirationTimestamp);
+    const formattedExpiration = expirationMoment
+      .tz(moment.tz.guess())
+      .format('DD MMM YYYY, hh:mm:ss A z');
+    const hoursUntilExpiration = expirationMoment.diff(moment(), 'hours', true);
+    let statusType: StatusType;
+    let statusText: string;
+    if (hoursUntilExpiration < 0) {
+      statusType = StatusType.ERROR;
+      statusText = 'Expired';
+    } else if (hoursUntilExpiration < EXPIRATION_WARNING_THRESHOLD_HOURS) {
+      statusType = StatusType.WARNING;
+      statusText = 'Expiring soon';
+    } else {
+      statusType = StatusType.OK;
+      statusText = 'OK';
+    }
+
+    retTokenInfo.expirationTimestamp = expirationTimestamp;
+    retTokenInfo.formattedExpiration = formattedExpiration;
+    retTokenInfo.type = token.MigToken.status.type;
+    retTokenInfo.statusType = statusType;
+    retTokenInfo.statusText = statusText;
+  }
+
+  return retTokenInfo;
 };
 
 export type ITokenInfo = ReturnType<typeof getTokenInfo>;

--- a/src/app/token/duck/actions.ts
+++ b/src/app/token/duck/actions.ts
@@ -1,6 +1,4 @@
-// NATODO do we need all of these? figure out the CRUD/polling
-
-import { IToken } from './types';
+import { IToken, ITokenFormValues } from './types';
 
 export const TokenActionTypes = {
   MIG_TOKEN_FETCH_REQUEST: 'MIG_TOKEN_FETCH_REQUEST',
@@ -22,6 +20,25 @@ export const TokenActionTypes = {
 };
 
 // NATODO what can we abstract out here? Take lessons from Migration Analytics?
+const addTokenRequest = (tokenValues: ITokenFormValues) => ({
+  type: TokenActionTypes.ADD_TOKEN_REQUEST,
+  tokenValues,
+});
+
+const addTokenSuccess = (newMigToken: IToken) => ({
+  type: TokenActionTypes.ADD_TOKEN_SUCCESS,
+  newMigToken,
+});
+
+const addTokenFailure = (error) => ({
+  type: TokenActionTypes.ADD_TOKEN_FAILURE,
+  error,
+});
+
+const updateTokens = (updatedTokens: IToken[]) => ({
+  type: TokenActionTypes.UPDATE_TOKENS,
+  updatedTokens,
+});
 
 const migTokenFetchRequest = () => ({
   type: TokenActionTypes.MIG_TOKEN_FETCH_REQUEST,
@@ -36,4 +53,34 @@ const migTokenFetchFailure = () => ({
   type: TokenActionTypes.MIG_TOKEN_FETCH_FAILURE,
 });
 
-// NATODO etc, for the other actions
+const startTokenPolling = (params) => ({
+  type: TokenActionTypes.TOKEN_POLL_START,
+  params
+});
+
+const stopTokenPolling = () => ({
+  type: TokenActionTypes.TOKEN_POLL_STOP,
+});
+
+
+// NATODO: Implement and/or remove unecessary copies
+export const TokenActions = {
+  // removeClusterRequest,
+  // removeClusterSuccess,
+  // removeClusterFailure,
+  // updateClusterSuccess,
+  // updateSearchTerm,
+  // setClusterAddEditStatus,
+  // watchClusterAddEditStatus,
+  // cancelWatchClusterAddEditStatus,
+  // clusterFetchSuccess,
+  // clusterFetchRequest,
+  // clusterFetchFailure,
+  // updateClusterRequest,
+  addTokenSuccess,
+  addTokenFailure,
+  addTokenRequest,
+  updateTokens,
+  startTokenPolling,
+  stopTokenPolling,
+};

--- a/src/app/token/duck/actions.ts
+++ b/src/app/token/duck/actions.ts
@@ -55,13 +55,12 @@ const migTokenFetchFailure = () => ({
 
 const startTokenPolling = (params) => ({
   type: TokenActionTypes.TOKEN_POLL_START,
-  params
+  params,
 });
 
 const stopTokenPolling = () => ({
   type: TokenActionTypes.TOKEN_POLL_STOP,
 });
-
 
 // NATODO: Implement and/or remove unecessary copies
 export const TokenActions = {

--- a/src/app/token/duck/reducers.ts
+++ b/src/app/token/duck/reducers.ts
@@ -39,6 +39,22 @@ const tokenActionHandlers: { [actionType: string]: TokenReducerFn } = {
   [TokenActionTypes.MIG_TOKEN_FETCH_FAILURE]: (state = INITIAL_STATE, action) => {
     return { ...state, isError: true, isFetching: false };
   },
+  [TokenActionTypes.ADD_TOKEN_SUCCESS]: (state = INITIAL_STATE, action) => {
+    return { ...state, tokenList: [...state.tokenList, action.newMigToken]};
+  },
+  [TokenActionTypes.TOKEN_POLL_START]: (state = INITIAL_STATE) => {
+    return { ...state, isPolling: true };
+  },
+  [TokenActionTypes.TOKEN_POLL_STOP]: (state = INITIAL_STATE, action) => {
+    return { ...state, isPolling: false };
+  },
+  [TokenActionTypes.UPDATE_TOKENS]: (state = INITIAL_STATE, action) => {
+    return {
+      ...state,
+      isFetchingInitialTokens: false,
+      tokenList: action.updatedTokens,
+     };
+  },
   // NATODO add handlers for the other actions
 };
 

--- a/src/app/token/duck/reducers.ts
+++ b/src/app/token/duck/reducers.ts
@@ -40,7 +40,7 @@ const tokenActionHandlers: { [actionType: string]: TokenReducerFn } = {
     return { ...state, isError: true, isFetching: false };
   },
   [TokenActionTypes.ADD_TOKEN_SUCCESS]: (state = INITIAL_STATE, action) => {
-    return { ...state, tokenList: [...state.tokenList, action.newMigToken]};
+    return { ...state, tokenList: [...state.tokenList, action.newMigToken] };
   },
   [TokenActionTypes.TOKEN_POLL_START]: (state = INITIAL_STATE) => {
     return { ...state, isPolling: true };
@@ -53,7 +53,7 @@ const tokenActionHandlers: { [actionType: string]: TokenReducerFn } = {
       ...state,
       isFetchingInitialTokens: false,
       tokenList: action.updatedTokens,
-     };
+    };
   },
   // NATODO add handlers for the other actions
 };

--- a/src/app/token/duck/sagas.ts
+++ b/src/app/token/duck/sagas.ts
@@ -1,2 +1,148 @@
 // NATODO
-export default {};
+import { takeLatest, select, race, take, call, put, delay } from 'redux-saga/effects';
+import { ClientFactory } from '../../../client/client_factory';
+import { IClusterClient } from '../../../client/client';
+import { MigResource, MigResourceKind } from '../../../client/resources';
+import { CoreNamespacedResource, CoreNamespacedResourceKind } from '../../../client/resources';
+import { IToken, IMigToken, ITokenFormValues, TokenType } from './types';
+import { TokenActionTypes, TokenActions } from './actions';
+import { createMigTokenSecret, createMigToken } from '../../../client/resources/conversions';
+
+function fetchTokenSecrets(client: IClusterClient, migTokens): Array<Promise<any>> {
+  const secretRefs: Array<Promise<any>> = [];
+
+  migTokens.forEach((token) => {
+    const secretRef = token.spec.secretRef;
+    const secretResource = new CoreNamespacedResource(
+      CoreNamespacedResourceKind.Secret,
+      secretRef.namespace
+    );
+    secretRefs.push(client.get(secretResource, secretRef.name));
+  });
+
+  return secretRefs;
+}
+
+function groupTokens(migTokens: IMigToken[], secretRefs: any[]): IToken[] {
+  return migTokens.map((mt) => ({
+    MigToken: mt,
+    Secret: secretRefs.find(s => s.kind === 'Secret' && s.metadata.name === mt.spec.secretRef.name),
+  }));
+}
+
+function* fetchTokensGenerator() {
+  const state = yield select();
+  const client: IClusterClient = ClientFactory.cluster(state);
+  const resource = new MigResource(MigResourceKind.MigToken, state.migMeta.namespace);
+  try {
+    let tokenList = yield client.list(resource);
+    tokenList = yield tokenList.data.items;
+    const secretRefPromises = yield Promise.all(fetchTokenSecrets(client, tokenList));
+    const secrets = secretRefPromises.map(s => s.data);
+    const groupedTokens = groupTokens(tokenList, secrets);
+    return { updatedTokens: groupedTokens };
+  } catch (e) {
+    throw e;
+  }
+}
+
+function* addTokenRequest(action) {
+  const state = yield select();
+  const { migMeta } = state;
+  const tokenValues: ITokenFormValues = action.tokenValues;
+  console.log('tokenValues: ', tokenValues);
+  const client: IClusterClient = ClientFactory.cluster(state);
+
+  let migTokenSecretData: string;
+  switch(tokenValues.tokenType) {
+    case TokenType.OAuth: {
+      // NATODO: Get OAuth token from values and set the migTokenSecretData to that
+      // should be coming out of localstorage, but let the event handler in the front-end
+      // handle that and set the appropriate form value
+      console.error('NOT IMPLEMENTED: Add OAuth TokenType')
+      break;
+    }
+    case TokenType.ServiceAccount: {
+      migTokenSecretData = tokenValues.serviceAccountToken;
+      break;
+    }
+    default: {
+      // NATODO: Rare edge case with unrecognized token type?
+      console.error(`addTokenRequest: Unknown TokenType: [${tokenValues.tokenType}]`);
+      break;
+    }
+  }
+
+  const secretResource = new CoreNamespacedResource(
+    CoreNamespacedResourceKind.Secret,
+    migMeta.configNamespace
+  );
+  const migTokenResource = new MigResource(MigResourceKind.MigToken, migMeta.namespace);
+
+  const migTokenSecret = createMigTokenSecret(
+    tokenValues.name, migMeta.configNamespace, migTokenSecretData);
+
+  try {
+    const migTokenLookup = yield client.get(migTokenResource, tokenValues.name);
+    // This should never happen -- we're using generateName which should ensure
+    // that the secret's name that's created is unique, but just in case...
+    if(migTokenLookup.status === 200) {
+      throw new Error(`MigToken "${tokenValues.name} already exists`)
+    }
+  } catch (err) {
+    //  If response is anything but a 404 response (the normal path), rethrow
+    if(!err.response || err.response.status !== 404) {
+      throw err;
+    }
+    // NATODO: Implement add edit status with token
+    // yield put(
+    //   TokenActionTypes.setClusterAddEditStatus(
+    //     createAddEditStatusWithMeta(AddEditState.Critical, AddEditMode.Add, err.message, '')
+    //   )
+    // );
+  }
+
+  let migTokenSecretResult;
+  try {
+    migTokenSecretResult = yield client.create(secretResource, migTokenSecret);
+  } catch (err) {
+    console.error(err.response);
+    yield put(TokenActions.addTokenFailure(`Failed to add token: ${err.message}`));
+    return;
+  }
+
+  let migTokenResult;
+  try {
+    const newMigToken = createMigToken(
+      tokenValues.name, migMeta.namespace,
+      migTokenSecretResult.data.metadata.name,
+      migTokenSecretResult.data.metadata.namespace,
+      tokenValues.associatedClusterName
+    );
+    migTokenResult = yield client.create(migTokenResource, newMigToken);
+  } catch (err) {
+    // Rollback succesfully created secret so we don't leak it if the token itself failed
+    console.error(err.response);
+    yield client.delete(secretResource, migTokenSecretResult.data.metadata.name);
+    yield put(TokenActions.addTokenFailure(`Failed to add token: ${err.message}`));
+    return;
+  }
+
+  yield put(TokenActions.addTokenSuccess({
+    MigToken: migTokenResult.data,
+    Secret: migTokenSecretResult.data,
+  }));
+}
+
+function* watchAddTokenRequest() {
+  yield takeLatest(TokenActionTypes.ADD_TOKEN_REQUEST, addTokenRequest);
+}
+
+export default {
+  // NATODO: Implement and/or remove unecessary copies
+  // watchRemoveClusterRequest,
+  watchAddTokenRequest,
+  // watchUpdateClusterRequest,
+  // watchClusterAddEditStatus,
+  fetchTokensGenerator,
+};

--- a/src/app/token/duck/types.ts
+++ b/src/app/token/duck/types.ts
@@ -18,7 +18,40 @@ export interface IMigToken {
   };
 }
 
+// NATODO: Define the token secret type
+// probably needs some shared fields like kind and metadata
+// export interface ITokenSecret {
+//   data: {
+//     token: string;
+//   }
+// }
+
 export interface IToken {
   MigToken: IMigToken;
-  // NATODO what else?
+  // Secret: ITokenSecret;
+  Secret: {
+    data: {
+      token: string;
+    };
+  };
+}
+
+
+export enum TokenFieldKey {
+  Name = 'name',
+  AssociatedClusterName = 'associatedClusterName',
+  TokenType = 'tokenType',
+  ServiceAccountToken = 'serviceAccountToken',
+}
+
+export enum TokenType {
+  OAuth = 'oAuth',
+  ServiceAccount = 'serviceAccount',
+}
+
+export interface ITokenFormValues {
+  [TokenFieldKey.Name]: string;
+  [TokenFieldKey.AssociatedClusterName]: string;
+  [TokenFieldKey.TokenType]: TokenType;
+  [TokenFieldKey.ServiceAccountToken]: string;
 }

--- a/src/app/token/duck/types.ts
+++ b/src/app/token/duck/types.ts
@@ -36,7 +36,6 @@ export interface IToken {
   };
 }
 
-
 export enum TokenFieldKey {
   Name = 'name',
   AssociatedClusterName = 'associatedClusterName',

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -5,7 +5,7 @@ import {
 } from '../../app/home/pages/PlansPage/components/Wizard/HooksFormComponent';
 import { IMigPlan } from '../../app/plan/duck/types';
 
-export function createTokenSecret(
+export function createMigClusterSecret(
   name: string,
   namespace: string,
   rawToken: string,
@@ -679,6 +679,54 @@ export function createMigHook(migHook: any, namespace: string) {
       namespace,
     },
     spec: migHookSpec,
+  };
+}
+
+export function createMigTokenSecret(
+  name: string,
+  namespace: string,
+  rawToken: string,
+) {
+  // btoa => to base64, atob => from base64
+  const encodedToken = btoa(rawToken);
+  return {
+    apiVersion: 'v1',
+    data: {
+      token: encodedToken,
+    },
+    kind: 'Secret',
+    metadata: {
+      generateName: `${name}-`,
+      namespace,
+    },
+    type: 'Opaque',
+  };
+}
+
+export function createMigToken(
+  name: string,
+  namespace: string,
+  migTokenSecretName: string,
+  migTokenSecretNamespace: string,
+  migClusterName: string,
+) {
+  return {
+    apiVersion: 'migration.openshift.io/v1alpha1',
+    kind: 'MigToken',
+    metadata: {
+      name,
+      namespace,
+    },
+    spec: {
+      migClusterRef: {
+        name: migClusterName,
+        namespace,
+      },
+      secretRef: {
+        name: migTokenSecretName,
+        namespace: migTokenSecretNamespace,
+      }
+    }
   };
 }
 

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -682,11 +682,7 @@ export function createMigHook(migHook: any, namespace: string) {
   };
 }
 
-export function createMigTokenSecret(
-  name: string,
-  namespace: string,
-  rawToken: string,
-) {
+export function createMigTokenSecret(name: string, namespace: string, rawToken: string) {
   // btoa => to base64, atob => from base64
   const encodedToken = btoa(rawToken);
   return {
@@ -708,7 +704,7 @@ export function createMigToken(
   namespace: string,
   migTokenSecretName: string,
   migTokenSecretNamespace: string,
-  migClusterName: string,
+  migClusterName: string
 ) {
   return {
     apiVersion: 'migration.openshift.io/v1alpha1',
@@ -725,8 +721,8 @@ export function createMigToken(
       secretRef: {
         name: migTokenSecretName,
         namespace: migTokenSecretNamespace,
-      }
-    }
+      },
+    },
   };
 }
 

--- a/src/client/resources/mig.ts
+++ b/src/client/resources/mig.ts
@@ -24,4 +24,5 @@ export enum MigResourceKind {
   MigMigration = 'migmigrations',
   MigCluster = 'migclusters',
   MigHook = 'mighooks',
+  MigToken= 'migtokens',
 }

--- a/src/client/resources/mig.ts
+++ b/src/client/resources/mig.ts
@@ -24,5 +24,5 @@ export enum MigResourceKind {
   MigMigration = 'migmigrations',
   MigCluster = 'migclusters',
   MigHook = 'mighooks',
-  MigToken= 'migtokens',
+  MigToken = 'migtokens',
 }

--- a/src/sagas.ts
+++ b/src/sagas.ts
@@ -5,6 +5,7 @@ import planSagas from './app/plan/duck/sagas';
 import logSagas from './app/logs/duck/sagas';
 import clusterSagas from './app/cluster/duck/sagas';
 import storageSagas from './app/storage/duck/sagas';
+import tokenSagas from './app/token/duck/sagas';
 import { initMigMeta } from './mig_meta';
 import { AuthActions } from './app/auth/duck/actions';
 import { setTokenExpiryHandler } from './client/client_factory';
@@ -36,6 +37,7 @@ export default function* rootSaga() {
     commonSagas.watchPlanPolling(),
     commonSagas.watchClustersPolling(),
     commonSagas.watchStoragePolling(),
+    commonSagas.watchTokenPolling(),
     commonSagas.watchAlerts(),
     planSagas.watchStagePolling(),
     planSagas.watchMigrationPolling(),
@@ -67,6 +69,7 @@ export default function* rootSaga() {
     storageSagas.watchAddStorageRequest(),
     storageSagas.watchStorageAddEditStatus(),
     storageSagas.watchUpdateStorageRequest(),
+    tokenSagas.watchAddTokenRequest(),
     authSagas.watchAuthEvents(),
   ]);
 }


### PR DESCRIPTION
This PR is another WIP PR adding incremental non-admin feature support; it includes:
* Adds MigToken support to the client
* Adds token polling
* Hooks up the Tokens table to the redux tree and removes fake tokens
* Adds "Add Token" support for SAs
* Some amount of refactoring where it made sense (ex: moving the token form values into the token types, since it is used in at least 2 places other than the form component itself)

It does **not** include:
* Token edit/delete
* OAuth token support (will follow up with this)

I also discovered #917 while implementing this but refrained from fixing it and adding scope creep. I'd like to follow up this PR with a distinct PR to repair this issue as well.

Closes #891
Closes #885 
