### PR TITLE
Add admin / non-admin role indicator in top-right of masthead

### DIFF
--- a/src/app/common/components/PageHeaderComponent.tsx
+++ b/src/app/common/components/PageHeaderComponent.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
-import { PageHeader, Brand, PageHeaderProps, Title } from '@patternfly/react-core';
+import { connect } from 'react-redux';
+import {
+  PageHeader,
+  Brand,
+  PageHeaderProps,
+  Title,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { UserIcon } from '@patternfly/react-icons';
 import openshiftLogo from './CAM_LOGO.svg';
+import IconWithText from './IconWithText';
+import { IReduxState } from '../../../reducers';
 const styles = require('./PageHeaderComponent.module');
 
-type PageHeaderComponentProps = Omit<PageHeaderProps, 'logo'>;
+interface PageHeaderComponentProps extends Omit<PageHeaderProps, 'logo'> {
+  isAdmin: boolean;
+}
 
 // NATODO: Remove WIP header
-const PageHeaderComponent: React.FunctionComponent<PageHeaderComponentProps> = (props) => (
+const PageHeaderComponent: React.FunctionComponent<PageHeaderComponentProps> = ({
+  isAdmin,
+  ...props
+}) => (
   <PageHeader
     logo={
       <>
@@ -19,8 +36,21 @@ const PageHeaderComponent: React.FunctionComponent<PageHeaderComponentProps> = (
         </Title>
       </>
     }
+    toolbar={
+      <Toolbar>
+        <ToolbarGroup>
+          {isAdmin !== null && (
+            <ToolbarItem>
+              <IconWithText icon={<UserIcon />} text={isAdmin ? 'Admin' : 'Non-admin'} />
+            </ToolbarItem>
+          )}
+        </ToolbarGroup>
+      </Toolbar>
+    }
     {...props}
   />
 );
 
-export default PageHeaderComponent;
+const mapStateToProps = (state: IReduxState) => ({ isAdmin: state.auth.isAdmin });
+const mapDispatchToProps = () => ({});
+export default connect(mapStateToProps, mapDispatchToProps)(PageHeaderComponent);


### PR DESCRIPTION
<img width="1438" alt="Screenshot 2020-06-18 18 16 34" src="https://user-images.githubusercontent.com/811963/85077260-d8905a00-b18f-11ea-87a3-233f2048adb0.png">


<img width="1440" alt="Screenshot 2020-06-18 18 17 06" src="https://user-images.githubusercontent.com/811963/85077287-ec3bc080-b18f-11ea-8d48-ea176e1f1f64.png">
