### PR TITLE
Typescript bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "style-loader": "^0.23.1",
     "ts-jest": "^24.0.1",
     "ts-loader": "~5.3.3",
-    "typescript": "3.8.3",
+    "typescript": "^3.9.5",
     "webpack": "^4.29.6",
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-cli": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "style-loader": "^0.23.1",
     "ts-jest": "^24.0.1",
     "ts-loader": "~5.3.3",
-    "typescript": "^3.3.4000",
+    "typescript": "3.8.3",
     "webpack": "^4.29.6",
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-cli": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "start-server-and-test": "^1.9.1",
     "style-loader": "^0.23.1",
     "ts-jest": "^24.0.1",
-    "ts-loader": "~5.3.3",
+    "ts-loader": "^7.0.5",
     "typescript": "^3.9.5",
     "webpack": "^4.29.6",
     "webpack-bundle-analyzer": "^3.3.2",

--- a/src/app/AppComponent.tsx
+++ b/src/app/AppComponent.tsx
@@ -8,7 +8,7 @@ import { history } from '../helpers';
 import { ConnectedRouter } from 'connected-react-router';
 import CertErrorComponent from './auth/CertErrorComponent';
 import OAuthLandingPage from './token/OAuthLandingPage';
-import { PollingContext } from './home/duck/context';
+import { PollingContext } from './home/duck';
 import { StatusPollingInterval } from './common/duck/sagas';
 import { clusterSagas } from './cluster/duck';
 import { storageSagas } from './storage/duck';

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useContext, useRef } from 'react';
 import { connect } from 'react-redux';
 import { Modal } from '@patternfly/react-core';
 import { IAddEditStatus, AddEditMode } from '../../add_edit_state';
-import { PollingContext } from '../../../home/duck/context';
+import { PollingContext } from '../../../home/duck/';
 import AddEditTokenForm from './AddEditTokenForm';
 import { ITokenFormValues } from '../../../token/duck/types';
 import { IReduxState } from '../../../../reducers';

--- a/src/app/common/components/ErrorModal.tsx
+++ b/src/app/common/components/ErrorModal.tsx
@@ -12,7 +12,7 @@ import { ErrorCircleOIcon } from '@patternfly/react-icons';
 import { useHistory } from 'react-router-dom';
 import { AlertActions } from '../duck/actions';
 import { connect } from 'react-redux';
-import { PollingContext } from '../../home/duck/context';
+import { PollingContext } from '../../home/duck';
 const styles = require('./ErrorModal.module');
 
 interface IProps {

--- a/src/app/home/HomeComponent.tsx
+++ b/src/app/home/HomeComponent.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useContext } from 'react';
 import { connect } from 'react-redux';
 import { useRouteMatch, Link, Switch, Route, Redirect } from 'react-router-dom';
 import { Nav, NavList, NavItem, Page, PageSidebar, SkipToContent } from '@patternfly/react-core';
-import { PollingContext } from '../home/duck/context';
+import { PollingContext } from '../home/duck';
 import { ClustersPage, StoragesPage, PlansPage, LogsPage, TokensPage } from './pages';
 import RefreshRoute from '../auth/RefreshRoute';
 import { ICluster } from '../cluster/duck/types';

--- a/src/app/home/duck/index.ts
+++ b/src/app/home/duck/index.ts
@@ -1,2 +1,2 @@
-export { default as homeHooks } from './hooks';
-export { default as homeContext } from './context';
+export * from './hooks';
+export * from './context';

--- a/src/app/home/pages/ClustersPage/ClustersPage.tsx
+++ b/src/app/home/pages/ClustersPage/ClustersPage.tsx
@@ -21,7 +21,7 @@ import { ClusterActions } from '../../../cluster/duck/actions';
 import { createAddEditStatus, AddEditState, AddEditMode } from '../../../common/add_edit_state';
 import ClustersTable from './components/ClustersTable';
 import AddEditClusterModal from './components/AddEditClusterModal';
-import { useOpenModal } from '../../duck/hooks';
+import { useOpenModal } from '../../duck';
 import { ICluster } from '../../../cluster/duck/types';
 import { IMigMeta } from '../../../../mig_meta';
 import { IReduxState } from '../../../../reducers';

--- a/src/app/home/pages/ClustersPage/components/ClusterActionsDropdown.tsx
+++ b/src/app/home/pages/ClustersPage/components/ClusterActionsDropdown.tsx
@@ -2,7 +2,7 @@ import React, { useState, useContext } from 'react';
 import { Dropdown, KebabToggle, DropdownItem, DropdownPosition } from '@patternfly/react-core';
 import AddEditClusterModal from './AddEditClusterModal';
 import ConfirmModal from '../../../../common/components/ConfirmModal';
-import { useOpenModal } from '../../../duck/hooks';
+import { useOpenModal } from '../../../duck';
 import { ClusterContext } from '../../../duck/context';
 import { IClusterInfo } from '../helpers';
 import { ICluster } from '../../../../cluster/duck/types';

