### PR TITLE
Fix isLoadingNewToken

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -133,7 +133,7 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
     ? tokenList.find((token) => token.MigToken.metadata.name === value)
     : null;
   const selectedTokenInfo = selectedToken && getTokenInfo(selectedToken);
-  const isLoadingNewToken = value && !selectedToken;
+  const isLoadingNewToken = !!value && !selectedToken;
 
   useEffect(() => {
     // If there's only one token available, pre-select it.


### PR DESCRIPTION
Found out the following message while running tests:
`Warning: Failed prop type: Invalid prop `isDisabled` of type `string` supplied to `SelectToggle`, expected `boolean`.`

Changing IsLoadingNewToken to be boolean fixes it.
