### PR TITLE
tokenOptions.find only if value not null

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -97,9 +97,11 @@ const getSelectedTokenOption = (
   tokenOptions: OptionWithValue<IToken>[]
 ) => {
   if (!selectedTokenRef) return null;
-  return tokenOptions.find((option) =>
-    isSameResource(option.value.MigToken.metadata, selectedTokenRef)
-  );
+  return tokenOptions.find((option) => {
+    if (option.value) {
+      isSameResource(option.value.MigToken.metadata, selectedTokenRef);
+    }
+  });
 };
 
 const TokenSelect: React.FunctionComponent<ITokenSelectProps> = ({


### PR DESCRIPTION
TokenOptions[] should never have items with empty (null) value, meanwhile when that happens it breaks the tests and potentially the application