### PR TITLE
Prevent errors from accessing new token properties on existing plan objects that didn't have them, fix token remove success message and tooltip

### DIFF
--- a/src/app/home/pages/TokensPage/components/TokenActionsDropdown.tsx
+++ b/src/app/home/pages/TokensPage/components/TokenActionsDropdown.tsx
@@ -46,6 +46,21 @@ const TokenActionsDropdown: React.FunctionComponent<ITokenActionsDropdownProps> 
   //   toggleIsAddEditOpen();
   // };
   const isRemoveDisabled = token.isAssociatedPlans;
+  const removeItem = (
+    <DropdownItem
+      isDisabled={isRemoveDisabled}
+      onClick={() => {
+        setKebabIsOpen(false);
+        toggleConfirmOpen();
+      }}
+      key="removeToken"
+    >
+      Remove
+    </DropdownItem>
+  );
+
+  console.log(token);
+
   return (
     <>
       <Dropdown
@@ -64,23 +79,17 @@ const TokenActionsDropdown: React.FunctionComponent<ITokenActionsDropdownProps> 
           >
             Edit
           </DropdownItem>,
-          <Tooltip
-            isVisible={isRemoveDisabled}
-            position="top"
-            content={<div>Token is associated with a plan and cannot be removed.</div>}
-            key="removeTokenTooltip"
-          >
-            <DropdownItem
-              isDisabled={isRemoveDisabled}
-              onClick={() => {
-                setKebabIsOpen(false);
-                toggleConfirmOpen();
-              }}
-              key="removeToken"
+          isRemoveDisabled ? (
+            <Tooltip
+              position="top"
+              content={<div>Token is associated with a plan and cannot be removed.</div>}
+              key="removeTokenTooltip"
             >
-              Remove
-            </DropdownItem>
-          </Tooltip>,
+              {removeItem}
+            </Tooltip>
+          ) : (
+            removeItem
+          ),
         ]}
         position={DropdownPosition.right}
       />

--- a/src/app/token/duck/sagas.ts
+++ b/src/app/token/duck/sagas.ts
@@ -168,7 +168,7 @@ function* removeTokenSaga(action) {
     ]);
 
     yield put(TokenActions.removeTokenSuccess(name));
-    yield put(AlertActions.alertSuccessTimeout(`Successfully removed cluster "${name}"!`));
+    yield put(AlertActions.alertSuccessTimeout(`Successfully removed token "${name}"!`));
   } catch (err) {
     yield put(AlertActions.alertErrorTimeout(err));
     yield put(TokenActions.removeTokenFailure(err));

--- a/src/app/token/duck/selectors.ts
+++ b/src/app/token/duck/selectors.ts
@@ -1,14 +1,17 @@
 import { createSelector } from 'reselect';
+import { IReduxState } from '../../../reducers';
 
-const planSelector = (state) => state.plan.migPlanList.map((p) => p);
-const tokenSelector = (state) => state.token.tokenList.map((t) => t);
+const planSelector = (state: IReduxState) => state.plan.migPlanList.map((p) => p);
+const tokenSelector = (state: IReduxState) => state.token.tokenList.map((t) => t);
 
 const getTokensWithStatus = createSelector([planSelector, tokenSelector], (plans, tokens) => {
   const tokensWithStatus = tokens.map((token) => {
     const isAssociatedPlans = plans.some(
       (plan) =>
-        plan.MigPlan.spec.destMigTokenRef.name === token.MigToken.metadata.name ||
-        plan.MigPlan.spec.srcMigTokenRef.name === token.MigToken.metadata.name
+        (plan.MigPlan.spec.destMigTokenRef &&
+          plan.MigPlan.spec.destMigTokenRef.name === token.MigToken.metadata.name) ||
+        (plan.MigPlan.spec.srcMigTokenRef &&
+          plan.MigPlan.spec.srcMigTokenRef.name === token.MigToken.metadata.name)
     );
     return { ...token, isAssociatedPlans: isAssociatedPlans };
   });


### PR DESCRIPTION
This fixes three small issues introduced by #953:

* The `getTokensWithStatus` selector references `plan.MigPlan.spec.destMigTokenRef.name` and `plan.MigPlan.spec.srcMigTokenRef.name`, which only exist on plans created since we introduced tokens. For existing CAM installations that upgrade to this new version, their plans won't have associated tokens, so these references will cause an error and crash the Tokens page. I added a condition to make sure `srcMigTokenRef` and `destMigTokenRef` exist before referencing their properties. This kind of issue might be a good candidate for using the [Optional Chaining syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) in the future, but I haven't considered compatibility for that.
* The success message on removing a token used the word "cluster" instead of "token".
* The token remove button has a tooltip to explain why it's disabled, but it was appearing even when it was enabled.