--- a/src/app/home/pages/PlansPage/PlansPage.tsx
+++ b/src/app/home/pages/PlansPage/PlansPage.tsx
@@ -22,7 +22,7 @@ import clusterSelectors from '../../../cluster/duck/selectors';
 import storageSelectors from '../../../storage/duck/selectors';
 import { PlanActions } from '../../../plan/duck';
 import PlansTable from './components/PlansTable';
-import { useOpenModal } from '../../duck/hooks';
+import { useOpenModal } from '../../duck';
 import WizardContainer from './components/Wizard/WizardContainer';
 import AddPlanDisabledTooltip from './components/AddPlanDisabledTooltip';
 import { ICluster } from '../../../cluster/duck/types';

--- a/src/app/home/pages/PlansPage/components/PlanActions.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanActions.tsx
@@ -9,7 +9,7 @@ import {
   Flex,
   FlexItem,
 } from '@patternfly/react-core';
-import { useOpenModal } from '../../../duck/hooks';
+import { useOpenModal } from '../../../duck';
 import MigrateModal from './MigrateModal';
 import { withRouter } from 'react-router-dom';
 import WizardContainer from './Wizard/WizardContainer';

--- a/src/app/home/pages/StoragesPage/StoragesPage.tsx
+++ b/src/app/home/pages/StoragesPage/StoragesPage.tsx
@@ -19,7 +19,7 @@ import { StorageContext } from '../../duck/context';
 import storageSelectors from '../../../storage/duck/selectors';
 import { StorageActions } from '../../../storage/duck/actions';
 import { createAddEditStatus, AddEditState, AddEditMode } from '../../../common/add_edit_state';
-import { useOpenModal } from '../../duck/hooks';
+import { useOpenModal } from '../../duck';
 import StoragesTable from './components/StoragesTable';
 import AddEditStorageModal from './components/AddEditStorageModal';
 import { IStorage } from '../../../storage/duck/types';

--- a/src/app/home/pages/StoragesPage/components/StorageActionsDropdown.tsx
+++ b/src/app/home/pages/StoragesPage/components/StorageActionsDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { Dropdown, KebabToggle, DropdownItem, DropdownPosition } from '@patternfly/react-core';
 import { IStorageInfo } from '../helpers';
-import { useOpenModal } from '../../../duck/hooks';
+import { useOpenModal } from '../../../duck';
 import { StorageContext } from '../../../duck/context';
 import ConfirmModal from '../../../../common/components/ConfirmModal';
 

--- a/src/app/home/pages/TokensPage/TokensPage.tsx
+++ b/src/app/home/pages/TokensPage/TokensPage.tsx
@@ -17,7 +17,7 @@ import { WrenchIcon, AddCircleOIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import clusterSelectors from '../../../cluster/duck/selectors';
 import TokensTable from './components/TokensTable';
-import { useOpenModal } from '../../duck/hooks';
+import { useOpenModal } from '../../duck';
 import { IReduxState } from '../../../../reducers';
 import { IToken } from '../../../token/duck/types';
 import { ICluster } from '../../../cluster/duck/types';

--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -239,7 +239,7 @@ const getPlansWithPlanStatus = createSelector(
   }
 );
 
-const getCounts = createSelector([planSelector], (plans) => {
+const getCounts = createSelector([planSelector], (plans: any[]) => {
   const counts = {
     notStarted: [],
     inProgress: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,7 +1581,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -5491,6 +5491,14 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+micromatch@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -6345,6 +6353,11 @@ picomatch@^2.0.4, picomatch@^2.0.7:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+
+picomatch@^2.0.5:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -7455,7 +7468,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -8390,16 +8403,16 @@ ts-jest@^24.0.1:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-loader@~5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.3.3.tgz#8b4af042e773132d86b3c99ef0acf3b4d325f473"
-  integrity sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==
+ts-loader@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-7.0.5.tgz#789338fb01cb5dc0a33c54e50558b34a73c9c4c5"
+  integrity sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==
   dependencies:
     chalk "^2.3.0"
     enhanced-resolve "^4.0.0"
     loader-utils "^1.0.2"
-    micromatch "^3.1.4"
-    semver "^5.0.1"
+    micromatch "^4.0.0"
+    semver "^6.0.0"
 
 tslib@^1.10.0:
   version "1.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8479,10 +8479,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@^3.3.4000:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8479,10 +8479,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
Typescript is upgraded to  3.9.5

TS was due for an upgrade but also there are deps needs for testing framework jest and @testing-library which requires Typescript > 3.8.3
Using new version exposes a couple of issues which have been addressed:
* TS2305 with app/home/duck/index
* TS2339 with app/plan/duck/selectors.ts

And also following `app/home/duck/index` fix makes use of the barrel file (index) for `{context|hooks}` imports.