### PR TITLE
NamespacesForm tests

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/__tests__/NamespacesForm.test.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/__tests__/NamespacesForm.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import rootReducer from '../../../../../../../reducers';
+
+import NamespacesForm from '../NamespacesForm';
+
+const store = createStore(rootReducer, {});
+
+describe('<NamespacesForm />', () => {
+  const initProps = {
+    isFetchingNamespaceList: true,
+    setFieldValue: () => {
+      return;
+    },
+    sourceClusterNamespaces: [],
+    values: {
+      persistentVolumes: [],
+      planName: '',
+      pvCopyMethodAssignment: {},
+      pvStorageClassAssignment: {},
+      pvVerifyFlagAssignment: {},
+      sourceTokenRef: {
+        name: '',
+        namespace: '',
+      },
+      targetTokenRef: {
+        name: '',
+        namespace: '',
+      },
+      selectedNamespaces: [],
+      selectedStorage: '',
+      sourceCluster: '',
+      targetCluster: '',
+    },
+  };
+
+  it('has loading status in header', () => {
+    const props = {
+      fetchNamespacesRequest: jest.fn(),
+      isFetchingNamespaceList: true,
+    };
+
+    render(
+      <Provider store={store}>
+        <NamespacesForm {...initProps} {...props} />
+      </Provider>
+    );
+
+    expect(screen.getByRole('heading')).toHaveTextContent('Loading...');
+    expect(props.fetchNamespacesRequest).toHaveBeenCalledTimes(1);
+    expect(props.fetchNamespacesRequest).toHaveBeenCalledWith(initProps.values.sourceCluster);
+  });
+
+  it('has no result found heading', () => {
+    const props = {
+      fetchNamespacesRequest: jest.fn(),
+      isFetchingNamespaceList: false,
+    };
+
+    const { rerender, container } = render(
+      <Provider store={store}>
+        <NamespacesForm {...initProps} {...props} />
+      </Provider>
+    );
+
+    expect(screen.getByRole('heading')).toHaveTextContent('No results found');
+    expect(props.fetchNamespacesRequest).toHaveBeenCalledTimes(1);
+    expect(props.fetchNamespacesRequest).toHaveBeenCalledWith(initProps.values.sourceCluster);
+  });
+
+  it('displays namespaces', () => {
+    const props = {
+      fetchNamespacesRequest: jest.fn(),
+      isFetchingNamespaceList: false,
+      sourceClusterNamespaces: [
+        {
+          name: 'namespace1',
+          podCount: 1,
+          pvcCount: 1,
+          serviceCount: 1,
+        },
+        {
+          name: 'namespace2',
+          podCount: 2,
+          pvcCount: 1,
+          serviceCount: 1,
+        },
+      ],
+    };
+
+    render(
+      <Provider store={store}>
+        <NamespacesForm {...initProps} {...props} />
+      </Provider>
+    );
+    expect(screen.getByRole('cell', { name: 'namespace1' })).toHaveTextContent('namespace1');
+    expect(screen.getByRole('cell', { name: 'namespace2' })).toHaveTextContent('namespace2');
+    expect(props.fetchNamespacesRequest).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This is a good simple example of testing a non connected component. Which would fit into our components unit testing family (It's not "pure" unit testing per say but it follows React Testing Library spirit by simulating something real from the user viewpoint)

Although this works fine for the `NamespacesForm` it doesn't works for some other steps such as the `GeneralForm` because the `WizardContainer` has `withFormik` wrapping the `WizardCcomponent` which requires delving into Formik implementation and mock it. Therefore while discussing with @mturley I realized we don't want to merge this one.

For more details and follow-up up please see https://github.com/konveyor/mig-ui/issues/962
