### PR TITLE
Fix bugs with token creation flow in plan wizard, form validation on general step, and polling in token modal

### DIFF
--- a/src/app/common/components/AddEditTokenModal/AddEditTokenForm.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenForm.tsx
@@ -144,10 +144,7 @@ const InnerAddEditTokenForm: React.FunctionComponent<
         />
         <div className={`${spacing.mtMd} ${spacing.mbLg} ${spacing.mlLg}`}>
           <TextContent>
-            <Text component="p">
-              Log in to the cluster to automatically generate the token, or enter the token string
-              in the field.
-            </Text>
+            <Text component="p">Log in to the cluster to automatically generate the token.</Text>
           </TextContent>
           <Button
             variant="secondary"

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
@@ -18,7 +18,7 @@ interface IAddEditTokenModalProps {
   clusterList: ICluster[];
   addToken: (tokenValues: ITokenFormValues) => void;
   onClose: () => void;
-  onTokenCreated?: (tokenRef: INameNamespaceRef) => void;
+  onTokenAdded?: (tokenRef: INameNamespaceRef) => void;
   preSelectedClusterName?: string;
   migMeta: IMigMeta;
 }
@@ -30,7 +30,7 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   isPolling,
   preventPollingWhileOpen = true,
   onClose,
-  onTokenCreated,
+  onTokenAdded,
   preSelectedClusterName,
   migMeta,
 }: IAddEditTokenModalProps) => {
@@ -58,7 +58,7 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   const handleAddEditSubmit = (tokenValues: ITokenFormValues) => {
     // NATODO: Switch on add or edit, for now just add
     addToken(tokenValues);
-    onTokenCreated && onTokenCreated({ name: tokenValues.name, namespace: migMeta.namespace });
+    onTokenAdded && onTokenAdded({ name: tokenValues.name, namespace: migMeta.namespace });
     onClose();
   };
 

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
@@ -8,6 +8,8 @@ import { ITokenFormValues } from '../../../token/duck/types';
 import { IReduxState } from '../../../../reducers';
 import { ICluster } from '../../../cluster/duck/types';
 import { TokenActions } from '../../../token/duck/actions';
+import { INameNamespaceRef } from '../../duck/types';
+import { IMigMeta } from '../../../../mig_meta';
 
 interface IAddEditTokenModalProps {
   addEditStatus: IAddEditStatus;
@@ -16,8 +18,9 @@ interface IAddEditTokenModalProps {
   clusterList: ICluster[];
   addToken: (tokenValues: ITokenFormValues) => void;
   onClose: () => void;
-  onTokenCreated?: (tokenName: string) => void;
+  onTokenCreated?: (tokenRef: INameNamespaceRef) => void;
   preSelectedClusterName?: string;
+  migMeta: IMigMeta;
 }
 
 const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
@@ -29,6 +32,7 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   onClose,
   onTokenCreated,
   preSelectedClusterName,
+  migMeta,
 }: IAddEditTokenModalProps) => {
   const containerRef = useRef(document.createElement('div'));
   useEffect(() => {
@@ -54,7 +58,7 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   const handleAddEditSubmit = (tokenValues: ITokenFormValues) => {
     // NATODO: Switch on add or edit, for now just add
     addToken(tokenValues);
-    onTokenCreated && onTokenCreated(tokenValues.name);
+    onTokenCreated && onTokenCreated({ name: tokenValues.name, namespace: migMeta.namespace });
     onClose();
   };
 
@@ -86,6 +90,7 @@ const mapStateToProps = (state: IReduxState) => ({
   addEditStatus: state.token.addEditStatus,
   isPolling: state.token.isPolling,
   clusterList: state.cluster.clusterList,
+  migMeta: state.migMeta,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
@@ -11,8 +11,8 @@ import { TokenActions } from '../../../token/duck/actions';
 
 interface IAddEditTokenModalProps {
   addEditStatus: IAddEditStatus;
-  isOpen: boolean;
   isPolling: boolean;
+  preventPollingWhileOpen?: boolean;
   clusterList: ICluster[];
   addToken: (tokenValues: ITokenFormValues) => void;
   onClose: () => void;
@@ -24,8 +24,8 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   addEditStatus,
   addToken,
   clusterList,
-  isOpen,
   isPolling,
+  preventPollingWhileOpen = true,
   onClose,
   onTokenCreated,
   preSelectedClusterName,
@@ -43,10 +43,11 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   const pollingContext = useContext(PollingContext);
 
   useEffect(() => {
-    if (isOpen && isPolling) {
+    if (isPolling && preventPollingWhileOpen) {
       pollingContext.stopAllPolling();
+      return () => pollingContext.startAllDefaultPolling();
     }
-  });
+  }, []);
 
   const modalTitle = addEditStatus.mode === AddEditMode.Edit ? 'Edit token' : 'Add token';
 
@@ -61,7 +62,7 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
     <Modal
       appendTo={containerRef.current}
       isSmall
-      isOpen={isOpen}
+      isOpen
       onClose={() => {
         // NATODO cancel/reset add/edit watch/state
         onClose();

--- a/src/app/common/components/SimpleSelect.tsx
+++ b/src/app/common/components/SimpleSelect.tsx
@@ -15,7 +15,7 @@ export interface OptionWithValue<T = string> extends SelectOptionObject {
 
 type OptionLike = string | SelectOptionObject | OptionWithValue;
 
-interface SimpleSelectProps
+export interface ISimpleSelectProps
   extends Omit<
     SelectProps,
     'onChange' | 'isExpanded' | 'onToggle' | 'onSelect' | 'selections' | 'value'
@@ -25,7 +25,7 @@ interface SimpleSelectProps
   value: OptionLike | OptionLike[];
 }
 
-const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({
+const SimpleSelect: React.FunctionComponent<ISimpleSelectProps> = ({
   onChange,
   options,
   value,

--- a/src/app/common/components/SimpleSelect.tsx
+++ b/src/app/common/components/SimpleSelect.tsx
@@ -23,7 +23,6 @@ interface SimpleSelectProps
   onChange: (selection: OptionLike) => void;
   options: OptionLike[];
   value: OptionLike | OptionLike[];
-  placeholderText?: string;
 }
 
 const SimpleSelect: React.FunctionComponent<SimpleSelectProps> = ({

--- a/src/app/common/components/SimpleSelect.tsx
+++ b/src/app/common/components/SimpleSelect.tsx
@@ -8,8 +8,8 @@ import {
   SelectOptionProps,
 } from '@patternfly/react-core';
 
-export interface OptionWithValue extends SelectOptionObject {
-  value: string;
+export interface OptionWithValue<T = string> extends SelectOptionObject {
+  value: T;
   props?: Partial<SelectOptionProps>; // Extra props for <SelectOption>, e.g. children, className
 }
 

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -1,0 +1,10 @@
+import { INameNamespaceRef } from './duck/types';
+
+interface INameNamespaceRefSuperset extends INameNamespaceRef {
+  [key: string]: any; // CRD metadata objects which might have more properties than just { name, namespace } are allowed
+}
+
+export const isSameResource = (
+  metaA: INameNamespaceRefSuperset,
+  metaB: INameNamespaceRefSuperset
+) => metaA.name === metaB.name && metaA.namespace === metaB.namespace;

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -149,7 +149,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           <TokenSelect
             fieldId="sourceToken"
             clusterName={values.sourceCluster}
-            value={values.sourceTokenRef && values.sourceTokenRef.name}
+            value={values.sourceTokenRef}
             onChange={(tokenRef) => {
               setFieldTouched('sourceTokenRef');
               setFieldValue('sourceTokenRef', tokenRef);
@@ -180,7 +180,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           <TokenSelect
             fieldId="targetToken"
             clusterName={values.targetCluster}
-            value={values.targetTokenRef && values.targetTokenRef.name}
+            value={values.targetTokenRef}
             onChange={(tokenRef) => {
               setFieldTouched('targetTokenRef');
               setFieldValue('targetTokenRef', tokenRef);

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -8,7 +8,7 @@ import TokenSelect from './TokenSelect';
 const styles = require('./GeneralForm.module');
 
 interface IGeneralFormProps
-  extends Pick<IOtherProps, 'clusterList' | 'storageList' | 'tokenList' | 'isEdit'>,
+  extends Pick<IOtherProps, 'clusterList' | 'storageList' | 'isEdit'>,
     Pick<
       FormikProps<IFormValues>,
       | 'handleBlur'
@@ -23,7 +23,6 @@ interface IGeneralFormProps
 const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   clusterList,
   storageList,
-  tokenList,
   errors,
   handleBlur,
   handleChange,
@@ -149,7 +148,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           </FormGroup>
           <TokenSelect
             fieldId="sourceToken"
-            tokenList={tokenList}
             clusterName={values.sourceCluster}
             value={values.sourceTokenRef && values.sourceTokenRef.name}
             onChange={(tokenRef) => {
@@ -181,7 +179,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           </FormGroup>
           <TokenSelect
             fieldId="targetToken"
-            tokenList={tokenList}
             clusterName={values.targetCluster}
             value={values.targetTokenRef && values.targetTokenRef.name}
             onChange={(tokenRef) => {

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -5,6 +5,7 @@ import { Form, FormGroup, Grid, GridItem, TextInput, Title } from '@patternfly/r
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import SimpleSelect from '../../../../../common/components/SimpleSelect';
 import TokenSelect from './TokenSelect';
+import { INameNamespaceRef } from '../../../../../common/duck/types';
 const styles = require('./GeneralForm.module');
 
 interface IGeneralFormProps
@@ -71,6 +72,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     const matchingStorage = storageList.find((c) => c.MigStorage.metadata.name === value);
     if (matchingStorage) {
       setFieldValue('selectedStorage', value);
+      setFieldTouched('selectedStorage', true, true);
     }
   };
 
@@ -78,6 +80,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     const matchingCluster = clusterList.find((c) => c.MigCluster.metadata.name === value);
     if (matchingCluster) {
       setFieldValue('sourceCluster', value);
+      setFieldTouched('sourceCluster', true, true);
       setFieldValue('selectedNamespaces', []);
       setFieldValue('sourceTokenRef', null);
     }
@@ -87,6 +90,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     const matchingCluster = clusterList.find((c) => c.MigCluster.metadata.name === value);
     if (matchingCluster) {
       setFieldValue('targetCluster', value);
+      setFieldTouched('targetCluster', true, true);
       setFieldValue('targetTokenRef', null);
     }
   };
@@ -138,7 +142,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             <SimpleSelect
               id="sourceCluster"
               onChange={handleSourceChange}
-              onBlur={() => setFieldTouched('sourceCluster', true, true)}
               options={srcClusterOptions}
               value={values.sourceCluster}
               placeholderText="Select source..."
@@ -148,9 +151,9 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             fieldId="sourceToken"
             clusterName={values.sourceCluster}
             value={values.sourceTokenRef}
-            onChange={(tokenRef) => {
-              setFieldTouched('sourceTokenRef');
+            onChange={(tokenRef: INameNamespaceRef) => {
               setFieldValue('sourceTokenRef', tokenRef);
+              setFieldTouched('sourceTokenRef', true, true);
             }}
             touched={touched.sourceTokenRef}
             error={errors.sourceTokenRef}
@@ -170,7 +173,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             <SimpleSelect
               id="targetCluster"
               onChange={handleTargetChange}
-              onBlur={() => setFieldTouched('sourceCluster', true, true)}
               options={targetClusterOptions}
               value={values.targetCluster}
               placeholderText="Select target..."
@@ -181,8 +183,8 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             clusterName={values.targetCluster}
             value={values.targetTokenRef}
             onChange={(tokenRef) => {
-              setFieldTouched('targetTokenRef');
               setFieldValue('targetTokenRef', tokenRef);
+              setFieldTouched('targetTokenRef', true, true);
             }}
             touched={touched.targetTokenRef}
             error={errors.targetTokenRef}
@@ -208,7 +210,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             <SimpleSelect
               id="selectedStorage"
               onChange={handleStorageChange}
-              onBlur={() => setFieldTouched('selectedStorage', true, true)}
               options={storageOptions}
               value={values.selectedStorage}
               placeholderText="Select repository..."

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -71,7 +71,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     const matchingStorage = storageList.find((c) => c.MigStorage.metadata.name === value);
     if (matchingStorage) {
       setFieldValue('selectedStorage', value);
-      setFieldTouched('selectedStorage');
     }
   };
 
@@ -80,7 +79,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     if (matchingCluster) {
       setFieldValue('sourceCluster', value);
       setFieldValue('selectedNamespaces', []);
-      setFieldTouched('sourceCluster');
       setFieldValue('sourceTokenRef', null);
     }
   };
@@ -89,7 +87,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     const matchingCluster = clusterList.find((c) => c.MigCluster.metadata.name === value);
     if (matchingCluster) {
       setFieldValue('targetCluster', value);
-      setFieldTouched('targetCluster');
       setFieldValue('targetTokenRef', null);
     }
   };
@@ -141,6 +138,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             <SimpleSelect
               id="sourceCluster"
               onChange={handleSourceChange}
+              onBlur={() => setFieldTouched('sourceCluster', true, true)}
               options={srcClusterOptions}
               value={values.sourceCluster}
               placeholderText="Select source..."
@@ -172,6 +170,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             <SimpleSelect
               id="targetCluster"
               onChange={handleTargetChange}
+              onBlur={() => setFieldTouched('sourceCluster', true, true)}
               options={targetClusterOptions}
               value={values.targetCluster}
               placeholderText="Select target..."
@@ -209,6 +208,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             <SimpleSelect
               id="selectedStorage"
               onChange={handleStorageChange}
+              onBlur={() => setFieldTouched('selectedStorage', true, true)}
               options={storageOptions}
               value={values.selectedStorage}
               placeholderText="Select repository..."

--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -200,15 +200,17 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
           isDisabled={!clusterName || isLoadingNewToken}
           {...props}
         />
-        <AddEditTokenModal
-          isOpen={isAddEditModalOpen}
-          onClose={toggleAddEditModal}
-          onTokenCreated={(tokenName: string) => {
-            // NATODO should we include the namespace from the MigToken in the select options and everything, to be future proof?
-            setTokenJustCreatedRef({ name: tokenName, namespace: migMeta.namespace });
-          }}
-          preSelectedClusterName={clusterName}
-        />
+        {isAddEditModalOpen && (
+          <AddEditTokenModal
+            onClose={toggleAddEditModal}
+            onTokenCreated={(tokenName: string) => {
+              // NATODO should we include the namespace from the MigToken in the select options and everything, to be future proof?
+              setTokenJustCreatedRef({ name: tokenName, namespace: migMeta.namespace });
+            }}
+            preSelectedClusterName={clusterName}
+            preventPollingWhileOpen={false}
+          />
+        )}
       </FormGroup>
       {newToken && newToken === selectedToken && (
         <div className={spacing.mSm}>

--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -234,8 +234,9 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
   );
 };
 
-const mapStateToProps = (state: IReduxState) => ({
+const mapStateToProps = (state: IReduxState): Partial<ITokenSelectProps> => ({
   migMeta: state.migMeta,
+  tokenList: state.token.tokenList,
 });
 
 const mapDispatchToProps = () => ({});

--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -115,7 +115,7 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
   ...props
 }: ITokenSelectProps) => {
   const [isAddEditModalOpen, toggleAddEditModal] = useOpenModal(false);
-  const [tokenJustCreatedRef, setTokenJustCreatedRef] = useState<INameNamespaceRef>(null);
+  const [tokenJustAddedRef, setTokenJustAddedRef] = useState<INameNamespaceRef>(null);
 
   const handleChange = (token: IToken) => {
     const { name, namespace } = token.MigToken.metadata;
@@ -123,7 +123,7 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
   };
 
   const onAddTokenClick = () => {
-    setTokenJustCreatedRef(null);
+    setTokenJustAddedRef(null);
     toggleAddEditModal();
   };
 
@@ -142,9 +142,9 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
   const selectedTokenInfo = selectedToken && getTokenInfo(selectedToken);
 
   const newToken: IToken =
-    tokenJustCreatedRef &&
-    tokenList.find((token) => isSameResource(token.MigToken.metadata, tokenJustCreatedRef));
-  const isLoadingNewToken = !!tokenJustCreatedRef && !newToken;
+    tokenJustAddedRef &&
+    tokenList.find((token) => isSameResource(token.MigToken.metadata, tokenJustAddedRef));
+  const isLoadingNewToken = !!tokenJustAddedRef && !newToken;
 
   useEffect(() => {
     if (newToken && !selectedToken) {
@@ -154,14 +154,14 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
       } else {
         // It's not associated with the selected cluster, so give up on selecting it.
         // Might be impossible? Prevents a forever-spinner if that changes.
-        setTokenJustCreatedRef(null);
+        setTokenJustAddedRef(null);
       }
     }
   }, [newToken]);
 
   useEffect(() => {
     // Clear any messages about freshly created tokens if the cluster selection changes
-    setTokenJustCreatedRef(null);
+    setTokenJustAddedRef(null);
   }, [clusterName]);
 
   return (
@@ -179,7 +179,7 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
           onChange={(selection: OptionWithValue<IToken>) => {
             if (selection.value) {
               handleChange(selection.value);
-              setTokenJustCreatedRef(null);
+              setTokenJustAddedRef(null);
             }
           }}
           options={tokenOptions}
@@ -200,7 +200,7 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
         {isAddEditModalOpen && (
           <AddEditTokenModal
             onClose={toggleAddEditModal}
-            onTokenCreated={setTokenJustCreatedRef}
+            onTokenAdded={setTokenJustAddedRef}
             preSelectedClusterName={clusterName}
             preventPollingWhileOpen={false}
           />

--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -25,7 +25,6 @@ import StatusIcon, { StatusType } from '../../../../../common/components/StatusI
 import { INameNamespaceRef } from '../../../../../common/duck/types';
 import { FormikTouched, FormikErrors } from 'formik';
 import { IReduxState } from '../../../../../../reducers';
-import { IMigMeta } from '../../../../../../mig_meta';
 import { isSameResource } from '../../../../../common/helpers';
 const styles = require('./TokenSelect.module');
 
@@ -39,7 +38,6 @@ interface ITokenSelectProps extends ISimpleSelectProps {
   error?: FormikErrors<INameNamespaceRef>;
   expiringSoonMessage: string;
   expiredMessage: string;
-  migMeta: IMigMeta;
 }
 
 const getTokenOptionsForCluster = (
@@ -114,7 +112,6 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
   error,
   expiringSoonMessage,
   expiredMessage,
-  migMeta,
   ...props
 }: ITokenSelectProps) => {
   const [isAddEditModalOpen, toggleAddEditModal] = useOpenModal(false);
@@ -203,10 +200,7 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
         {isAddEditModalOpen && (
           <AddEditTokenModal
             onClose={toggleAddEditModal}
-            onTokenCreated={(tokenName: string) => {
-              // NATODO should we include the namespace from the MigToken in the select options and everything, to be future proof?
-              setTokenJustCreatedRef({ name: tokenName, namespace: migMeta.namespace });
-            }}
+            onTokenCreated={setTokenJustCreatedRef}
             preSelectedClusterName={clusterName}
             preventPollingWhileOpen={false}
           />
@@ -257,7 +251,6 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
 };
 
 const mapStateToProps = (state: IReduxState): Partial<ITokenSelectProps> => ({
-  migMeta: state.migMeta,
   tokenList: state.token.tokenList,
 });
 

--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -1,6 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { FormGroup, Button, Level, LevelItem, Flex, FlexItem } from '@patternfly/react-core';
+import {
+  FormGroup,
+  Button,
+  Level,
+  LevelItem,
+  Flex,
+  FlexItem,
+  Spinner,
+} from '@patternfly/react-core';
 import { CheckIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import flexStyles from '@patternfly/react-styles/css/layouts/Flex/flex';
@@ -175,7 +183,16 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
           }}
           options={tokenOptions}
           value={getSelectedTokenOption(value, tokenOptions)}
-          placeholderText="Select token..."
+          placeholderText={
+            isLoadingNewToken ? (
+              <Flex className={`${spacing.mlSm} ${flexStyles.modifiers.alignItemsCenter}`}>
+                <Spinner size="md" />
+                <FlexItem>Adding token...</FlexItem>
+              </Flex>
+            ) : (
+              'Select token...'
+            )
+          }
           isDisabled={!clusterName || isLoadingNewToken}
         />
         <AddEditTokenModal
@@ -188,7 +205,6 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
           preSelectedClusterName={clusterName}
         />
       </FormGroup>
-      {isLoadingNewToken && <div className={spacing.mSm}>Loading...</div>}
       {newToken && newToken === selectedToken && (
         <div className={spacing.mSm}>
           <IconWithText

--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -12,7 +12,10 @@ import {
 import { CheckIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import flexStyles from '@patternfly/react-styles/css/layouts/Flex/flex';
-import SimpleSelect, { OptionWithValue } from '../../../../../common/components/SimpleSelect';
+import SimpleSelect, {
+  OptionWithValue,
+  ISimpleSelectProps,
+} from '../../../../../common/components/SimpleSelect';
 import AddEditTokenModal from '../../../../../common/components/AddEditTokenModal';
 import IconWithText from '../../../../../common/components/IconWithText';
 import { IToken } from '../../../../../token/duck/types';
@@ -26,7 +29,7 @@ import { IMigMeta } from '../../../../../../mig_meta';
 import { isSameResource } from '../../../../../common/helpers';
 const styles = require('./TokenSelect.module');
 
-interface ITokenSelectProps {
+interface ITokenSelectProps extends ISimpleSelectProps {
   fieldId: string;
   tokenList: IToken[];
   clusterName: string;
@@ -112,6 +115,7 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
   expiringSoonMessage,
   expiredMessage,
   migMeta,
+  ...props
 }: ITokenSelectProps) => {
   const [isAddEditModalOpen, toggleAddEditModal] = useOpenModal(false);
   const [tokenJustCreatedRef, setTokenJustCreatedRef] = useState<INameNamespaceRef>(null);
@@ -194,6 +198,7 @@ const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({
             )
           }
           isDisabled={!clusterName || isLoadingNewToken}
+          {...props}
         />
         <AddEditTokenModal
           isOpen={isAddEditModalOpen}

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -112,7 +112,6 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
 
   useEffect(
     () => {
-      console.log({ touched, errors, values });
       const steps = [
         {
           id: stepId.General,

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -14,6 +14,7 @@ import WizardStepContainer from './WizardStepContainer';
 import { StatusType } from '../../../../../common/components/StatusIcon';
 import { getTokenInfo } from '../../../TokensPage/helpers';
 import { INameNamespaceRef } from '../../../../../common/duck/types';
+import { isSameResource } from '../../../../../common/helpers';
 
 const styles = require('./WizardComponent.module');
 
@@ -104,18 +105,14 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     fieldKeys.every((fieldKey) => {
       const tokenRef = values[fieldKey] as INameNamespaceRef;
       const selectedToken =
-        tokenRef &&
-        tokenList.find(
-          (token) =>
-            token.MigToken.metadata.name === tokenRef.name &&
-            token.MigToken.metadata.namespace === tokenRef.namespace
-        );
+        tokenRef && tokenList.find((token) => isSameResource(token.MigToken.metadata, tokenRef));
       const tokenInfo = selectedToken && getTokenInfo(selectedToken);
       return tokenInfo && tokenInfo.statusType !== StatusType.ERROR;
     });
 
   useEffect(
     () => {
+      console.log({ touched, errors, values });
       const steps = [
         {
           id: stepId.General,

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -125,7 +125,6 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
               <GeneralForm
                 clusterList={clusterList}
                 storageList={storageList}
-                tokenList={tokenList}
                 values={values}
                 errors={errors}
                 touched={touched}
@@ -254,6 +253,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
       setUpdatedSteps(steps);
     },
     //****************** Don't forget to update this array if you add changes to wizard children!!! */
+    // TODO: we should really remove this and just define steps outside the useEffect, if that doesn't break anything
     [
       currentPlan,
       values,

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -266,6 +266,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
       touched,
       currentPlanStatus,
       migHookList,
+      tokenList,
       hookAddEditStatus,
       isAddHooksOpen,
       isFetchingHookList,

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -1,4 +1,4 @@
-import { withFormik } from 'formik';
+import { withFormik, FormikErrors } from 'formik';
 import WizardComponent from './WizardComponent';
 import { PlanActions } from '../../../../../plan/duck/actions';
 import planSelectors from '../../../../../plan/duck/selectors';
@@ -130,7 +130,9 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
   },
 
   validate: (values, props) => {
-    const errors: any = {};
+    const errors: any = {}; // TODO figure out why using FormikErrors<IFormValues> here causes type errors below
+
+    console.log('VALIDATING!', values);
 
     if (!values.planName) {
       errors.planName = 'Required';

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -132,8 +132,6 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
   validate: (values, props) => {
     const errors: any = {}; // TODO figure out why using FormikErrors<IFormValues> here causes type errors below
 
-    console.log('VALIDATING!', values);
-
     if (!values.planName) {
       errors.planName = 'Required';
     } else if (!utils.testDNS1123(values.planName)) {

--- a/src/app/home/pages/TokensPage/TokensPage.tsx
+++ b/src/app/home/pages/TokensPage/TokensPage.tsx
@@ -91,7 +91,7 @@ ITokensPageBaseProps) => {
             <CardBody>
               {/* NATODO add a TokenContext provider here when we wire up watchAddEditStatus */}
               {renderTokenCardBody()}
-              <AddEditTokenModal isOpen={isAddEditModalOpen} onClose={toggleAddEditModal} />
+              {isAddEditModalOpen && <AddEditTokenModal onClose={toggleAddEditModal} />}
             </CardBody>
           </Card>
         )}


### PR DESCRIPTION
Fixes #930 

When the user is creating a plan and there are no available tokens for the selected cluster, they can open the add token modal right from the token select dropdown and then have that token selected once it is finished being added/loaded. My previous logic for this was flawed: the token name from the modal was immediately set in Formik state on submitting the modal, but the token doesn't immediately load into `tokenList` in redux so we'd end up in a state where the selected value is not one of the available options. Also, if somehow the created token does not match the selected cluster, we'd be stuck with that "loading" message indefinitely.

This PR fixes that issue by keeping the name of the token being created in state and waiting for a matching token to load before trying to set the Formik value. If the new token loads but does not match the selected cluster, it gives up and just hides the loading message. I also made that message a little nicer-looking by rendering it inside the placeholder text of the Select component, with a spinner and "Adding token..." instead of "Loading...":

![Screenshot 2020-06-24 15 03 53](https://user-images.githubusercontent.com/811963/85623920-1df0d380-b637-11ea-8f3b-62233a610a52.png)

See the fixed flow in action:

![q1u3UXQgwj](https://user-images.githubusercontent.com/811963/85623518-87bcad80-b636-11ea-9e8c-d4dfb4e79589.gif)


This PR also fixes the behavior of the AddEditTokenModal around polling. Previously when it was opened it would stop polling, but never resume it on close. We want polling to be paused while the modal is open and resumed on close, but when it is open inside the wizard we don't want to resume polling on close because the wizard also keeps polling paused. (Modal-in-a-modal is a fun use case 😄 ) So, this PR adds a prop `preventPollingWhileOpen` that defaults to true, and has a false value when mounted in the wizard. As part of this, I just tied that polling pause/resume to the component being mounted and unmounted, so instead of mounting it all the time and using the `isOpen` prop to hide/show the modal, I only mount the modal when `isOpen` would be true. (this also results in less cruft in the `<body>` caused by [the z-index hack](https://github.com/konveyor/mig-ui/pull/914/files#diff-30cc324d6d215c2355f893820ccd6dc8R37); that wrapper will only be present when the modal is open instead of all the time).

Lastly, there was an issue where selecting a source or target cluster would cause the "Required" validation message to appear even though there is a selected value, and it would only go away when some other field was changed. It seems like this was caused by the `setFieldTouched` method being called on change instead of on blur, so I fixed that. I also cleaned up a few things around TypeScript types for `SimpleSelect`, to enable non-string values in the `OptionWithValue` type (yay, [generics](https://www.typescriptlang.org/docs/handbook/generics.html)!)