### PR TITLE
Storage forms validation

### DIFF
--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
@@ -163,6 +163,7 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
       </FormGroup>
       <Flex breakpointMods={[{ modifier: FlexModifiers['space-items-md'] }]}>
         <Button
+          aria-label="GCP Storage Submit Form"
           variant="primary"
           type="submit"
           isDisabled={isAddEditButtonDisabled(
@@ -175,7 +176,6 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           {addEditButtonTextFn(currentStatus)}
         </Button>
         <Button
-          aria-label="GCP Storage Submit Form"
           variant="secondary"
           isDisabled={isCheckConnectionButtonDisabled(
             currentStatus,

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -248,8 +248,53 @@ describe('<AddEditStorageModal />', () => {
     expect(name).toHaveValue('gcp-name');
     expect(bucket).toHaveValue('gcp-bucket-name');
     expect(creds).toHaveValue('GCP-credentials');
-    // TODO: Complete form for submit button to be enabled
-    // expect(addButton).not.toHaveAttribute('disabled');
+    expect(addButton).not.toHaveAttribute('disabled');
+  });
+
+  describe('<GCPForm />', () => {
+    it('allows editing a GCPForm component form with valid values', async () => {
+      const props = {
+        provider: 'gcp',
+        initialStorageValues: {
+          name: 'gcp-name',
+          gcpBucket: 'gcp-bucket',
+          gcpBlob: 'GCP-creds',
+        },
+        onClose: jest.fn(),
+        onAddEditSubmit: jest.fn(),
+        addEditStatus: {
+          state: 'ready',
+          mode: 'edit',
+          message: 'The storage is ready.',
+          reason: '',
+        },
+        checkConnection: jest.fn(),
+      };
+
+      render(
+        <Provider store={store}>
+          <GCPForm {...props} />
+        </Provider>
+      );
+
+      const name = screen.getByLabelText(/Repository name/);
+      const bucket = screen.getByLabelText(/GCP bucket name/);
+      const creds = screen.getByLabelText(/GCP credential JSON blob/);
+      const addButton = screen.getByRole('button', { name: /GCP Storage Submit Form/ });
+
+      expect(addButton).toHaveAttribute('disabled');
+      userEvent.clear(bucket);
+      userEvent.type(bucket, 'new-bucket');
+      userEvent.click(addButton);
+
+      await waitFor(() => {
+        expect(name).toHaveValue('gcp-name');
+        expect(bucket).toHaveValue('new-bucket');
+        expect(creds).toHaveValue('GCP-creds');
+        expect(addButton).not.toHaveAttribute('disabled');
+        expect(props.onAddEditSubmit).toHaveBeenCalled();
+      });
+    });
   });
 
   it('forbids filling a GCP form with unvalid values', async () => {

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -97,12 +97,12 @@ describe('<AddEditStorageModal />', () => {
       const url = screen.getByLabelText(/S3 endpoint/);
       const accessKey = screen.getByLabelText(/S3 provider access key/);
       const secretKey = screen.getByLabelText(/S3 provider secret access key/);
-      const addButton = screen.getByRole('button', { name: /S3 Storage Submit Form/ });
+      const editButton = screen.getByRole('button', { name: /S3 Storage Submit Form/ });
 
-      expect(addButton).toHaveAttribute('disabled');
+      expect(editButton).toHaveAttribute('disabled');
       userEvent.clear(bucketName);
       userEvent.type(bucketName, 'new-bucket');
-      userEvent.click(addButton);
+      userEvent.click(editButton);
 
       await waitFor(() => {
         expect(name).toHaveValue('s3-name');
@@ -111,7 +111,7 @@ describe('<AddEditStorageModal />', () => {
         expect(url).toHaveValue('http://s3.example.com');
         expect(accessKey).toHaveValue('s3-user');
         expect(secretKey).toHaveValue('s3-secret');
-        expect(addButton).not.toHaveAttribute('disabled');
+        expect(editButton).not.toHaveAttribute('disabled');
         expect(props.onAddEditSubmit).toHaveBeenCalled();
       });
     });
@@ -281,18 +281,18 @@ describe('<AddEditStorageModal />', () => {
       const name = screen.getByLabelText(/Repository name/);
       const bucket = screen.getByLabelText(/GCP bucket name/);
       const creds = screen.getByLabelText(/GCP credential JSON blob/);
-      const addButton = screen.getByRole('button', { name: /GCP Storage Submit Form/ });
+      const editButton = screen.getByRole('button', { name: /GCP Storage Submit Form/ });
 
-      expect(addButton).toHaveAttribute('disabled');
+      expect(editButton).toHaveAttribute('disabled');
       userEvent.clear(bucket);
       userEvent.type(bucket, 'new-bucket');
-      userEvent.click(addButton);
+      userEvent.click(editButton);
 
       await waitFor(() => {
         expect(name).toHaveValue('gcp-name');
         expect(bucket).toHaveValue('new-bucket');
         expect(creds).toHaveValue('GCP-creds');
-        expect(addButton).not.toHaveAttribute('disabled');
+        expect(editButton).not.toHaveAttribute('disabled');
         expect(props.onAddEditSubmit).toHaveBeenCalled();
       });
     });

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -48,7 +48,7 @@ describe('<AddEditStorageModal />', () => {
     userEvent.click(screen.getByText('S3'));
 
     const repoName = screen.getByLabelText(/Replication repository name/);
-    userEvent.type(repoName, 'STORAGE-S3-BAD-NAME');
+    userEvent.type(repoName, 'S3-BAD-NAME');
     fireEvent.blur(repoName);
 
     const bucketName = screen.getByLabelText(/S3 bucket name/);
@@ -60,7 +60,7 @@ describe('<AddEditStorageModal />', () => {
     fireEvent.blur(endpoint);
 
     await waitFor(() => {
-      expect(screen.getByText(/Invalid character: "STORAGE-S3-BAD-NAME"/)).not.toBeNull();
+      expect(screen.getByText(/Invalid character: "S3-BAD-NAME"/)).not.toBeNull();
       expect(
         screen.getByText('The bucket name can be between 3 and 63 characters long.')
       ).not.toBeNull();
@@ -103,7 +103,7 @@ describe('<AddEditStorageModal />', () => {
     userEvent.click(screen.getByText('AWS S3'));
 
     const repoName = screen.getByLabelText(/Replication repository name/);
-    userEvent.type(repoName, 'STORAGE-AWS-S3-BAD-NAME');
+    userEvent.type(repoName, 'AWS-S3-BAD-NAME');
     fireEvent.blur(repoName);
 
     const bucketName = screen.getByLabelText(/S3 bucket name/);
@@ -111,7 +111,7 @@ describe('<AddEditStorageModal />', () => {
     fireEvent.blur(bucketName);
 
     await waitFor(() => {
-      expect(screen.getByText(/Invalid character: "STORAGE-AWS-S3-BAD-NAME"/)).not.toBeNull();
+      expect(screen.getByText(/Invalid character: "AWS-S3-BAD-NAME"/)).not.toBeNull();
       expect(
         screen.getByText('The bucket name can be between 3 and 63 characters long.')
       ).not.toBeNull();
@@ -135,6 +135,33 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByDisplayValue('GCP-bucket-name')).toBeInTheDocument;
     expect(screen.getByDisplayValue('GCP-credentials')).toBeInTheDocument;
     expect(screen.getByLabelText('GCP Storage Submit Form')).toBeEnabled;
+  });
+
+  it('forbids filling a GCP form with unvalid values', async () => {
+    render(
+      <Provider store={store}>
+        <AddEditStorageModal isOpen={true} />
+      </Provider>
+    );
+
+    userEvent.click(screen.getByText('Select a type...'));
+    userEvent.click(screen.getByText('GCP'));
+
+    const repoName = screen.getByLabelText(/Repository name/);
+    userEvent.type(repoName, 'GCP-BAD-NAME');
+    fireEvent.blur(repoName);
+
+    const bucketName = screen.getByLabelText(/GCP bucket name/);
+    userEvent.type(bucketName, 'ab');
+    fireEvent.blur(bucketName);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid character: "GCP-BAD-NAME"/)).not.toBeNull();
+      expect(
+        screen.getByText('The bucket name can be between 3 and 63 characters long.')
+      ).not.toBeNull();
+      expect(screen.getByLabelText('GCP Storage Submit Form')).toBeEnabled;
+    });
   });
 
   it('allows filling an Azure form with valid values', () => {

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -92,6 +92,33 @@ describe('<AddEditStorageModal />', () => {
     expect(screen.getByLabelText('S3 Storage Submit Form')).toBeEnabled;
   });
 
+  it('forbids filling an AWS S3 form with unvalid values', async () => {
+    render(
+      <Provider store={store}>
+        <AddEditStorageModal isOpen={true} />
+      </Provider>
+    );
+
+    userEvent.click(screen.getByText('Select a type...'));
+    userEvent.click(screen.getByText('AWS S3'));
+
+    const repoName = screen.getByLabelText(/Replication repository name/);
+    userEvent.type(repoName, 'STORAGE-AWS-S3-BAD-NAME');
+    fireEvent.blur(repoName);
+
+    const bucketName = screen.getByLabelText(/S3 bucket name/);
+    userEvent.type(bucketName, 'ab');
+    fireEvent.blur(bucketName);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid character: "STORAGE-AWS-S3-BAD-NAME"/)).not.toBeNull();
+      expect(
+        screen.getByText('The bucket name can be between 3 and 63 characters long.')
+      ).not.toBeNull();
+      expect(screen.getByLabelText('S3 Storage Submit Form')).toBeDisabled;
+    });
+  });
+
   it('allows filling a GCP form with valid values', () => {
     render(
       <Provider store={store}>

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -8,6 +8,8 @@ import { Provider } from 'react-redux';
 import rootReducer from '../../../../../../../reducers';
 
 import AddEditStorageModal from '../index';
+import S3Form from '../ProviderForms/S3Form';
+import GCPForm from '../ProviderForms/GCPForm';
 
 const store = createStore(rootReducer, {});
 
@@ -55,6 +57,63 @@ describe('<AddEditStorageModal />', () => {
     expect(accessKey).toHaveValue('storage-s3-user');
     expect(secretKey).toHaveValue('storage-s3-password');
     expect(addButton).not.toHaveAttribute('disabled');
+  });
+
+  describe('<S3Form />', () => {
+    it('allows editing a S3 form with valid values', async () => {
+      const props = {
+        provider: 'generic-s3',
+        initialStorageValues: {
+          name: 's3-name',
+          awsBucketName: 's3-bucket-name',
+          awsBucketRegion: 's3-bucket-region',
+          s3Url: 'http://s3.example.com',
+          accessKey: 's3-user',
+          secret: 's3-secret',
+          requireSSL: false,
+        },
+        isAWS: false,
+        onAddEditSubmit: jest.fn(),
+        onClose: jest.fn(),
+        addEditStatus: {
+          state: 'ready',
+          mode: 'edit',
+          message: 'The storage is ready.',
+          reason: '',
+        },
+        checkConnection: jest.fn(),
+      };
+
+      render(
+        <Provider store={store}>
+          <S3Form {...props} />
+        </Provider>
+      );
+
+      const name = screen.getByLabelText(/Replication repository name/);
+      const bucketName = screen.getByLabelText(/S3 bucket name/);
+      const bucketRegion = screen.getByLabelText(/S3 bucket region/);
+      const url = screen.getByLabelText(/S3 endpoint/);
+      const accessKey = screen.getByLabelText(/S3 provider access key/);
+      const secretKey = screen.getByLabelText(/S3 provider secret access key/);
+      const addButton = screen.getByRole('button', { name: /S3 Storage Submit Form/ });
+
+      expect(addButton).toHaveAttribute('disabled');
+      userEvent.clear(bucketName);
+      userEvent.type(bucketName, 'new-bucket');
+      userEvent.click(addButton);
+
+      await waitFor(() => {
+        expect(name).toHaveValue('s3-name');
+        expect(bucketName).toHaveValue('new-bucket');
+        expect(bucketRegion).toHaveValue('s3-bucket-region');
+        expect(url).toHaveValue('http://s3.example.com');
+        expect(accessKey).toHaveValue('s3-user');
+        expect(secretKey).toHaveValue('s3-secret');
+        expect(addButton).not.toHaveAttribute('disabled');
+        expect(props.onAddEditSubmit).toHaveBeenCalled();
+      });
+    });
   });
 
   it('forbids filling a S3 form with unvalid values', async () => {

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -13,28 +13,48 @@ const store = createStore(rootReducer, {});
 
 describe('<AddEditStorageModal />', () => {
   it('allows filling a S3 form with valid values', () => {
+    const props = {
+      isOpen: true,
+      addEditStatus: {
+        state: 'pending',
+        mode: 'add',
+      },
+    };
+
     render(
       <Provider store={store}>
-        <AddEditStorageModal isOpen={true} />
+        <AddEditStorageModal {...props} />
       </Provider>
     );
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('S3'));
-    userEvent.type(screen.getByLabelText(/Replication repository name/), 'storage-s3-name');
-    userEvent.type(screen.getByLabelText(/S3 bucket name/), 'storage-s3-bucket-name');
-    userEvent.type(screen.getByLabelText(/S3 bucket region/), 'storage-s3-bucket-region');
-    userEvent.type(screen.getByLabelText(/S3 endpoint/), 'storage-s3-url');
-    userEvent.type(screen.getByLabelText(/S3 provider access key/), 'storage-s3-user');
-    userEvent.type(screen.getByLabelText(/S3 provider secret access key/), 'storage-s3-password');
 
-    expect(screen.getByDisplayValue('storage-s3-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-s3-bucket-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-s3-bucket-region')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-s3-url')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-s3-user')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('storage-s3-password')).toBeInTheDocument;
-    expect(screen.getByLabelText('S3 Storage Submit Form')).toBeEnabled;
+    const name = screen.getByLabelText(/Replication repository name/);
+    const bucketName = screen.getByLabelText(/S3 bucket name/);
+    const bucketRegion = screen.getByLabelText(/S3 bucket region/);
+    const url = screen.getByLabelText(/S3 endpoint/);
+    const accessKey = screen.getByLabelText(/S3 provider access key/);
+    const secretKey = screen.getByLabelText(/S3 provider secret access key/);
+    const addButton = screen.getByRole('button', { name: /S3 Storage Submit Form/ });
+
+    expect(screen.getByText(/Add replication repository/)).toBeInTheDocument;
+    expect(addButton).toHaveAttribute('disabled');
+
+    userEvent.type(name, 'storage-s3-name');
+    userEvent.type(bucketName, 'storage-s3-bucket-name');
+    userEvent.type(bucketRegion, 'storage-s3-bucket-region');
+    userEvent.type(url, 'storage-s3-url');
+    userEvent.type(accessKey, 'storage-s3-user');
+    userEvent.type(secretKey, 'storage-s3-password');
+
+    expect(name).toHaveValue('storage-s3-name');
+    expect(bucketName).toHaveValue('storage-s3-bucket-name');
+    expect(bucketRegion).toHaveValue('storage-s3-bucket-region');
+    expect(url).toHaveValue('storage-s3-url');
+    expect(accessKey).toHaveValue('storage-s3-user');
+    expect(secretKey).toHaveValue('storage-s3-password');
+    expect(addButton).not.toHaveAttribute('disabled');
   });
 
   it('forbids filling a S3 form with unvalid values', async () => {
@@ -65,31 +85,52 @@ describe('<AddEditStorageModal />', () => {
         screen.getByText('The bucket name can be between 3 and 63 characters long.')
       ).not.toBeNull();
       expect(screen.getByText('S3 Endpoint must be a valid URL.')).not.toBeNull();
-      expect(screen.getByLabelText('S3 Storage Submit Form')).toBeDisabled;
+      expect(screen.getByRole('button', { name: /S3 Storage Submit Form/ })).toHaveAttribute(
+        'disabled'
+      );
     });
   });
 
   it('allows filling an AWS S3 form with valid values', () => {
+    const props = {
+      isOpen: true,
+      addEditStatus: {
+        state: 'pending',
+        mode: 'add',
+      },
+    };
+
     render(
       <Provider store={store}>
-        <AddEditStorageModal isOpen={true} />
+        <AddEditStorageModal {...props} />
       </Provider>
     );
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('AWS S3'));
-    userEvent.type(screen.getByLabelText(/Replication repository name/), 'AWS-S3-name');
-    userEvent.type(screen.getByLabelText(/S3 bucket name/), 'AWS-S3-bucket-name');
-    userEvent.type(screen.getByLabelText(/S3 bucket region/), 'AWS-S3-bucket-region');
-    userEvent.type(screen.getByLabelText(/S3 provider access key/), 'AWS-S3-user');
-    userEvent.type(screen.getByLabelText(/S3 provider secret access key/), 'AWS-S3-password');
 
-    expect(screen.getByDisplayValue('AWS-S3-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('AWS-S3-bucket-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('AWS-S3-bucket-region')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('AWS-S3-user')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('AWS-S3-password')).toBeInTheDocument;
-    expect(screen.getByLabelText('S3 Storage Submit Form')).toBeEnabled;
+    const name = screen.getByLabelText(/Replication repository name/);
+    const bucketName = screen.getByLabelText(/S3 bucket name/);
+    const bucketRegion = screen.getByLabelText(/S3 bucket region/);
+    const accessKey = screen.getByLabelText(/S3 provider access key/);
+    const secretKey = screen.getByLabelText(/S3 provider secret access key/);
+    const addButton = screen.getByRole('button', { name: /S3 Storage Submit Form/ });
+
+    expect(screen.getByText(/Add replication repository/)).toBeInTheDocument;
+    expect(addButton).toHaveAttribute('disabled');
+
+    userEvent.type(name, 'AWS-S3-name');
+    userEvent.type(bucketName, 'AWS-S3-bucket-name');
+    userEvent.type(bucketRegion, 'AWS-S3-bucket-region');
+    userEvent.type(accessKey, 'AWS-S3-user');
+    userEvent.type(secretKey, 'AWS-S3-password');
+
+    expect(name).toHaveValue('AWS-S3-name');
+    expect(bucketName).toHaveValue('AWS-S3-bucket-name');
+    expect(bucketRegion).toHaveValue('AWS-S3-bucket-region');
+    expect(accessKey).toHaveValue('AWS-S3-user');
+    expect(secretKey).toHaveValue('AWS-S3-password');
+    expect(addButton).not.toHaveAttribute('disabled');
   });
 
   it('forbids filling an AWS S3 form with unvalid values', async () => {
@@ -115,26 +156,47 @@ describe('<AddEditStorageModal />', () => {
       expect(
         screen.getByText('The bucket name can be between 3 and 63 characters long.')
       ).not.toBeNull();
-      expect(screen.getByLabelText('S3 Storage Submit Form')).toBeDisabled;
+      expect(screen.getByRole('button', { name: /S3 Storage Submit Form/ })).toHaveAttribute(
+        'disabled'
+      );
     });
   });
 
   it('allows filling a GCP form with valid values', () => {
+    const props = {
+      isOpen: true,
+      addEditStatus: {
+        state: 'pending',
+        mode: 'add',
+      },
+    };
+
     render(
       <Provider store={store}>
-        <AddEditStorageModal isOpen={true} />
+        <AddEditStorageModal {...props} />
       </Provider>
     );
 
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('GCP'));
-    userEvent.type(screen.getByLabelText(/Repository name/), 'GCP-name');
-    userEvent.type(screen.getByLabelText(/GCP bucket name/), 'GCP-bucket-name');
-    userEvent.type(screen.getByLabelText(/GCP credential JSON blob/), 'GCP-credentials');
-    expect(screen.getByDisplayValue('GCP-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('GCP-bucket-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('GCP-credentials')).toBeInTheDocument;
-    expect(screen.getByLabelText('GCP Storage Submit Form')).toBeEnabled;
+
+    const name = screen.getByLabelText(/Repository name/);
+    const bucket = screen.getByLabelText(/GCP bucket name/);
+    const creds = screen.getByLabelText(/GCP credential JSON blob/);
+    const addButton = screen.getByRole('button', { name: /GCP Storage Submit Form/ });
+
+    expect(screen.getByText(/Add replication repository/)).toBeInTheDocument;
+    expect(addButton).toHaveAttribute('disabled');
+
+    userEvent.type(name, 'gcp-name');
+    userEvent.type(bucket, 'gcp-bucket-name');
+    userEvent.type(creds, 'GCP-credentials');
+
+    expect(name).toHaveValue('gcp-name');
+    expect(bucket).toHaveValue('gcp-bucket-name');
+    expect(creds).toHaveValue('GCP-credentials');
+    // TODO: Complete form for submit button to be enabled
+    // expect(addButton).not.toHaveAttribute('disabled');
   });
 
   it('forbids filling a GCP form with unvalid values', async () => {
@@ -160,11 +222,53 @@ describe('<AddEditStorageModal />', () => {
       expect(
         screen.getByText('The bucket name can be between 3 and 63 characters long.')
       ).not.toBeNull();
-      expect(screen.getByLabelText('GCP Storage Submit Form')).toBeEnabled;
+      expect(screen.getByRole('button', { name: /GCP Storage Submit Form/ })).toHaveAttribute(
+        'disabled'
+      );
     });
   });
 
   it('allows filling an Azure form with valid values', () => {
+    const props = {
+      isOpen: true,
+      addEditStatus: {
+        state: 'pending',
+        mode: 'add',
+      },
+    };
+
+    render(
+      <Provider store={store}>
+        <AddEditStorageModal {...props} />
+      </Provider>
+    );
+
+    userEvent.click(screen.getByText('Select a type...'));
+    userEvent.click(screen.getByText('Azure'));
+    userEvent.click(screen.getByRole('dialog', { name: /Repository information/ }));
+
+    const name = screen.getByLabelText(/Repository name/);
+    const group = screen.getByLabelText(/Azure resource group/);
+    const account = screen.getByLabelText(/Azure storage account name/);
+    const creds = screen.getByLabelText(/Azure credentials/);
+    const addButton = screen.getByLabelText(/Azure Storage Submit Form/);
+
+    expect(screen.getByText(/Add replication repository/)).toBeInTheDocument;
+    expect(addButton).toHaveAttribute('disabled');
+
+    userEvent.type(name, 'azure-name');
+    userEvent.type(group, 'azure-resource-group');
+    userEvent.type(account, 'azure-account-name');
+    userEvent.type(creds, 'azure-credentials');
+
+    expect(name).toHaveValue('azure-name');
+    expect(group).toHaveValue('azure-resource-group');
+    expect(account).toHaveValue('azure-account-name');
+    expect(creds).toHaveValue('azure-credentials');
+    expect(addButton).not.toHaveAttribute('disabled');
+  });
+
+  it('forbids filling an Azure form with unvalid values', async () => {
     render(
       <Provider store={store}>
         <AddEditStorageModal isOpen={true} />
@@ -174,15 +278,14 @@ describe('<AddEditStorageModal />', () => {
     userEvent.click(screen.getByText('Select a type...'));
     userEvent.click(screen.getByText('Azure'));
     userEvent.click(screen.getByRole('dialog', { name: /Repository information/ }));
-    userEvent.type(screen.getByLabelText(/Repository name/), 'azure-name');
-    userEvent.type(screen.getByLabelText(/Azure resource group/), 'azure-resource-group');
-    userEvent.type(screen.getByLabelText(/Azure storage account name/), 'azure-account-name');
-    userEvent.type(screen.getByLabelText(/Azure credentials/), 'azure-credentials');
 
-    expect(screen.getByDisplayValue('azure-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('azure-resource-group')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('azure-account-name')).toBeInTheDocument;
-    expect(screen.getByDisplayValue('azure-credentials')).toBeInTheDocument;
-    expect(screen.getByLabelText('Azure Storage Submit Form')).toBeEnabled;
+    const repoName = screen.getByLabelText(/Repository name/);
+    userEvent.type(repoName, 'AZURE-BAD-NAME');
+    fireEvent.blur(repoName);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid character: "AZURE-BAD-NAME"/)).not.toBeNull();
+      expect(screen.getByLabelText(/Azure Storage Submit Form/)).toHaveAttribute('disabled');
+    });
   });
 });

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -128,15 +128,11 @@ describe('<AddEditStorageModal />', () => {
 
     const repoName = screen.getByLabelText(/Replication repository name/);
     userEvent.type(repoName, 'S3-BAD-NAME');
-    fireEvent.blur(repoName);
-
     const bucketName = screen.getByLabelText(/S3 bucket name/);
     userEvent.type(bucketName, 'ab');
-    fireEvent.blur(bucketName);
 
     const endpoint = screen.getByLabelText(/S3 endpoint/);
     userEvent.type(endpoint, 'not-a-url');
-    fireEvent.blur(endpoint);
 
     await waitFor(() => {
       expect(screen.getByText(/Invalid character: "S3-BAD-NAME"/)).not.toBeNull();
@@ -204,11 +200,9 @@ describe('<AddEditStorageModal />', () => {
 
     const repoName = screen.getByLabelText(/Replication repository name/);
     userEvent.type(repoName, 'AWS-S3-BAD-NAME');
-    fireEvent.blur(repoName);
 
     const bucketName = screen.getByLabelText(/S3 bucket name/);
     userEvent.type(bucketName, 'ab');
-    fireEvent.blur(bucketName);
 
     await waitFor(() => {
       expect(screen.getByText(/Invalid character: "AWS-S3-BAD-NAME"/)).not.toBeNull();
@@ -270,11 +264,9 @@ describe('<AddEditStorageModal />', () => {
 
     const repoName = screen.getByLabelText(/Repository name/);
     userEvent.type(repoName, 'GCP-BAD-NAME');
-    fireEvent.blur(repoName);
 
     const bucketName = screen.getByLabelText(/GCP bucket name/);
     userEvent.type(bucketName, 'ab');
-    fireEvent.blur(bucketName);
 
     await waitFor(() => {
       expect(screen.getByText(/Invalid character: "GCP-BAD-NAME"/)).not.toBeNull();
@@ -340,7 +332,6 @@ describe('<AddEditStorageModal />', () => {
 
     const repoName = screen.getByLabelText(/Repository name/);
     userEvent.type(repoName, 'AZURE-BAD-NAME');
-    fireEvent.blur(repoName);
 
     await waitFor(() => {
       expect(screen.getByText(/Invalid character: "AZURE-BAD-NAME"/)).not.toBeNull();


### PR DESCRIPTION
Adds form validation for S3, AWS S3, GCP and Azure fields

Also revisited existing test to add enabled/disabled button properly enforced