### PR TITLE
AddEditClusterModal initial component test

### DIFF
--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -102,6 +102,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
+          data-testid="cluster-name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
           onBlur={handleBlur}
@@ -157,6 +158,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
+          data-testid="url"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(urlKey)}
           onBlur={handleBlur}
@@ -181,6 +183,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
+          data-testid="token"
           value={values.token}
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(tokenKey)}

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -182,7 +182,6 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          data-testid="account-token"
           value={values.token}
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(tokenKey)}

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -25,6 +25,7 @@ import CertificateUpload from '../../../../../common/components/CertificateUploa
 const nameKey = 'name';
 const urlKey = 'url';
 const tokenKey = 'token';
+const azureTokenKey = 'azureToken';
 const isAzureKey = 'isAzure';
 const azureResourceGroupKey = 'azureResourceGroup';
 const requireSSLKey = 'requireSSL';
@@ -102,14 +103,13 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          data-testid="cluster-name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
           onBlur={handleBlur}
           value={values.name}
           name={nameKey}
           type="text"
-          id="cluster-name-input"
+          id={nameKey}
           isDisabled={currentStatus.mode === AddEditMode.Edit}
           isValid={!(touched.name && errors.name)}
         />
@@ -118,7 +118,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         <Checkbox
           label="Azure cluster"
           aria-label="Azure cluster"
-          id="azure-cluster-checkbox"
+          id={azureTokenKey}
           name={isAzureKey}
           isChecked={values.isAzure}
           onChange={formikHandleChange}
@@ -141,7 +141,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
             onInput={formikSetFieldTouched(azureResourceGroupKey)}
             onBlur={handleBlur}
             name={azureResourceGroupKey}
-            id="azure-token-input"
+            id={azureResourceGroupKey}
             type="text"
             isValid={!(touched.azureResourceGroup && errors.azureResourceGroup)}
           />
@@ -158,14 +158,13 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          data-testid="url"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(urlKey)}
           onBlur={handleBlur}
           value={values.url}
           name={urlKey}
           type="text"
-          id="url-input"
+          id={urlKey}
           isValid={!(touched.url && errors.url)}
         />
       </FormGroup>
@@ -183,13 +182,13 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          data-testid="token"
+          data-testid="account-token"
           value={values.token}
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(tokenKey)}
           onBlur={handleBlur}
           name={tokenKey}
-          id="token-input"
+          id={tokenKey}
           type={isTokenHidden ? 'password' : 'text'}
           isValid={!(touched.token && errors.token)}
         />
@@ -211,7 +210,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           isChecked={values.requireSSL}
           name={requireSSLKey}
           label="Require SSL verification"
