### PR TITLE
Component testing: Add filling forms for AWS S3, GCP and Azure

### DIFF
--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
@@ -189,6 +189,7 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
       </FormGroup>
       <Flex breakpointMods={[{ modifier: FlexModifiers['space-items-md'] }]}>
         <Button
+          aria-label="Azure Storage Submit Form"
           variant="primary"
           type="submit"
           isDisabled={isAddEditButtonDisabled(

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
@@ -114,14 +114,13 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          aria-label="Repository name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
           onBlur={handleBlur}
           value={values.name}
           name={nameKey}
           type="text"
-          id="storage-name-input"
+          id={nameKey}
           isDisabled={currentStatus.mode === AddEditMode.Edit}
           isValid={!(touched.name && errors.name)}
         />
@@ -136,14 +135,13 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          aria-label="Azure resource group"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(azureResourceGroupKey)}
           onBlur={handleBlur}
           value={values.azureResourceGroup}
           name={azureResourceGroupKey}
           type="text"
-          id="azure-resource-group-input"
+          id={azureResourceGroupKey}
           isValid={!(touched.azureResourceGroup && errors.azureResourceGroup)}
         />
       </FormGroup>
@@ -157,14 +155,13 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          aria-label="Azure storage account name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(azureStorageAccountKey)}
           onBlur={handleBlur}
           value={values.azureStorageAccount}
           name={azureStorageAccountKey}
           type="text"
-          id="azure-storage-input"
+          id={azureStorageAccountKey}
           isValid={!(touched.azureStorageAccount && errors.azureStorageAccount)}
         />
       </FormGroup>
@@ -176,14 +173,13 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         isValid={!(touched.azureBlob && errors.azureBlob)}
       >
         <TextArea
-          aria-label="Azure credentials (Copy and paste .INI file contents here)"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(azureBlobKey)}
           onBlur={handleBlur}
           value={values.azureBlob}
           name={azureBlobKey}
           type="text"
-          id="storage-blob-input"
+          id={azureBlobKey}
           isValid={!(touched.azureBlob && errors.azureBlob)}
         />
       </FormGroup>

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
@@ -22,7 +22,7 @@ import ConnectionStatusLabel from '../../../../../../common/components/Connectio
 import { withFormik, FormikProps } from 'formik';
 import utils from '../../../../../../common/duck/utils';
 
-/* 
+/*
 This URL is swapped out with downstream build scripts to point to the downstream documentation reference
 */
 const CREDENTIAL_DOCUMENTATION_URL =
@@ -114,6 +114,7 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
+          aria-label="Repository name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
           onBlur={handleBlur}
@@ -135,6 +136,7 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
+          aria-label="Azure resource group"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(azureResourceGroupKey)}
           onBlur={handleBlur}
@@ -155,6 +157,7 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
+          aria-label="Azure storage account name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(azureStorageAccountKey)}
           onBlur={handleBlur}
@@ -173,6 +176,7 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         isValid={!(touched.azureBlob && errors.azureBlob)}
       >
         <TextArea
+          aria-label="Azure credentials (Copy and paste .INI file contents here)"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(azureBlobKey)}
           onBlur={handleBlur}
@@ -218,7 +222,12 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           isOpen={isPopUpModalOpen}
           onClose={handleModalToggle}
           actions={[
-            <Button key="confirm" variant="primary" onClick={handleModalToggle}>
+            <Button
+              aria-label="Repository information"
+              key="confirm"
+              variant="primary"
+              onClick={handleModalToggle}
+            >
               Close
             </Button>,
           ]}

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
@@ -179,6 +179,7 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           {addEditButtonTextFn(currentStatus)}
         </Button>
         <Button
