### PR TITLE
update manual validation fix to work in edit mode

### DIFF
--- a/src/app/common/duck/hooks.ts
+++ b/src/app/common/duck/hooks.ts
@@ -68,13 +68,17 @@ export const usePaginationState = (items: any[], initialItemsPerPage: number) =>
   return { currentPageItems, setPageNumber, paginationProps };
 };
 
-export const useForcedValidationOnChange = <T>(values: T, validateForm: () => void) => {
+export const useForcedValidationOnChange = <T>(
+  values: T,
+  isEdit: boolean,
+  validateForm: () => void
+) => {
   // This is a hack to fix https://github.com/konveyor/mig-ui/issues/941.
   // TODO: We should either figure out how to let Formik properly validate itself on Select elements,
   //       or we should replace Formik.
   const lastValidatedValuesRef = useRef<T>(values);
   useEffect(() => {
-    if (values !== lastValidatedValuesRef.current) {
+    if (values !== lastValidatedValuesRef.current || isEdit) {
       validateForm();
       lastValidatedValuesRef.current = values;
     }

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -36,7 +36,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   values,
   validateForm,
 }: IGeneralFormProps) => {
-  useForcedValidationOnChange<IFormValues>(values, validateForm);
+  useForcedValidationOnChange<IFormValues>(values, isEdit, validateForm);
 
   const planNameInputRef = useRef(null);
   useEffect(() => {

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -136,7 +136,10 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
       errors.planName = 'Required';
     } else if (!utils.testDNS1123(values.planName)) {
       errors.planName = utils.DNS1123Error(values.planName);
-    } else if (props.planList.some((plan) => plan.MigPlan.metadata.name === values.planName)) {
+    } else if (
+      !props.isEdit &&
+      props.planList.some((plan) => plan.MigPlan.metadata.name === values.planName)
+    ) {
       errors.planName =
         'A plan with that name already exists. Enter a unique name for the migration plan.';
     }


### PR DESCRIPTION
- Updates the forced validation hook needed to fix a formik validation issue that is showing up in edit mode. 
- Fixes validation for duplicate plan to only run in non-edit mode
