### PR TITLE
Replace withFormik HoC in WizardContainer with <Formik /> and useFormikContext(), via new <WizardFormik> wrapper

### DIFF
--- a/src/app/home/pages/PlansPage/PlansPage.tsx
+++ b/src/app/home/pages/PlansPage/PlansPage.tsx
@@ -51,7 +51,7 @@ const PlansPageBase: React.FunctionComponent<IPlansPageBaseProps> = ({
   migrationCancelRequest,
   isFetchingInitialPlans,
 }: IPlansPageBaseProps) => {
-  const [isWizardOpen, toggleWizardOpen] = useOpenModal(false);
+  const [isAddWizardOpen, toggleAddWizardOpen] = useOpenModal(false);
 
   const [addPlanDisabledObj, setAddPlanDisabledObj] = useState<IAddPlanDisabledObjModel>({
     isAddPlanDisabled: true,
@@ -126,7 +126,7 @@ const PlansPageBase: React.FunctionComponent<IPlansPageBaseProps> = ({
                       <div>
                         <Button
                           isDisabled={addPlanDisabledObj.isAddPlanDisabled}
-                          onClick={toggleWizardOpen}
+                          onClick={toggleAddWizardOpen}
                           variant="primary"
                         >
                           Add migration plan
@@ -138,7 +138,7 @@ const PlansPageBase: React.FunctionComponent<IPlansPageBaseProps> = ({
                   <PlansTable
                     planList={planList}
                     addPlanDisabledObj={addPlanDisabledObj}
-                    toggleWizardOpen={toggleWizardOpen}
+                    toggleAddWizardOpen={toggleAddWizardOpen}
                   />
                 )}
                 <WizardContainer
@@ -146,8 +146,8 @@ const PlansPageBase: React.FunctionComponent<IPlansPageBaseProps> = ({
                   clusterList={clusterList}
                   storageList={storageList}
                   isEdit={false}
-                  isOpen={isWizardOpen}
-                  onHandleWizardModalClose={toggleWizardOpen}
+                  isOpen={isAddWizardOpen}
+                  onHandleWizardModalClose={toggleAddWizardOpen}
                 />
               </PlanContext.Provider>
             </CardBody>

--- a/src/app/home/pages/PlansPage/components/PlanActions.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanActions.tsx
@@ -18,7 +18,7 @@ import ConfirmModal from '../../../../common/components/ConfirmModal';
 const PlanActions = ({ plan, history }) => {
   const [isMigrateModalOpen, toggleMigrateModalOpen] = useOpenModal(false);
   const [isDeleteModalOpen, toggleDeleteModalOpen] = useOpenModal(false);
-  const [isWizardOpen, toggleWizardOpen] = useOpenModal(false);
+  const [isEditWizardOpen, toggleEditWizardOpen] = useOpenModal(false);
   const planContext = useContext(PlanContext);
   const {
     hasClosedCondition,
@@ -31,7 +31,7 @@ const PlanActions = ({ plan, history }) => {
   } = plan.PlanStatus;
 
   const editPlan = () => {
-    toggleWizardOpen();
+    toggleEditWizardOpen();
   };
 
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
@@ -118,8 +118,8 @@ const PlanActions = ({ plan, history }) => {
           planList={planContext.planList}
           clusterList={planContext.clusterList}
           storageList={planContext.storageList}
-          isOpen={isWizardOpen}
-          onHandleWizardModalClose={toggleWizardOpen}
+          isOpen={isEditWizardOpen}
+          onHandleWizardModalClose={toggleEditWizardOpen}
           editPlanObj={plan.MigPlan}
           isEdit={true}
         />

--- a/src/app/home/pages/PlansPage/components/PlansTable.tsx
+++ b/src/app/home/pages/PlansPage/components/PlansTable.tsx
@@ -17,7 +17,7 @@ import { IPlan } from '../../../../plan/duck/types';
 interface IPlansTableProps {
   planList: IPlan[];
   addPlanDisabledObj: IAddPlanDisabledObjModel;
-  toggleWizardOpen: () => void;
+  toggleAddWizardOpen: () => void;
 }
 
 interface IExpandedCells {
@@ -27,7 +27,7 @@ interface IExpandedCells {
 const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
   planList,
   addPlanDisabledObj,
-  toggleWizardOpen,
+  toggleAddWizardOpen,
 }: IPlansTableProps) => {
   const [expandedCells, setExpandedCells] = useState<IExpandedCells>({});
 
@@ -161,7 +161,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
           <AddPlanDisabledTooltip addPlanDisabledObj={addPlanDisabledObj}>
             <Button
               id="add-plan-btn"
-              onClick={toggleWizardOpen}
+              onClick={toggleAddWizardOpen}
               isDisabled={addPlanDisabledObj.isAddPlanDisabled}
               variant="secondary"
             >

--- a/src/app/home/pages/PlansPage/components/Wizard/CopyOptionsForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/CopyOptionsForm.tsx
@@ -1,21 +1,19 @@
 import React, { useEffect } from 'react';
-import { FormikProps } from 'formik';
+import { useFormikContext } from 'formik';
 import { isEmpty } from 'lodash';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import CopyOptionsTable from './CopyOptionsTable';
 import { IPlanPersistentVolume } from '../../../../../plan/duck/types';
 
-interface ICopyOptionsFormProps
-  extends Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isFetchingPVList'>,
-    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
+type ICopyOptionsFormProps = Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isFetchingPVList'>;
 
 const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
   clusterList,
   currentPlan,
   isFetchingPVList,
-  setFieldValue,
-  values,
 }: ICopyOptionsFormProps) => {
+  const { setFieldValue, values } = useFormikContext<IFormValues>();
+
   const migPlanPvs = currentPlan.spec.persistentVolumes;
 
   const destCluster = clusterList.find(

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { FormikProps } from 'formik';
+import { useFormikContext } from 'formik';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import { Form, FormGroup, Grid, GridItem, TextInput, Title } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
@@ -10,33 +10,24 @@ import { useForcedValidationOnChange } from '../../../../../common/duck/hooks';
 import { NON_ADMIN_ENABLED } from '../../../../../../TEMPORARY_GLOBAL_FLAGS';
 const styles = require('./GeneralForm.module');
 
-interface IGeneralFormProps
-  extends Pick<IOtherProps, 'clusterList' | 'storageList' | 'isEdit'>,
-    Pick<
-      FormikProps<IFormValues>,
-      | 'handleBlur'
-      | 'handleChange'
-      | 'setFieldTouched'
-      | 'setFieldValue'
-      | 'values'
-      | 'touched'
-      | 'errors'
-      | 'validateForm'
-    > {}
+type IGeneralFormProps = Pick<IOtherProps, 'clusterList' | 'storageList' | 'isEdit'>;
 
 const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   clusterList,
   storageList,
-  errors,
-  handleBlur,
-  handleChange,
   isEdit,
-  setFieldTouched,
-  setFieldValue,
-  touched,
-  values,
-  validateForm,
 }: IGeneralFormProps) => {
+  const {
+    handleBlur,
+    handleChange,
+    setFieldTouched,
+    setFieldValue,
+    values,
+    touched,
+    errors,
+    validateForm,
+  } = useFormikContext<IFormValues>();
+
   useForcedValidationOnChange<IFormValues>(values, isEdit, validateForm);
 
   const planNameInputRef = useRef(null);

--- a/src/app/home/pages/PlansPage/components/Wizard/NamespacesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/NamespacesForm.tsx
@@ -1,24 +1,22 @@
 import React, { useEffect } from 'react';
-import { FormikProps } from 'formik';
+import { useFormikContext } from 'formik';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import { Bullseye, EmptyState, Grid, GridItem, Title } from '@patternfly/react-core';
 import NamespacesTable from './NamespacesTable';
 import { Spinner } from '@patternfly/react-core';
 
-interface INamespacesFormProps
-  extends Pick<
-      IOtherProps,
-      'fetchNamespacesRequest' | 'isFetchingNamespaceList' | 'sourceClusterNamespaces'
-    >,
-    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
+type INamespacesFormProps = Pick<
+  IOtherProps,
+  'fetchNamespacesRequest' | 'isFetchingNamespaceList' | 'sourceClusterNamespaces'
+>;
 
 const NamespacesForm: React.FunctionComponent<INamespacesFormProps> = ({
   fetchNamespacesRequest,
   isFetchingNamespaceList,
   sourceClusterNamespaces,
-  setFieldValue,
-  values,
 }: INamespacesFormProps) => {
+  const { setFieldValue, values } = useFormikContext<IFormValues>();
+
   useEffect(() => {
     fetchNamespacesRequest(values.sourceCluster);
   }, []);

--- a/src/app/home/pages/PlansPage/components/Wizard/ResultsStep.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/ResultsStep.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { Bullseye, Title, Button, Flex, FlexModifiers, FlexItem } from '@patternfly/react-core';
+import { Bullseye, Title, Button, Flex, FlexModifiers } from '@patternfly/react-core';
 import ConditionsGrid from './ConditionsGrid';
 import { ICurrentPlanStatus, CurrentPlanState } from '../../../../../plan/duck/reducers';
 import { Spinner } from '@patternfly/react-core';
@@ -10,10 +10,10 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
+import { useFormikContext } from 'formik';
+import { IFormValues } from './WizardContainer';
 
 interface IProps {
-  values: any;
-  errors: any;
   startPlanStatusPolling: (planName) => void;
   onClose: () => void;
   currentPlan: any;
@@ -21,15 +21,14 @@ interface IProps {
   isPollingStatus: boolean;
 }
 
-const ResultsStep: React.FunctionComponent<IProps> = (props) => {
-  const {
-    values,
-    currentPlan,
-    currentPlanStatus,
-    isPollingStatus,
-    startPlanStatusPolling,
-    onClose,
-  } = props;
+const ResultsStep: React.FunctionComponent<IProps> = ({
+  currentPlan,
+  currentPlanStatus,
+  isPollingStatus,
+  startPlanStatusPolling,
+  onClose,
+}: IProps) => {
+  const { values } = useFormikContext<IFormValues>();
 
   const handlePollRestart = () => {
     startPlanStatusPolling(values.planName);

--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { FormikProps } from 'formik';
+import { useFormikContext } from 'formik';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import VolumesTable from './VolumesTable';
 import {
@@ -16,23 +16,19 @@ import { IPlanPersistentVolume } from '../../../../../plan/duck/types';
 
 const styles = require('./VolumesTable.module');
 
-interface IVolumesFormProps
-  extends Pick<
-      IOtherProps,
-      | 'isPVError'
-      | 'currentPlan'
-      | 'currentPlanStatus'
-      | 'getPVResourcesRequest'
-      | 'pvResourceList'
-      | 'isFetchingPVResources'
-      | 'pvDiscoveryRequest'
-      | 'isPollingStatus'
-    >,
-    Pick<FormikProps<IFormValues>, 'setFieldValue' | 'values'> {}
+type IVolumesFormProps = Pick<
+  IOtherProps,
+  | 'isPVError'
+  | 'currentPlan'
+  | 'currentPlanStatus'
+  | 'getPVResourcesRequest'
+  | 'pvResourceList'
+  | 'isFetchingPVResources'
+  | 'pvDiscoveryRequest'
+  | 'isPollingStatus'
+>;
 
 const VolumesForm: React.FunctionComponent<IVolumesFormProps> = ({
-  setFieldValue,
-  values,
   isPVError,
   currentPlan,
   currentPlanStatus,
@@ -42,6 +38,8 @@ const VolumesForm: React.FunctionComponent<IVolumesFormProps> = ({
   pvDiscoveryRequest,
   isPollingStatus,
 }: IVolumesFormProps) => {
+  const { setFieldValue, values } = useFormikContext<IFormValues>();
+
   useEffect(() => {
     //kick off pv discovery once volumes form is reached with current selected namespaces
     pvDiscoveryRequest(values);

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -21,7 +21,6 @@ const styles = require('./WizardComponent.module');
 
 const WizardComponent = (props: IOtherProps) => {
   const [stepIdReached, setStepIdReached] = useState(1);
-  const [updatedSteps, setUpdatedSteps] = useState([]);
   const pollingContext = useContext(PollingContext);
   const [isAddHooksOpen, setIsAddHooksOpen] = useState(false);
 
@@ -105,151 +104,126 @@ const WizardComponent = (props: IOtherProps) => {
       return tokenInfo && tokenInfo.statusType !== StatusType.ERROR;
     });
 
-  useEffect(
-    () => {
-      const steps = [
-        {
-          id: stepId.General,
-          name: 'General',
-          component: (
-            <WizardStepContainer title="General">
-              <GeneralForm clusterList={clusterList} storageList={storageList} isEdit={isEdit} />
-            </WizardStepContainer>
-          ),
-          enableNext: NON_ADMIN_ENABLED
-            ? areFieldsTouchedAndValid([
-                'planName',
-                'sourceCluster',
-                'sourceTokenRef',
-                'targetCluster',
-                'targetTokenRef',
-                'selectedStorage',
-              ]) && areSelectedTokensValid(['sourceTokenRef', 'targetTokenRef'])
-            : areFieldsTouchedAndValid([
-                'planName',
-                'sourceCluster',
-                'targetCluster',
-                'selectedStorage',
-              ]),
-        },
-        {
-          id: stepId.Namespaces,
-          name: 'Namespaces',
-          component: (
-            <WizardStepContainer title="Namespaces">
-              <NamespacesForm
-                isFetchingNamespaceList={isFetchingNamespaceList}
-                fetchNamespacesRequest={fetchNamespacesRequest}
-                sourceClusterNamespaces={sourceClusterNamespaces}
-              />
-            </WizardStepContainer>
-          ),
-          enableNext: !errors.selectedNamespaces,
-          canJumpTo: stepIdReached >= stepId.Namespaces,
-        },
-        {
-          id: stepId.PersistentVolumes,
-          name: 'Persistent volumes',
-          component: (
-            <WizardStepContainer title="Persistent volumes">
-              <VolumesForm
-                currentPlan={currentPlan}
-                isPVError={isPVError}
-                getPVResourcesRequest={getPVResourcesRequest}
-                pvResourceList={pvResourceList}
-                isFetchingPVResources={isFetchingPVList}
-                isPollingStatus={isPollingStatus}
-                pvDiscoveryRequest={pvDiscoveryRequest}
-                currentPlanStatus={currentPlanStatus}
-              />
-            </WizardStepContainer>
-          ),
-          enableNext:
-            !isFetchingPVList &&
-            currentPlanStatus.state !== 'Pending' &&
-            currentPlanStatus.state !== 'Critical',
-          canJumpTo: stepIdReached >= stepId.PersistentVolumes,
-        },
-        {
-          id: stepId.StorageClass,
-          name: 'Copy options',
-          component: (
-            <WizardStepContainer title="Copy options">
-              <CopyOptionsForm
-                currentPlan={currentPlan}
-                isFetchingPVList={isFetchingPVList}
-                clusterList={clusterList}
-              />
-            </WizardStepContainer>
-          ),
-          canJumpTo: stepIdReached >= stepId.StorageClass,
-        },
-        {
-          id: stepId.Hooks,
-          name: 'Hooks',
-          component: (
-            <WizardStepContainer title="Hooks">
-              <HooksStep
-                removeHookRequest={removeHookRequest}
-                addHookRequest={addHookRequest}
-                updateHookRequest={updateHookRequest}
-                isFetchingHookList={isFetchingHookList}
-                migHookList={migHookList}
-                fetchHooksRequest={fetchHooksRequest}
-                watchHookAddEditStatus={watchHookAddEditStatus}
-                hookAddEditStatus={hookAddEditStatus}
-                cancelAddEditWatch={cancelAddEditWatch}
-                resetAddEditState={resetAddEditState}
-                currentPlan={currentPlan}
-                isAddHooksOpen={isAddHooksOpen}
-                setIsAddHooksOpen={setIsAddHooksOpen}
-              />
-            </WizardStepContainer>
-          ),
-          canJumpTo: stepIdReached >= stepId.Hooks,
-          enableNext: !isAddHooksOpen,
-          hideBackButton: isAddHooksOpen,
-          hideCancelButton: isAddHooksOpen,
-          nextButtonText: 'Finish',
-        },
-        {
-          id: stepId.Results,
-          name: 'Results',
-          isFinishedStep: true,
-          component: (
-            <ResultsStep
-              currentPlan={currentPlan}
-              currentPlanStatus={currentPlanStatus}
-              isPollingStatus={isPollingStatus}
-              startPlanStatusPolling={startPlanStatusPolling}
-              onClose={handleClose}
-            />
-          ),
-        },
-      ];
-
-      setUpdatedSteps(steps);
+  const steps = [
+    {
+      id: stepId.General,
+      name: 'General',
+      component: (
+        <WizardStepContainer title="General">
+          <GeneralForm clusterList={clusterList} storageList={storageList} isEdit={isEdit} />
+        </WizardStepContainer>
+      ),
+      enableNext: NON_ADMIN_ENABLED
+        ? areFieldsTouchedAndValid([
+            'planName',
+            'sourceCluster',
+            'sourceTokenRef',
+            'targetCluster',
+            'targetTokenRef',
+            'selectedStorage',
+          ]) && areSelectedTokensValid(['sourceTokenRef', 'targetTokenRef'])
+        : areFieldsTouchedAndValid([
+            'planName',
+            'sourceCluster',
+            'targetCluster',
+            'selectedStorage',
+          ]),
     },
-    //****************** Don't forget to update this array if you add changes to wizard children!!! */
-    // TODO: we should really remove this and just define steps outside the useEffect, if that doesn't break anything
-    [
-      currentPlan,
-      values,
-      isPVError,
-      isFetchingPVList,
-      isPollingStatus,
-      isFetchingNamespaceList,
-      pvResourceList,
-      errors,
-      touched,
-      currentPlanStatus,
-      migHookList,
-      tokenList,
-      hookAddEditStatus,
-      isAddHooksOpen,
-      isFetchingHookList,
-    ]
-  );
+    {
+      id: stepId.Namespaces,
+      name: 'Namespaces',
+      component: (
+        <WizardStepContainer title="Namespaces">
+          <NamespacesForm
+            isFetchingNamespaceList={isFetchingNamespaceList}
+            fetchNamespacesRequest={fetchNamespacesRequest}
+            sourceClusterNamespaces={sourceClusterNamespaces}
+          />
+        </WizardStepContainer>
+      ),
+      enableNext: !errors.selectedNamespaces,
+      canJumpTo: stepIdReached >= stepId.Namespaces,
+    },
+    {
+      id: stepId.PersistentVolumes,
+      name: 'Persistent volumes',
+      component: (
+        <WizardStepContainer title="Persistent volumes">
+          <VolumesForm
+            currentPlan={currentPlan}
+            isPVError={isPVError}
+            getPVResourcesRequest={getPVResourcesRequest}
+            pvResourceList={pvResourceList}
+            isFetchingPVResources={isFetchingPVList}
+            isPollingStatus={isPollingStatus}
+            pvDiscoveryRequest={pvDiscoveryRequest}
+            currentPlanStatus={currentPlanStatus}
+          />
+        </WizardStepContainer>
+      ),
+      enableNext:
+        !isFetchingPVList &&
+        currentPlanStatus.state !== 'Pending' &&
+        currentPlanStatus.state !== 'Critical',
+      canJumpTo: stepIdReached >= stepId.PersistentVolumes,
+    },
+    {
+      id: stepId.StorageClass,
+      name: 'Copy options',
+      component: (
+        <WizardStepContainer title="Copy options">
+          <CopyOptionsForm
+            currentPlan={currentPlan}
+            isFetchingPVList={isFetchingPVList}
+            clusterList={clusterList}
+          />
+        </WizardStepContainer>
+      ),
+      canJumpTo: stepIdReached >= stepId.StorageClass,
+    },
+    {
+      id: stepId.Hooks,
+      name: 'Hooks',
+      component: (
+        <WizardStepContainer title="Hooks">
+          <HooksStep
+            removeHookRequest={removeHookRequest}
+            addHookRequest={addHookRequest}
+            updateHookRequest={updateHookRequest}
+            isFetchingHookList={isFetchingHookList}
+            migHookList={migHookList}
+            fetchHooksRequest={fetchHooksRequest}
+            watchHookAddEditStatus={watchHookAddEditStatus}
+            hookAddEditStatus={hookAddEditStatus}
+            cancelAddEditWatch={cancelAddEditWatch}
+            resetAddEditState={resetAddEditState}
+            currentPlan={currentPlan}
+            isAddHooksOpen={isAddHooksOpen}
+            setIsAddHooksOpen={setIsAddHooksOpen}
+          />
+        </WizardStepContainer>
+      ),
+      canJumpTo: stepIdReached >= stepId.Hooks,
+      enableNext: !isAddHooksOpen,
+      hideBackButton: isAddHooksOpen,
+      hideCancelButton: isAddHooksOpen,
+      nextButtonText: 'Finish',
+    },
+    {
+      id: stepId.Results,
+      name: 'Results',
+      isFinishedStep: true,
+      component: (
+        <ResultsStep
+          currentPlan={currentPlan}
+          currentPlanStatus={currentPlanStatus}
+          isPollingStatus={isPollingStatus}
+          startPlanStatusPolling={startPlanStatusPolling}
+          onClose={handleClose}
+        />
+      ),
+    },
+  ];
 
   const onMove: WizardStepFunctionType = (newStep, prevStep) => {
     //stop pv polling when navigating
@@ -301,7 +275,7 @@ const WizardComponent = (props: IOtherProps) => {
           onBack={onMove}
           title="Create a migration plan"
           onClose={handleClose}
-          steps={updatedSteps}
+          steps={steps}
           isFullWidth
           isCompactNav
           className={styles.wizardModifier}

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -25,19 +25,7 @@ const WizardComponent = (props: IOtherProps) => {
   const pollingContext = useContext(PollingContext);
   const [isAddHooksOpen, setIsAddHooksOpen] = useState(false);
 
-  const {
-    values,
-    touched,
-    errors,
-    handleChange,
-    handleBlur,
-    setFieldTouched,
-    setFieldValue,
-    resetForm,
-    validateForm,
-  } = useFormikContext<IFormValues>();
-  // TODO we should call useFormikContext in each step's form component to get these
-  //   instead of passing them down as props through all the layers
+  const { values, touched, errors, resetForm } = useFormikContext<IFormValues>();
 
   const {
     clusterList,
@@ -125,19 +113,7 @@ const WizardComponent = (props: IOtherProps) => {
           name: 'General',
           component: (
             <WizardStepContainer title="General">
-              <GeneralForm
-                clusterList={clusterList}
-                storageList={storageList}
-                values={values}
-                errors={errors}
-                touched={touched}
-                handleBlur={handleBlur}
-                handleChange={handleChange}
-                setFieldTouched={setFieldTouched}
-                setFieldValue={setFieldValue}
-                validateForm={validateForm}
-                isEdit={isEdit}
-              />
+              <GeneralForm clusterList={clusterList} storageList={storageList} isEdit={isEdit} />
             </WizardStepContainer>
           ),
           enableNext: NON_ADMIN_ENABLED
@@ -162,8 +138,6 @@ const WizardComponent = (props: IOtherProps) => {
           component: (
             <WizardStepContainer title="Namespaces">
               <NamespacesForm
-                values={values}
-                setFieldValue={setFieldValue}
                 isFetchingNamespaceList={isFetchingNamespaceList}
                 fetchNamespacesRequest={fetchNamespacesRequest}
                 sourceClusterNamespaces={sourceClusterNamespaces}
@@ -179,8 +153,6 @@ const WizardComponent = (props: IOtherProps) => {
           component: (
             <WizardStepContainer title="Persistent volumes">
               <VolumesForm
-                values={values}
-                setFieldValue={setFieldValue}
                 currentPlan={currentPlan}
                 isPVError={isPVError}
                 getPVResourcesRequest={getPVResourcesRequest}
@@ -204,8 +176,6 @@ const WizardComponent = (props: IOtherProps) => {
           component: (
             <WizardStepContainer title="Copy options">
               <CopyOptionsForm
-                values={values}
-                setFieldValue={setFieldValue}
                 currentPlan={currentPlan}
                 isFetchingPVList={isFetchingPVList}
                 clusterList={clusterList}
@@ -248,8 +218,6 @@ const WizardComponent = (props: IOtherProps) => {
           isFinishedStep: true,
           component: (
             <ResultsStep
-              values={values}
-              errors={errors}
               currentPlan={currentPlan}
               currentPlanStatus={currentPlanStatus}
               isPollingStatus={isPollingStatus}

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -123,6 +123,8 @@ const WizardContainer: React.FunctionComponent<IOtherProps> = (props: IOtherProp
     initialValues.targetCluster = editPlanObj.spec.destMigClusterRef.name || null;
     initialValues.selectedNamespaces = editPlanObj.spec.namespaces || [];
     initialValues.selectedStorage = editPlanObj.spec.migStorageRef.name || null;
+    initialValues.targetTokenRef = editPlanObj.spec.destMigTokenRef || null;
+    initialValues.sourceTokenRef = editPlanObj.spec.srcMigTokenRef || null;
     // TODO need to look into this closer, but it was resetting form values after pv discovery is run & messing with the UI state
     // See https://github.com/konveyor/mig-ui/issues/797
     // initialValues.persistentVolumes = editPlanObj.spec.persistentVolumes || [];

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -116,7 +116,7 @@ export const defaultInitialValues: IFormValues = {
 
 const WizardContainer: React.FunctionComponent<IOtherProps> = (props: IOtherProps) => {
   const { editPlanObj, isEdit, planList } = props;
-  const initialValues = defaultInitialValues;
+  const initialValues = { ...defaultInitialValues };
   if (editPlanObj && isEdit) {
     initialValues.planName = editPlanObj.metadata.name || '';
     initialValues.sourceCluster = editPlanObj.spec.srcMigClusterRef.name || null;

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -1,9 +1,8 @@
-import { withFormik, FormikErrors } from 'formik';
+import React from 'react';
 import WizardComponent from './WizardComponent';
 import { PlanActions } from '../../../../../plan/duck/actions';
 import planSelectors from '../../../../../plan/duck/selectors';
 import { connect } from 'react-redux';
-import utils from '../../../../../common/duck/utils';
 import { ICurrentPlanStatus } from '../../../../../plan/duck/reducers';
 import { IMigHook } from '../../../../../../client/resources/conversions';
 import {
@@ -26,7 +25,7 @@ import { IStorage } from '../../../../../storage/duck/types';
 import { IReduxState } from '../../../../../../reducers';
 import { IToken } from '../../../../../token/duck/types';
 import { INameNamespaceRef } from '../../../../../common/duck/types';
-import { NON_ADMIN_ENABLED } from '../../../../../../TEMPORARY_GLOBAL_FLAGS';
+import WizardFormik from './WizardFormik';
 
 export interface IFormValues {
   planName: string;
@@ -101,78 +100,39 @@ export interface IOtherProps {
   validatePlanPollStop: () => void;
 }
 
-const WizardContainer = withFormik<IOtherProps, IFormValues>({
-  mapPropsToValues: ({ editPlanObj, isEdit }) => {
-    const values: IFormValues = {
-      planName: '',
-      sourceCluster: null,
-      sourceTokenRef: null,
-      targetCluster: null,
-      targetTokenRef: null,
-      selectedNamespaces: [],
-      selectedStorage: null,
-      persistentVolumes: [],
-      pvStorageClassAssignment: {},
-      pvVerifyFlagAssignment: {},
-      pvCopyMethodAssignment: {},
-    };
-    if (editPlanObj && isEdit) {
-      values.planName = editPlanObj.metadata.name || '';
-      values.sourceCluster = editPlanObj.spec.srcMigClusterRef.name || null;
-      values.targetCluster = editPlanObj.spec.destMigClusterRef.name || null;
-      values.selectedNamespaces = editPlanObj.spec.namespaces || [];
-      values.selectedStorage = editPlanObj.spec.migStorageRef.name || null;
-      // TODO need to look into this closer, but it was resetting form values after pv discovery is run & messing with the UI state
-      // See https://github.com/konveyor/mig-ui/issues/797
-      // values.persistentVolumes = editPlanObj.spec.persistentVolumes || [];
-    }
+export const defaultInitialValues: IFormValues = {
+  planName: '',
+  sourceCluster: null,
+  sourceTokenRef: null,
+  targetCluster: null,
+  targetTokenRef: null,
+  selectedNamespaces: [],
+  selectedStorage: null,
+  persistentVolumes: [],
+  pvStorageClassAssignment: {},
+  pvVerifyFlagAssignment: {},
+  pvCopyMethodAssignment: {},
+};
 
-    return values;
-  },
-
-  validate: (values, props) => {
-    const errors: any = {}; // TODO figure out why using FormikErrors<IFormValues> here causes type errors below
-
-    if (!values.planName) {
-      errors.planName = 'Required';
-    } else if (!utils.testDNS1123(values.planName)) {
-      errors.planName = utils.DNS1123Error(values.planName);
-    } else if (
-      !props.isEdit &&
-      props.planList.some((plan) => plan.MigPlan.metadata.name === values.planName)
-    ) {
-      errors.planName =
-        'A plan with that name already exists. Enter a unique name for the migration plan.';
-    }
-    if (!values.sourceCluster) {
-      errors.sourceCluster = 'Required';
-    }
-    if (!values.selectedNamespaces || values.selectedNamespaces.length === 0) {
-      errors.selectedNamespaces = 'Required';
-    }
-    if (!values.targetCluster) {
-      errors.targetCluster = 'Required';
-    }
-    if (NON_ADMIN_ENABLED) {
-      if (!values.sourceTokenRef) {
-        errors.sourceTokenRef = 'Required';
-      }
-      if (!values.targetTokenRef) {
-        errors.targetTokenRef = 'Required';
-      }
-    }
-    if (!values.selectedStorage) {
-      errors.selectedStorage = 'Required';
-    }
-    return errors;
-  },
-
-  handleSubmit: () => {
-    return null;
-  },
-  validateOnBlur: false,
-  enableReinitialize: true,
-})(WizardComponent);
+const WizardContainer: React.FunctionComponent<IOtherProps> = (props: IOtherProps) => {
+  const { editPlanObj, isEdit, planList } = props;
+  const initialValues = defaultInitialValues;
+  if (editPlanObj && isEdit) {
+    initialValues.planName = editPlanObj.metadata.name || '';
+    initialValues.sourceCluster = editPlanObj.spec.srcMigClusterRef.name || null;
+    initialValues.targetCluster = editPlanObj.spec.destMigClusterRef.name || null;
+    initialValues.selectedNamespaces = editPlanObj.spec.namespaces || [];
+    initialValues.selectedStorage = editPlanObj.spec.migStorageRef.name || null;
+    // TODO need to look into this closer, but it was resetting form values after pv discovery is run & messing with the UI state
+    // See https://github.com/konveyor/mig-ui/issues/797
+    // initialValues.persistentVolumes = editPlanObj.spec.persistentVolumes || [];
+  }
+  return (
+    <WizardFormik initialValues={initialValues} isEdit={isEdit} planList={planList}>
+      <WizardComponent {...props} />
+    </WizardFormik>
+  );
+};
 
 const mapStateToProps = (state: IReduxState) => {
   return {

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Formik } from 'formik';
+import { IPlan } from '../../../../../plan/duck/types';
+import { IFormValues } from './WizardContainer';
+import utils from '../../../../../common/duck/utils';
+import { NON_ADMIN_ENABLED } from '../../../../../../TEMPORARY_GLOBAL_FLAGS';
+
+export interface IWizardFormikProps {
+  initialValues: IFormValues;
+  isEdit?: boolean;
+  planList?: IPlan[];
+  children: React.ReactNode;
+}
+
+const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
+  initialValues,
+  isEdit = false,
+  planList = [],
+  children,
+}: IWizardFormikProps) => (
+  <Formik<IFormValues>
+    initialValues={initialValues}
+    validate={(values: IFormValues) => {
+      const errors: { [key in keyof IFormValues]?: string } = {}; // TODO figure out why using FormikErrors<IFormValues> here causes type errors below
+
+      if (!values.planName) {
+        errors.planName = 'Required';
+      } else if (!utils.testDNS1123(values.planName)) {
+        errors.planName = utils.DNS1123Error(values.planName);
+      } else if (
+        !isEdit &&
+        planList.some((plan) => plan.MigPlan.metadata.name === values.planName)
+      ) {
+        errors.planName =
+          'A plan with that name already exists. Enter a unique name for the migration plan.';
+      }
+      if (!values.sourceCluster) {
+        errors.sourceCluster = 'Required';
+      }
+      if (!values.selectedNamespaces || values.selectedNamespaces.length === 0) {
+        errors.selectedNamespaces = 'Required';
+      }
+      if (!values.targetCluster) {
+        errors.targetCluster = 'Required';
+      }
+      if (NON_ADMIN_ENABLED) {
+        if (!values.sourceTokenRef) {
+          errors.sourceTokenRef = 'Required';
+        }
+        if (!values.targetTokenRef) {
+          errors.targetTokenRef = 'Required';
+        }
+      }
+      if (!values.selectedStorage) {
+        errors.selectedStorage = 'Required';
+      }
+      return errors;
+    }}
+    onSubmit={() => {
+      return null;
+    }}
+    validateOnBlur={false}
+    enableReinitialize
+  >
+    {children}
+  </Formik>
+);
+
+export default WizardFormik;


### PR DESCRIPTION
Closes #962.

This PR changes the `withFormik` higher-order-component call in `WizardContainer` to instead use a new `<WizardFormik>` wrapper component, which itself uses a newer Formik API (`<Formik>` component wrapping the form, and `useFormikContext()` calls in descendant components). https://formik.org/docs/api/useFormikContext

This is cleaner for two reasons:
1. We no longer have to pass all the FormikProps down from WizardComponent into each wizard step, the steps themselves can pull those props out of `useFormikContext()`.
2. Because the individual wizard step components no longer directly expect props from formik, they can be rendered in a unit test with `<WizardFormik>` directly wrapping them, and formik behavior specific to each wizard step can be tested without mounting the rest of the wizard.

The `WizardFormik` component contains all the configuration details that were previously passed to `withFormik`, except for the `mapPropsToValues` function which has been replaced by `initialValues`. I exposed `initialValues` as a prop and defined it in `WizardContainer`, so that we can use alternate initial values in unit tests. The `defaultInitialValues` are now exported from `WizardContainer` if we want to just use that in a unit test.

This might also be a better pattern to use in the future for smaller forms, but it's not as crucial for those right now since they don't pass these props down through so many layers that we might want to test independently. So I left `withFormik` alone outside the wizard for now.

cc @gildub , this should make your form component unit tests easier.
cc @ibolton336, this might help us fix some of the weird Formik issues we were having: I think moving from `mapPropsToValues` to `initialValues` might have had some effect on the initialization/re-initialization issues, but I haven't verified that.