+          aria-label="GCP Storage Submit Form"
           variant="secondary"
           isDisabled={isCheckConnectionButtonDisabled(
             currentStatus,

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
@@ -106,6 +106,7 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
 
         <TextInput
+          aria-label="Repository name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
           onBlur={handleBlur}
@@ -128,11 +129,13 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
 
         <TextInput
+          aria-label="GCP bucket name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(gcpBucketKey)}
           onBlur={handleBlur}
           value={values.gcpBucket}
           name={gcpBucketKey}
+          // name="type"
           type="text"
           id="storage-bucket-name-input"
           isValid={!(touched.gcpBucket && errors.gcpBucket)}
@@ -151,6 +154,7 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
+          aria-label="GCP credential JSON blob"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(gcpBlobKey)}
           onBlur={handleBlur}

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
@@ -106,14 +106,13 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
 
         <TextInput
-          aria-label="Repository name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
           onBlur={handleBlur}
           value={values.name}
           name={nameKey}
           type="text"
-          id="storage-name-input"
+          id={nameKey}
           isDisabled={currentStatus.mode === AddEditMode.Edit}
           isValid={!(touched.name && errors.name)}
         />
@@ -129,15 +128,13 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
 
         <TextInput
-          aria-label="GCP bucket name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(gcpBucketKey)}
           onBlur={handleBlur}
           value={values.gcpBucket}
           name={gcpBucketKey}
-          // name="type"
           type="text"
-          id="storage-bucket-name-input"
+          id={gcpBucketKey}
           isValid={!(touched.gcpBucket && errors.gcpBucket)}
         />
       </FormGroup>
@@ -154,14 +151,13 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          aria-label="GCP credential JSON blob"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(gcpBlobKey)}
           onBlur={handleBlur}
           value={values.gcpBlob}
           name={gcpBlobKey}
           type={isBlobHidden ? 'password' : 'text'}
-          id="storage-blob-input"
+          id={gcpBlobKey}
           isValid={!(touched.gcpBlob && errors.gcpBlob)}
         />
       </FormGroup>

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/S3Form.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/S3Form.tsx
@@ -101,14 +101,13 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          aria-label="Replication repository name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
           onBlur={handleBlur}
           value={values.name}
           name={nameKey}
           type="text"
-          id="storage-name-input"
+          id={nameKey}
           isDisabled={currentStatus.mode === AddEditMode.Edit}
           isValid={!(touched.name && errors.name)}
         />
@@ -123,14 +122,13 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          aria-label="S3 bucket name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(awsBucketNameKey)}
           onBlur={handleBlur}
           value={values.awsBucketName}
           name={awsBucketNameKey}
           type="text"
-          id="storage-bucket-name-input"
+          id={awsBucketNameKey}
           isValid={!(touched.awsBucketName && errors.awsBucketName)}
         />
       </FormGroup>
@@ -143,14 +141,13 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          aria-label="S3 bucket region"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(awsBucketRegionKey)}
           onBlur={handleBlur}
           value={values.awsBucketRegion}
           name={awsBucketRegionKey}
           type="text"
-          id="storage-bucket-region-input"
+          id={awsBucketRegionKey}
           isValid={!(touched.awsBucketRegion && errors.awsBucketRegion)}
         />
       </FormGroup>