-          id="require-ssl-input"
+          id={requireSSLKey}
         />
       </FormGroup>
       {values.requireSSL && (

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterModal.test.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterModal.test.tsx
@@ -32,7 +32,7 @@ describe('<AddEditClusterModal />', () => {
     expect(screen.getByDisplayValue('clustername')).toBeInTheDocument;
     expect(screen.getByDisplayValue('http://example.com')).toBeInTheDocument;
     expect(screen.getByDisplayValue('qwertyuiop')).toBeInTheDocument;
-    expect(screen.getByRole('button', { name: 'Add cluster' })).not.toBeDisabled;
+    expect(screen.getByRole('button', { name: 'Add cluster' })).toBeEnabled;
   });
 
   it('cannot add a cluster with unvalid cluster name', () => {
@@ -98,6 +98,6 @@ describe('<AddEditClusterModal />', () => {
     expect(screen.getByDisplayValue('existing-clustername')).toBeInTheDocument;
     expect(screen.getByDisplayValue('http://existing.example.com')).toBeInTheDocument;
     expect(screen.getByDisplayValue('existing-token')).toBeInTheDocument;
-    expect(screen.getByRole('button', { name: 'Add cluster' })).not.toBeDisabled;
+    expect(screen.getByRole('button', { name: 'Add cluster' })).toBeEnabled;
   });
 });

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterModal.test.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterModal.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import rootReducer from '../../../../../../../reducers';
+
+import AddEditClusterModal from '../index';
+
+const store = createStore(rootReducer, {});
+
+describe('<AddEditClusterModal />', () => {
+  it('adds a cluster with valid values', () => {
+    const initialProps = {
+      isOpen: true,
+      onHandleClose: jest.fn(),
+      cluster: jest.fn(),
+    };
+
+    render(
+      <Provider store={store}>
+        <AddEditClusterModal {...initialProps} />
+      </Provider>
+    );
+
+    userEvent.type(screen.getByTestId('cluster-name'), 'clustername');
+    userEvent.type(screen.getByTestId('url'), 'http://example.com');
+    userEvent.type(screen.getByTestId('token'), 'qwertyuiop');
+
+    expect(screen.getByDisplayValue('clustername')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('http://example.com')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('qwertyuiop')).toBeInTheDocument;
+    expect(screen.getByRole('button', { name: 'Add cluster' })).not.toBeDisabled;
+  });
+
+  it('cannot add a cluster with unvalid cluster name', () => {
+    const initialProps = {
+      isOpen: true,
+      onHandleClose: jest.fn(),
+      cluster: jest.fn(),
+    };
+
+    render(
+      <Provider store={store}>
+        <AddEditClusterModal {...initialProps} />
+      </Provider>
+    );
+
+    userEvent.type(screen.getByTestId('cluster-name'), '-clustername');
+    userEvent.type(screen.getByTestId('url'), 'example.com');
+
+    expect(screen.getByRole('button', { name: 'Add cluster' })).toBeDisabled;
+  });
+
+  it('cannot add a cluster with unvalid cluster url', () => {
+    const initialProps = {
+      isOpen: true,
+      onHandleClose: jest.fn(),
+      cluster: jest.fn(),
+    };
+
+    render(
+      <Provider store={store}>
+        <AddEditClusterModal {...initialProps} />
+      </Provider>
+    );
+
+    userEvent.type(screen.getByTestId('url'), 'example.com');
+
+    expect(screen.getByRole('button', { name: 'Add cluster' })).toBeDisabled;
+  });
+
+  it('updates a cluster with valid fields', () => {
+    const initialProps = {
+      isOpen: true,
+      onHandleClose: jest.fn(),
+      cluster: jest.fn(),
+    };
+
+    const testInitialClusterValues = {
+      clusterName: 'existing-clustername',
+      clusterUrl: 'http://existing.example.com',
+      clusterSvcToken: 'existing-token',
+      clusterIsAzure: null,
+      clusterAzureResourceGroup: null,
+      clusterRequireSSL: null,
+      clusterCABundle: null,
+    };
+
+    render(
+      <Provider store={store}>
+        <AddEditClusterModal {...initialProps} initialClusterValues={testInitialClusterValues} />
+      </Provider>
+    );
+
+    expect(screen.getByDisplayValue('existing-clustername')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('http://existing.example.com')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('existing-token')).toBeInTheDocument;
+    expect(screen.getByRole('button', { name: 'Add cluster' })).not.toBeDisabled;
+  });
+});

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterModal.test.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterModal.test.tsx
@@ -15,8 +15,6 @@ describe('<AddEditClusterModal />', () => {
   it('adds a cluster with valid values', () => {
     const initialProps = {
       isOpen: true,
-      onHandleClose: jest.fn(),
-      cluster: jest.fn(),
     };
 
     render(
@@ -38,8 +36,6 @@ describe('<AddEditClusterModal />', () => {
   it('cannot add a cluster with unvalid cluster name', () => {
     const initialProps = {
       isOpen: true,
-      onHandleClose: jest.fn(),
-      cluster: jest.fn(),
     };
 
     render(
@@ -57,8 +53,6 @@ describe('<AddEditClusterModal />', () => {
   it('cannot add a cluster with unvalid cluster url', () => {
     const initialProps = {
       isOpen: true,
-      onHandleClose: jest.fn(),
-      cluster: jest.fn(),
     };
 
     render(
@@ -75,8 +69,6 @@ describe('<AddEditClusterModal />', () => {
   it('updates a cluster with valid fields', () => {
     const initialProps = {
       isOpen: true,
-      onHandleClose: jest.fn(),
-      cluster: jest.fn(),
     };
 
     const testInitialClusterValues = {

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterModal.test.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterModal.test.tsx
@@ -12,7 +12,7 @@ import AddEditClusterModal from '../index';
 const store = createStore(rootReducer, {});
 
 describe('<AddEditClusterModal />', () => {
-  it('adds a cluster with valid values', () => {
+  it('allows filling form with valid values', () => {
     const initialProps = {
       isOpen: true,
     };
@@ -33,7 +33,7 @@ describe('<AddEditClusterModal />', () => {
     expect(screen.getByRole('button', { name: 'Add cluster' })).toBeEnabled;
   });
 
-  it('cannot add a cluster with unvalid cluster name', () => {
+  it('forbids filling from with unvalid name', () => {
     const initialProps = {
       isOpen: true,
     };
@@ -66,7 +66,7 @@ describe('<AddEditClusterModal />', () => {
     expect(screen.getByRole('button', { name: 'Add cluster' })).toBeDisabled;
   });
 
-  it('updates a cluster with valid fields', () => {
+  it('allows updating form with valid values', () => {
     const initialProps = {
       isOpen: true,
     };


### PR DESCRIPTION
Contains 3 types of test examples:
- Allows filing a cluster with valid values: The "Add cluster" button should be enabled
- Triggers validation messages when using invalid values: The "Add cluster" button should be disabled
- Loads a form with provided values and allows changing form: The "Update cluster" button should be enabled
