### PR TITLE
Prevent disabled add plan button from suppressing tooltip

### DIFF
--- a/src/app/home/pages/PlansPage/PlansPage.tsx
+++ b/src/app/home/pages/PlansPage/PlansPage.tsx
@@ -119,15 +119,19 @@ const PlansPageBase: React.FunctionComponent<IPlansPageBaseProps> = ({
                 {!planList ? null : planList.length === 0 ? (
                   <EmptyState variant="full">
                     <EmptyStateIcon icon={AddCircleOIcon} />
-                    <Title size="lg">No migration plans exist</Title>
+                    <Title size="lg" className={spacing.mbLg}>
+                      No migration plans exist
+                    </Title>
                     <AddPlanDisabledTooltip addPlanDisabledObj={addPlanDisabledObj}>
-                      <Button
-                        isDisabled={addPlanDisabledObj.isAddPlanDisabled}
-                        onClick={toggleWizardOpen}
-                        variant="primary"
-                      >
-                        Add migration plan
-                      </Button>
+                      <div>
+                        <Button
+                          isDisabled={addPlanDisabledObj.isAddPlanDisabled}
+                          onClick={toggleWizardOpen}
+                          variant="primary"
+                        >
+                          Add migration plan
+                        </Button>
+                      </div>
                     </AddPlanDisabledTooltip>
                   </EmptyState>
                 ) : (


### PR DESCRIPTION
At some point, something about the `<Tooltip>` behavior changed and it no longer works when the immediate child is disabled. So when the user has no plans, the "Add migration plan" button is disabled with no indication of why. Wrapping the button in a div fixes the hover event somehow, so this tooltip works again.

![Screenshot 2020-06-18 13 44 19](https://user-images.githubusercontent.com/811963/85054278-d0bdbf00-b169-11ea-991c-ed054f42e763.png)