@@ -165,14 +162,13 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
           {/*
             // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
           <TextInput
-            aria-label="S3 endpoint"
             onChange={formikHandleChange}
             onInput={formikSetFieldTouched(s3UrlKey)}
             onBlur={handleBlur}
             value={values.s3Url}
             name={s3UrlKey}
             type="text"
-            id="storage-s3-url-input"
+            id={s3UrlKey}
             isValid={!(touched.s3Url && errors.s3Url)}
           />
         </FormGroup>
@@ -191,14 +187,13 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
 
         <TextInput
-          aria-label="S3 provider access key"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(accessKeyKey)}
           onBlur={handleBlur}
           value={values.accessKey}
           name={accessKeyKey}
           type={isAccessKeyHidden ? 'password' : 'text'}
-          id="storage-access-key-input"
+          id={accessKeyKey}
           isValid={!(touched.accessKey && errors.accessKey)}
         />
       </FormGroup>
@@ -215,14 +210,13 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          aria-label="S3 provider secret access key"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(secretKey)}
           onBlur={handleBlur}
           value={values.secret}
           name={secretKey}
           type={isSecretHidden ? 'password' : 'text'}
-          id="storage-secret-input"
+          id={secretKey}
           isValid={!(touched.secret && errors.secret)}
         />
       </FormGroup>

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/S3Form.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/S3Form.tsx
@@ -266,6 +266,7 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
       )}
       <Flex breakpointMods={[{ modifier: FlexModifiers['space-items-md'] }]}>
         <Button
+          aria-label="S3 Storage Submit Form"
           variant="primary"
           type="submit"
           isDisabled={isAddEditButtonDisabled(currentStatus, errors, touched, true)}

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/S3Form.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/S3Form.tsx
@@ -101,7 +101,7 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          data-testid="storage-name-input"
+          aria-label="Replication repository name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
           onBlur={handleBlur}
@@ -123,7 +123,7 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          data-testid="storage-bucket-name-input"
+          aria-label="S3 bucket name"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(awsBucketNameKey)}
           onBlur={handleBlur}
@@ -143,7 +143,7 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          data-testid="storage-bucket-region-input"
+          aria-label="S3 bucket region"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(awsBucketRegionKey)}
           onBlur={handleBlur}
@@ -165,7 +165,7 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
           {/*
             // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
           <TextInput
-            data-testid="storage-s3-url-input"
+            aria-label="S3 endpoint"
             onChange={formikHandleChange}
             onInput={formikSetFieldTouched(s3UrlKey)}
             onBlur={handleBlur}
@@ -191,7 +191,7 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
 
         <TextInput
-          data-testid="storage-access-key-input"
+          aria-label="S3 provider access key"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(accessKeyKey)}
           onBlur={handleBlur}
@@ -215,7 +215,7 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
         {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
         <TextInput
-          data-testid="storage-secret-input"
+          aria-label="S3 provider secret access key"
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(secretKey)}
           onBlur={handleBlur}

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -21,16 +21,16 @@ describe('<AddEditStorageModal />', () => {
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('S3'));
-    userEvent.type(screen.getByTestId('storage-name-input'), 'storage-name');
-    userEvent.type(screen.getByTestId('storage-bucket-name-input'), 'storage-bucket-name');
-    userEvent.type(screen.getByTestId('storage-bucket-region-input'), 'storage-bucket-region');
-    userEvent.type(screen.getByTestId('storage-s3-url-input'), 'storage-s3-url');
-    userEvent.type(screen.getByTestId('storage-access-key-input'), 'storage-s3-user');
-    userEvent.type(screen.getByTestId('storage-secret-input'), 'storage-s3-password');
+    userEvent.type(screen.getByLabelText('Replication repository name'), 'storage-s3-name');
+    userEvent.type(screen.getByLabelText('S3 bucket name'), 'storage-s3-bucket-name');
+    userEvent.type(screen.getByLabelText('S3 bucket region'), 'storage-s3-bucket-region');
+    userEvent.type(screen.getByLabelText('S3 endpoint'), 'storage-s3-url');
+    userEvent.type(screen.getByLabelText('S3 provider access key'), 'storage-s3-user');
+    userEvent.type(screen.getByLabelText('S3 provider secret access key'), 'storage-s3-password');
 
-    expect(screen.getByDisplayValue('storage-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-bucket-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-bucket-region')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('storage-s3-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('storage-s3-bucket-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('storage-s3-bucket-region')).toBeInTheDocument;
     expect(screen.getByDisplayValue('storage-s3-url')).toBeInTheDocument;
     expect(screen.getByDisplayValue('storage-s3-user')).toBeInTheDocument;
     expect(screen.getByDisplayValue('storage-s3-password')).toBeInTheDocument;

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -21,12 +21,12 @@ describe('<AddEditStorageModal />', () => {
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('S3'));
-    userEvent.type(screen.getByLabelText('Replication repository name'), 'storage-s3-name');
-    userEvent.type(screen.getByLabelText('S3 bucket name'), 'storage-s3-bucket-name');
-    userEvent.type(screen.getByLabelText('S3 bucket region'), 'storage-s3-bucket-region');
-    userEvent.type(screen.getByLabelText('S3 endpoint'), 'storage-s3-url');
-    userEvent.type(screen.getByLabelText('S3 provider access key'), 'storage-s3-user');
-    userEvent.type(screen.getByLabelText('S3 provider secret access key'), 'storage-s3-password');
+    userEvent.type(screen.getByLabelText(/Replication repository name/), 'storage-s3-name');
+    userEvent.type(screen.getByLabelText(/S3 bucket name/), 'storage-s3-bucket-name');
+    userEvent.type(screen.getByLabelText(/S3 bucket region/), 'storage-s3-bucket-region');
+    userEvent.type(screen.getByLabelText(/S3 endpoint/), 'storage-s3-url');
+    userEvent.type(screen.getByLabelText(/S3 provider access key/), 'storage-s3-user');
+    userEvent.type(screen.getByLabelText(/S3 provider secret access key/), 'storage-s3-password');
 
     expect(screen.getByDisplayValue('storage-s3-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('storage-s3-bucket-name')).toBeInTheDocument;
@@ -46,11 +46,11 @@ describe('<AddEditStorageModal />', () => {
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('AWS S3'));
-    userEvent.type(screen.getByLabelText('Replication repository name'), 'AWS-S3-name');
-    userEvent.type(screen.getByLabelText('S3 bucket name'), 'AWS-S3-bucket-name');
-    userEvent.type(screen.getByLabelText('S3 bucket region'), 'AWS-S3-bucket-region');
-    userEvent.type(screen.getByLabelText('S3 provider access key'), 'AWS-S3-user');
-    userEvent.type(screen.getByLabelText('S3 provider secret access key'), 'AWS-S3-password');
+    userEvent.type(screen.getByLabelText(/Replication repository name/), 'AWS-S3-name');
+    userEvent.type(screen.getByLabelText(/S3 bucket name/), 'AWS-S3-bucket-name');
+    userEvent.type(screen.getByLabelText(/S3 bucket region/), 'AWS-S3-bucket-region');
+    userEvent.type(screen.getByLabelText(/S3 provider access key/), 'AWS-S3-user');
+    userEvent.type(screen.getByLabelText(/S3 provider secret access key/), 'AWS-S3-password');
 
     expect(screen.getByDisplayValue('AWS-S3-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('AWS-S3-bucket-name')).toBeInTheDocument;
@@ -69,10 +69,9 @@ describe('<AddEditStorageModal />', () => {
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('GCP'));
-    userEvent.type(screen.getByLabelText('Repository name'), 'GCP-name');
-    userEvent.type(screen.getByLabelText('GCP bucket name'), 'GCP-bucket-name');
-    userEvent.type(screen.getByLabelText('GCP credential JSON blob'), 'GCP-credentials');
-
+    userEvent.type(screen.getByLabelText(/Repository name/), 'GCP-name');
+    userEvent.type(screen.getByLabelText(/GCP bucket name/), 'GCP-bucket-name');
+    userEvent.type(screen.getByLabelText(/GCP credential JSON blob/), 'GCP-credentials');
     expect(screen.getByDisplayValue('GCP-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('GCP-bucket-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('GCP-credentials')).toBeInTheDocument;
@@ -88,11 +87,11 @@ describe('<AddEditStorageModal />', () => {
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('Azure'));
-    userEvent.click(screen.getByLabelText('Repository information'));
-    userEvent.type(screen.getByLabelText('Repository name'), 'azure-name');
-    userEvent.type(screen.getByLabelText('Azure resource group'), 'azure-resource-group');
-    userEvent.type(screen.getByLabelText('Azure storage account name'), 'azure-account-name');
-    userEvent.type(screen.getByLabelText(/Azure credentials /), 'azure-credentials');
+    userEvent.click(screen.getByRole('dialog', { name: /Repository information/ }));
+    userEvent.type(screen.getByLabelText(/Repository name/), 'azure-name');
+    userEvent.type(screen.getByLabelText(/Azure resource group/), 'azure-resource-group');
+    userEvent.type(screen.getByLabelText(/Azure storage account name/), 'azure-account-name');
+    userEvent.type(screen.getByLabelText(/Azure credentials/), 'azure-credentials');
 
     expect(screen.getByDisplayValue('azure-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('azure-resource-group')).toBeInTheDocument;

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -36,4 +36,30 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByDisplayValue('storage-s3-password')).toBeInTheDocument;
     expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
   });
+
+  it('allows filling an AWS S3 form with valid values', () => {
+    render(
+      <Provider store={store}>
+        <AddEditStorageModal isOpen={true} />
+      </Provider>
+    );
+
+    userEvent.click(screen.getByText('Select a type...'));
+    userEvent.click(screen.getByText('AWS S3'));
+    userEvent.type(screen.getByLabelText('Replication repository name'), 'storage-AWS-S3-name');
+    userEvent.type(screen.getByLabelText('S3 bucket name'), 'storage-AWS-S3-bucket-name');
+    userEvent.type(screen.getByLabelText('S3 bucket region'), 'storage-AWS-S3-bucket-region');
+    userEvent.type(screen.getByLabelText('S3 provider access key'), 'storage-AWS-S3-user');
+    userEvent.type(
+      screen.getByLabelText('S3 provider secret access key'),
+      'storage-AWS-S3-password'
+    );
+
+    expect(screen.getByDisplayValue('storage-AWS-S3-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('storage-AWS-S3-bucket-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('storage-AWS-S3-bucket-region')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('storage-AWS-S3-user')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('storage-AWS-S3-password')).toBeInTheDocument;
+    expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
+  });
 });

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -98,6 +98,6 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByDisplayValue('azure-resource-group')).toBeInTheDocument;
     expect(screen.getByDisplayValue('azure-account-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('azure-credentials')).toBeInTheDocument;
-    // expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
+    expect(screen.getByLabelText('Azure Storage Submit Form')).toBeEnabled;
   });
 });

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -62,4 +62,23 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByDisplayValue('storage-AWS-S3-password')).toBeInTheDocument;
     expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
   });
+
+  it('allows filling an GCP form with valid values', () => {
+    render(
+      <Provider store={store}>
+        <AddEditStorageModal isOpen={true} />
+      </Provider>
+    );
+
+    userEvent.click(screen.getByText('Select a type...'));
+    userEvent.click(screen.getByText('GCP'));
+    userEvent.type(screen.getByLabelText('Repository name'), 'GCP-name');
+    userEvent.type(screen.getByLabelText('GCP bucket name'), 'GCP-bucket-name');
+    userEvent.type(screen.getByLabelText('GCP credential JSON blob'), 'GCP-credentials');
+
+    expect(screen.getByDisplayValue('GCP-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('GCP-bucket-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('GCP-credentials')).toBeInTheDocument;
+    expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
+  });
 });

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -81,4 +81,26 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByDisplayValue('GCP-credentials')).toBeInTheDocument;
     expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
   });
+
+  it('allows filling an Azure form with valid values', () => {
+    render(
+      <Provider store={store}>
+        <AddEditStorageModal isOpen={true} />
+      </Provider>
+    );
+
+    userEvent.click(screen.getByText('Select a type...'));
+    userEvent.click(screen.getByText('Azure'));
+    userEvent.click(screen.getByLabelText('Repository information'));
+    userEvent.type(screen.getByLabelText('Repository name'), 'azure-name');
+    userEvent.type(screen.getByLabelText('Azure resource group'), 'azure-resource-group');
+    userEvent.type(screen.getByLabelText('Azure storage account name'), 'azure-account-name');
+    userEvent.type(screen.getByLabelText(/Azure credentials /), 'azure-credentials');
+
+    expect(screen.getByDisplayValue('azure-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('azure-resource-group')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('azure-account-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('azure-credentials')).toBeInTheDocument;
+    // expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
+  });
 });

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -60,7 +60,7 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
   });
 
-  it('allows filling an GCP form with valid values', () => {
+  it('allows filling a GCP form with valid values', () => {
     render(
       <Provider store={store}>
         <AddEditStorageModal isOpen={true} />

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -34,7 +34,7 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByDisplayValue('storage-s3-url')).toBeInTheDocument;
     expect(screen.getByDisplayValue('storage-s3-user')).toBeInTheDocument;
     expect(screen.getByDisplayValue('storage-s3-password')).toBeInTheDocument;
-    expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
+    expect(screen.getByLabelText('S3 Storage Submit Form')).toBeEnabled;
   });
 
   it('allows filling an AWS S3 form with valid values', () => {
@@ -57,7 +57,7 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByDisplayValue('AWS-S3-bucket-region')).toBeInTheDocument;
     expect(screen.getByDisplayValue('AWS-S3-user')).toBeInTheDocument;
     expect(screen.getByDisplayValue('AWS-S3-password')).toBeInTheDocument;
-    expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
+    expect(screen.getByLabelText('S3 Storage Submit Form')).toBeEnabled;
   });
 
   it('allows filling a GCP form with valid values', () => {

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -76,7 +76,7 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByDisplayValue('GCP-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('GCP-bucket-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('GCP-credentials')).toBeInTheDocument;
-    expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
+    expect(screen.getByLabelText('GCP Storage Submit Form')).toBeEnabled;
   });
 
   it('allows filling an Azure form with valid values', () => {

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -46,20 +46,17 @@ describe('<AddEditStorageModal />', () => {
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('AWS S3'));
-    userEvent.type(screen.getByLabelText('Replication repository name'), 'storage-AWS-S3-name');
-    userEvent.type(screen.getByLabelText('S3 bucket name'), 'storage-AWS-S3-bucket-name');
-    userEvent.type(screen.getByLabelText('S3 bucket region'), 'storage-AWS-S3-bucket-region');
-    userEvent.type(screen.getByLabelText('S3 provider access key'), 'storage-AWS-S3-user');
-    userEvent.type(
-      screen.getByLabelText('S3 provider secret access key'),
-      'storage-AWS-S3-password'
-    );
+    userEvent.type(screen.getByLabelText('Replication repository name'), 'AWS-S3-name');
+    userEvent.type(screen.getByLabelText('S3 bucket name'), 'AWS-S3-bucket-name');
+    userEvent.type(screen.getByLabelText('S3 bucket region'), 'AWS-S3-bucket-region');
+    userEvent.type(screen.getByLabelText('S3 provider access key'), 'AWS-S3-user');
+    userEvent.type(screen.getByLabelText('S3 provider secret access key'), 'AWS-S3-password');
 
-    expect(screen.getByDisplayValue('storage-AWS-S3-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-AWS-S3-bucket-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-AWS-S3-bucket-region')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-AWS-S3-user')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-AWS-S3-password')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('AWS-S3-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('AWS-S3-bucket-name')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('AWS-S3-bucket-region')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('AWS-S3-user')).toBeInTheDocument;
+    expect(screen.getByDisplayValue('AWS-S3-password')).toBeInTheDocument;
     expect(screen.getByRole('button', { name: 'Add Repository' })).toBeEnabled;
   });
 


### PR DESCRIPTION
- Replaces `getByTestId` with `getByLabelText` per react testing library (dom) recommendation by using `aria-label` instead of `data-testid` tag. This also has the advantage of not using a tag only dedicated for tests.
- Replaces (and uses) `getByRole` with `getByTestId` for the primary submit button. This allows to easily identify the button for both "Add" and "Update" repository cases.
- Adds test cases for AWS S3, GCP and Azure storages.
- Fix `input` fields `id` to match `label` `for` (or `fieldId`)  