### PR TITLE
Add temporary NON_ADMIN_ENABLED global flag

### DIFF
--- a/src/TEMPORARY_GLOBAL_FLAGS.ts
+++ b/src/TEMPORARY_GLOBAL_FLAGS.ts
@@ -1,0 +1,3 @@
+// NATODO delete this file and remove all references when we are ready to release non-admin support
+
+export const NON_ADMIN_ENABLED = false;

--- a/src/TEMPORARY_GLOBAL_FLAGS.ts
+++ b/src/TEMPORARY_GLOBAL_FLAGS.ts
@@ -1,3 +1,4 @@
 // NATODO delete this file and remove all references when we are ready to release non-admin support
+// (will need to manually revert changes from https://github.com/konveyor/mig-ui/pull/966)
 
 export const NON_ADMIN_ENABLED = false;

--- a/src/app/AppComponent.tsx
+++ b/src/app/AppComponent.tsx
@@ -21,6 +21,7 @@ import { TokenActions } from './token/duck/actions';
 import AlertModal from './common/components/AlertModal';
 import ErrorModal from './common/components/ErrorModal';
 import { ICluster } from './cluster/duck/types';
+import { NON_ADMIN_ENABLED } from '../TEMPORARY_GLOBAL_FLAGS';
 
 interface IProps {
   isLoggedIn?: boolean;
@@ -137,16 +138,18 @@ const AppComponent: React.SFC<IProps> = ({
   };
 
   const startDefaultTokenPolling = () => {
-    const tokenPollParams = {
-      asyncFetch: tokenSagas.fetchTokensGenerator,
-      callback: handleTokenPoll,
-      delay: StatusPollingInterval,
-      retryOnFailure: true,
-      retryAfter: 5,
-      stopAfterRetries: 2,
-      pollName: 'token',
-    };
-    startTokenPolling(tokenPollParams);
+    if (NON_ADMIN_ENABLED) {
+      const tokenPollParams = {
+        asyncFetch: tokenSagas.fetchTokensGenerator,
+        callback: handleTokenPoll,
+        delay: StatusPollingInterval,
+        retryOnFailure: true,
+        retryAfter: 5,
+        stopAfterRetries: 2,
+        pollName: 'token',
+      };
+      startTokenPolling(tokenPollParams);
+    }
   };
 
   return (

--- a/src/app/auth/duck/reducers.ts
+++ b/src/app/auth/duck/reducers.ts
@@ -1,5 +1,6 @@
 import { AuthActionTypes } from './actions';
 import { IMigMeta, ILoginParams } from './types';
+import { NON_ADMIN_ENABLED } from '../../../TEMPORARY_GLOBAL_FLAGS';
 
 const LS_KEY_HAS_LOGGED_IN = 'hasLoggedIn';
 const hasLoggedIn = JSON.parse(localStorage.getItem(LS_KEY_HAS_LOGGED_IN));
@@ -24,7 +25,7 @@ const INITIAL_STATE: IAuthReducerState = {
   user: null,
   oauthMeta: null,
   certError: null,
-  isAdmin: null,
+  isAdmin: NON_ADMIN_ENABLED ? null : true,
   isHideWelcomeScreen: hasLoggedIn ? hasLoggedIn.isHideWelcomeScreen : true,
   tenantNamespaceList: [],
   migMeta: {},
@@ -39,7 +40,7 @@ export const authReducer: AuthReducerFn = (state = INITIAL_STATE, action) => {
     case AuthActionTypes.SET_OAUTH_META:
       return { ...state, oauthMeta: action.oauthMeta };
     case AuthActionTypes.SET_IS_ADMIN:
-      return { ...state, isAdmin: action.hasAdmin };
+      return NON_ADMIN_ENABLED ? { ...state, isAdmin: action.hasAdmin } : state;
     case AuthActionTypes.CERT_ERROR_OCCURRED:
       return { ...state, certError: { failedUrl: action.failedUrl } };
     case AuthActionTypes.SET_WELCOME_SCREEN_BOOL:

--- a/src/app/auth/duck/sagas.ts
+++ b/src/app/auth/duck/sagas.ts
@@ -9,6 +9,7 @@ import moment from 'moment';
 
 import { isSelfSignedCertError, handleSelfSignedCertError } from '../../common/duck/utils';
 import { getActiveNamespaceFromStorage } from '../../common/helpers';
+import { NON_ADMIN_ENABLED } from '../../../TEMPORARY_GLOBAL_FLAGS';
 
 const LS_KEY_CURRENT_USER = 'currentUser';
 
@@ -125,7 +126,9 @@ export function* fetchIsAdmin(): any {
 
 export function* loginSuccess() {
   yield put(AuthActions.checkHasLoggedIn());
-  yield put(AuthActions.fetchIsAdmin());
+  if (NON_ADMIN_ENABLED) {
+    yield put(AuthActions.fetchIsAdmin());
+  }
 }
 
 function* watchAuthEvents() {

--- a/src/app/auth/duck/sagas.ts
+++ b/src/app/auth/duck/sagas.ts
@@ -125,8 +125,8 @@ export function* fetchIsAdmin(): any {
 }
 
 export function* loginSuccess() {
-  yield put(AuthActions.checkHasLoggedIn());
   if (NON_ADMIN_ENABLED) {
+    yield put(AuthActions.checkHasLoggedIn());
     yield put(AuthActions.fetchIsAdmin());
   }
 }
@@ -136,9 +136,11 @@ function* watchAuthEvents() {
   yield takeLatest(AuthActionTypes.INIT_FROM_STORAGE, initFromStorage);
   yield takeLatest(AuthActionTypes.FETCH_TOKEN, fetchToken);
   yield takeLatest(AuthActionTypes.FETCH_OAUTH_META, fetchOauthMeta);
-  yield takeLatest(AuthActionTypes.FETCH_IS_ADMIN, fetchIsAdmin);
   yield takeLatest(AuthActionTypes.LOGIN_SUCCESS, loginSuccess);
-  yield takeLatest(AuthActionTypes.CHECK_HAS_LOGGED_IN, checkHasLoggedIn);
+  if (NON_ADMIN_ENABLED) {
+    yield takeLatest(AuthActionTypes.CHECK_HAS_LOGGED_IN, checkHasLoggedIn);
+    yield takeLatest(AuthActionTypes.FETCH_IS_ADMIN, fetchIsAdmin);
+  }
   yield takeLatest(AuthActionTypes.FETCH_TENANT_NAMESPACES, fetchTenantNamespaces);
 }
 

--- a/src/app/common/components/PageHeaderComponent.tsx
+++ b/src/app/common/components/PageHeaderComponent.tsx
@@ -18,6 +18,7 @@ import {
 import accessibleStyles from '@patternfly/react-styles/css/utilities/Accessibility/accessibility';
 
 import { css } from '@patternfly/react-styles';
+import { NON_ADMIN_ENABLED } from '../../../TEMPORARY_GLOBAL_FLAGS';
 const styles = require('./PageHeaderComponent.module');
 
 interface PageHeaderComponentProps extends Omit<PageHeaderProps, 'logo'> {
@@ -37,7 +38,7 @@ const PageHeaderComponent: React.FunctionComponent<PageHeaderComponentProps> = (
     toolbar={
       <Toolbar>
         <ToolbarGroup>
-          {isAdmin !== null && (
+          {NON_ADMIN_ENABLED && isAdmin !== null && (
             <ToolbarItem>
               <IconWithText icon={<UserIcon />} text={isAdmin ? 'Admin' : 'Non-admin'} />
             </ToolbarItem>
@@ -63,12 +64,14 @@ const PageHeaderComponent: React.FunctionComponent<PageHeaderComponentProps> = (
     logo={
       <>
         <Brand className={styles.logoPointer} src={openshiftLogo} alt="OpenShift Logo" />
-        <Title
-          size="2xl"
-          style={{ marginLeft: 40, backgroundColor: 'red', color: 'white', padding: 10 }}
-        >
-          WORK IN PROGRESS
-        </Title>
+        {NON_ADMIN_ENABLED && (
+          <Title
+            size="2xl"
+            style={{ marginLeft: 40, backgroundColor: 'red', color: 'white', padding: 10 }}
+          >
+            WORK IN PROGRESS
+          </Title>
+        )}
       </>
     }
     {...props}

--- a/src/app/common/components/PageHeaderComponent.tsx
+++ b/src/app/common/components/PageHeaderComponent.tsx
@@ -46,7 +46,7 @@ const PageHeaderComponent: React.FunctionComponent<PageHeaderComponentProps> = (
         </ToolbarGroup>
 
         <ToolbarGroup className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnLg)}>
-          {!isWelcomeScreen && (
+          {NON_ADMIN_ENABLED && !isWelcomeScreen && (
             <ToolbarItem>
               <Button
                 id="default-example-uid-02"

--- a/src/app/home/HomeComponent.tsx
+++ b/src/app/home/HomeComponent.tsx
@@ -11,6 +11,9 @@ import { ICluster } from '../cluster/duck/types';
 import PageHeaderComponent from '../common/components/PageHeaderComponent';
 import ActiveNamespaceModal from '../common/components/ActiveNamespaceModal';
 import { getActiveNamespaceFromStorage } from '../common/helpers';
+
+import { NON_ADMIN_ENABLED } from '../../TEMPORARY_GLOBAL_FLAGS';
+
 const mainContainerId = 'mig-ui-page-main-container';
 
 const NavItemLink: React.FunctionComponent<{ to: string; label: string }> = ({ to, label }) => {
@@ -43,7 +46,7 @@ const HomeComponent: React.FunctionComponent<IHomeComponentProps> = ({
         <NavItemLink to="/clusters" label="Clusters" />
         <NavItemLink to="/storages" label="Replication repositories" />
         <NavItemLink to="/plans" label="Migration plans" />
-        <NavItemLink to="/tokens" label="Tokens" />
+        {NON_ADMIN_ENABLED && <NavItemLink to="/tokens" label="Tokens" />}
       </NavList>
     </Nav>
   );
@@ -101,9 +104,11 @@ const HomeComponent: React.FunctionComponent<IHomeComponentProps> = ({
                 isLoggedIn
                 component={LogsPage}
               />
-              <Route exact path="/tokens">
-                <TokensPage />
-              </Route>
+              {NON_ADMIN_ENABLED && (
+                <Route exact path="/tokens">
+                  <TokensPage />
+                </Route>
+              )}
               <Route path="*">
                 <Redirect to="/" />
               </Route>

--- a/src/app/home/HomeComponent.tsx
+++ b/src/app/home/HomeComponent.tsx
@@ -68,24 +68,28 @@ const HomeComponent: React.FunctionComponent<IHomeComponentProps> = ({
       skipToContent={<SkipToContent href={`#${mainContainerId}`}>Skip to content</SkipToContent>}
       mainContainerId={mainContainerId}
     >
-      <ActiveNamespaceModal
-        isOpen={namespaceSelectIsOpen}
-        onClose={() => setNamespaceSelectIsOpen(false)}
-      />
+      {NON_ADMIN_ENABLED && (
+        <ActiveNamespaceModal
+          isOpen={namespaceSelectIsOpen}
+          onClose={() => setNamespaceSelectIsOpen(false)}
+        />
+      )}
 
       <Switch>
         <Route exact path="/">
-          {!isHideWelcomeScreen || !activeNamespace ? (
+          {NON_ADMIN_ENABLED && (!isHideWelcomeScreen || !activeNamespace) ? (
             <Redirect to="/welcome" />
           ) : (
             <Redirect to="/clusters" />
           )}
         </Route>
-        <Route exact path="/welcome">
-          <WelcomePage openNamespaceSelect={() => setNamespaceSelectIsOpen(true)} />
-        </Route>
+        {NON_ADMIN_ENABLED && (
+          <Route exact path="/welcome">
+            <WelcomePage openNamespaceSelect={() => setNamespaceSelectIsOpen(true)} />
+          </Route>
+        )}
         <Route path="*">
-          {activeNamespace ? (
+          {activeNamespace || !NON_ADMIN_ENABLED ? (
             // Don't render any route other than /welcome until the user selects a namespace
             <Switch>
               <Route exact path="/clusters">

--- a/src/app/home/pages/ClustersPage/components/ClusterActionsDropdown.tsx
+++ b/src/app/home/pages/ClustersPage/components/ClusterActionsDropdown.tsx
@@ -7,6 +7,7 @@ import { ClusterContext } from '../../../duck/context';
 import { IClusterInfo } from '../helpers';
 import { ICluster } from '../../../../cluster/duck/types';
 import AddEditTokenModal from '../../../../common/components/AddEditTokenModal';
+import { NON_ADMIN_ENABLED } from '../../../../../TEMPORARY_GLOBAL_FLAGS';
 
 interface IClusterActionsDropdownProps {
   cluster: ICluster;
@@ -62,15 +63,19 @@ const ClusterActionsDropdown: React.FunctionComponent<IClusterActionsDropdownPro
         isOpen={kebabIsOpen}
         isPlain
         dropdownItems={[
-          <DropdownItem
-            onClick={() => {
-              setKebabIsOpen(false);
-              toggleAddEditTokenModal();
-            }}
-            key="addToken"
-          >
-            Add token
-          </DropdownItem>,
+          ...(NON_ADMIN_ENABLED
+            ? [
+                <DropdownItem
+                  onClick={() => {
+                    setKebabIsOpen(false);
+                    toggleAddEditTokenModal();
+                  }}
+                  key="addToken"
+                >
+                  Add token
+                </DropdownItem>,
+              ]
+            : []),
           ...(isAdmin
             ? [
                 <DropdownItem

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -7,6 +7,7 @@ import SimpleSelect from '../../../../../common/components/SimpleSelect';
 import TokenSelect from './TokenSelect';
 import { INameNamespaceRef } from '../../../../../common/duck/types';
 import { useForcedValidationOnChange } from '../../../../../common/duck/hooks';
+import { NON_ADMIN_ENABLED } from '../../../../../../TEMPORARY_GLOBAL_FLAGS';
 const styles = require('./GeneralForm.module');
 
 interface IGeneralFormProps
@@ -87,7 +88,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
       setFieldValue('sourceCluster', value);
       setFieldTouched('sourceCluster', true, true);
       setFieldValue('selectedNamespaces', []);
-      setFieldValue('sourceTokenRef', null);
+      if (NON_ADMIN_ENABLED) setFieldValue('sourceTokenRef', null);
     }
   };
 
@@ -96,7 +97,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     if (matchingCluster) {
       setFieldValue('targetCluster', value);
       setFieldTouched('targetCluster', true, true);
-      setFieldValue('targetTokenRef', null);
+      if (NON_ADMIN_ENABLED) setFieldValue('targetTokenRef', null);
     }
   };
 
@@ -152,19 +153,21 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
               placeholderText="Select source..."
             />
           </FormGroup>
-          <TokenSelect
-            fieldId="sourceToken"
-            clusterName={values.sourceCluster}
-            value={values.sourceTokenRef}
-            onChange={(tokenRef: INameNamespaceRef) => {
-              setFieldValue('sourceTokenRef', tokenRef);
-              setFieldTouched('sourceTokenRef', true, true);
-            }}
-            touched={touched.sourceTokenRef}
-            error={errors.sourceTokenRef}
-            expiringSoonMessage="The users's selected token on cluster source will expire soon."
-            expiredMessage="The user's selected token on cluster source is expired."
-          />
+          {NON_ADMIN_ENABLED && (
+            <TokenSelect
+              fieldId="sourceToken"
+              clusterName={values.sourceCluster}
+              value={values.sourceTokenRef}
+              onChange={(tokenRef: INameNamespaceRef) => {
+                setFieldValue('sourceTokenRef', tokenRef);
+                setFieldTouched('sourceTokenRef', true, true);
+              }}
+              touched={touched.sourceTokenRef}
+              error={errors.sourceTokenRef}
+              expiringSoonMessage="The users's selected token on cluster source will expire soon."
+              expiredMessage="The user's selected token on cluster source is expired."
+            />
+          )}
         </GridItem>
 
         <GridItem>
@@ -183,19 +186,21 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
               placeholderText="Select target..."
             />
           </FormGroup>
-          <TokenSelect
-            fieldId="targetToken"
-            clusterName={values.targetCluster}
-            value={values.targetTokenRef}
-            onChange={(tokenRef) => {
-              setFieldValue('targetTokenRef', tokenRef);
-              setFieldTouched('targetTokenRef', true, true);
-            }}
-            touched={touched.targetTokenRef}
-            error={errors.targetTokenRef}
-            expiringSoonMessage="The users's selected token on cluster target will expire soon."
-            expiredMessage="The user's selected token on cluster target is expired."
-          />
+          {NON_ADMIN_ENABLED && (
+            <TokenSelect
+              fieldId="targetToken"
+              clusterName={values.targetCluster}
+              value={values.targetTokenRef}
+              onChange={(tokenRef) => {
+                setFieldValue('targetTokenRef', tokenRef);
+                setFieldTouched('targetTokenRef', true, true);
+              }}
+              touched={touched.targetTokenRef}
+              error={errors.targetTokenRef}
+              expiringSoonMessage="The users's selected token on cluster target will expire soon."
+              expiredMessage="The user's selected token on cluster target is expired."
+            />
+          )}
         </GridItem>
       </Grid>
 

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -15,6 +15,7 @@ import { StatusType } from '../../../../../common/components/StatusIcon';
 import { getTokenInfo } from '../../../TokensPage/helpers';
 import { INameNamespaceRef } from '../../../../../common/duck/types';
 import { isSameResource } from '../../../../../common/helpers';
+import { NON_ADMIN_ENABLED } from '../../../../../../TEMPORARY_GLOBAL_FLAGS';
 
 const styles = require('./WizardComponent.module');
 
@@ -134,15 +135,21 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
               />
             </WizardStepContainer>
           ),
-          enableNext:
-            areFieldsTouchedAndValid([
-              'planName',
-              'sourceCluster',
-              'sourceTokenRef',
-              'targetCluster',
-              'targetTokenRef',
-              'selectedStorage',
-            ]) && areSelectedTokensValid(['sourceTokenRef', 'targetTokenRef']),
+          enableNext: NON_ADMIN_ENABLED
+            ? areFieldsTouchedAndValid([
+                'planName',
+                'sourceCluster',
+                'sourceTokenRef',
+                'targetCluster',
+                'targetTokenRef',
+                'selectedStorage',
+              ]) && areSelectedTokensValid(['sourceTokenRef', 'targetTokenRef'])
+            : areFieldsTouchedAndValid([
+                'planName',
+                'sourceCluster',
+                'targetCluster',
+                'selectedStorage',
+              ]),
         },
         {
           id: stepId.Namespaces,
@@ -291,11 +298,15 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
         addPlanRequest({
           planName: props.values.planName,
           sourceCluster: props.values.sourceCluster,
-          sourceTokenRef: props.values.sourceTokenRef,
           targetCluster: props.values.targetCluster,
-          targetTokenRef: props.values.targetTokenRef,
           selectedStorage: props.values.selectedStorage,
           namespaces: props.values.selectedNamespaces,
+          ...(NON_ADMIN_ENABLED
+            ? {
+                sourceTokenRef: props.values.sourceTokenRef,
+                targetTokenRef: props.values.targetTokenRef,
+              }
+            : {}),
         });
       }
     }

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -26,6 +26,7 @@ import { IStorage } from '../../../../../storage/duck/types';
 import { IReduxState } from '../../../../../../reducers';
 import { IToken } from '../../../../../token/duck/types';
 import { INameNamespaceRef } from '../../../../../common/duck/types';
+import { NON_ADMIN_ENABLED } from '../../../../../../TEMPORARY_GLOBAL_FLAGS';
 
 export interface IFormValues {
   planName: string;
@@ -146,17 +147,19 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
     if (!values.sourceCluster) {
       errors.sourceCluster = 'Required';
     }
-    if (!values.sourceTokenRef) {
-      errors.sourceTokenRef = 'Required';
-    }
     if (!values.selectedNamespaces || values.selectedNamespaces.length === 0) {
       errors.selectedNamespaces = 'Required';
     }
     if (!values.targetCluster) {
       errors.targetCluster = 'Required';
     }
-    if (!values.targetTokenRef) {
-      errors.targetTokenRef = 'Required';
+    if (NON_ADMIN_ENABLED) {
+      if (!values.sourceTokenRef) {
+        errors.sourceTokenRef = 'Required';
+      }
+      if (!values.targetTokenRef) {
+        errors.targetTokenRef = 'Required';
+      }
     }
     if (!values.selectedStorage) {
       errors.selectedStorage = 'Required';

--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -33,6 +33,7 @@ import { push } from 'connected-react-router';
 import planUtils from './utils';
 import { createAddEditStatus, AddEditState, AddEditMode } from '../../common/add_edit_state';
 import _ from 'lodash';
+import { NON_ADMIN_ENABLED } from '../../../TEMPORARY_GLOBAL_FLAGS';
 
 const uuidv1 = require('uuid/v1');
 const PlanMigrationPollingInterval = 5000;
@@ -75,7 +76,9 @@ function* addPlanSaga(action) {
 
 function* namespaceFetchRequest(action) {
   const state = yield select();
-  const discoveryClient: IDiscoveryClient = ClientFactory.discovery(state, action.clusterName);
+  const discoveryClient: IDiscoveryClient = NON_ADMIN_ENABLED
+    ? ClientFactory.discovery(state, action.clusterName)
+    : ClientFactory.discovery(state);
   const namespaces: DiscoveryResource = new NamespaceDiscovery(action.clusterName);
   try {
     const res = yield discoveryClient.get(namespaces);
@@ -544,7 +547,9 @@ function* planCloseAndCheck(action) {
 
 function* getPVResourcesRequest(action) {
   const state = yield select();
-  const discoveryClient: IDiscoveryClient = ClientFactory.discovery(state, action.clusterName);
+  const discoveryClient: IDiscoveryClient = NON_ADMIN_ENABLED
+    ? ClientFactory.discovery(state, action.clusterName)
+    : ClientFactory.discovery(state);
   try {
     const pvResourceRefs = action.pvList.map((pv) => {
       const persistentVolume = new PersistentVolumeDiscovery(pv.name, action.clusterName);

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -5,6 +5,7 @@ import {
 } from '../../app/home/pages/PlansPage/components/Wizard/HooksFormComponent';
 import { IMigPlan } from '../../app/plan/duck/types';
 import { INameNamespaceRef } from '../../app/common/duck/types';
+import { NON_ADMIN_ENABLED } from '../../TEMPORARY_GLOBAL_FLAGS';
 
 export function createMigClusterSecret(
   name: string,
@@ -388,17 +389,19 @@ export function updateMigPlanFromValues(
       namespace: migPlan.metadata.namespace,
     };
   }
-  if (planValues.sourceTokenRef) {
-    updatedSpec.srcMigTokenRef = { ...planValues.sourceTokenRef };
-  }
   if (planValues.targetCluster) {
     updatedSpec.destMigClusterRef = {
       name: planValues.targetCluster,
       namespace: migPlan.metadata.namespace,
     };
   }
-  if (planValues.targetTokenRef) {
-    updatedSpec.destMigTokenRef = { ...planValues.targetTokenRef };
+  if (NON_ADMIN_ENABLED) {
+    if (planValues.sourceTokenRef) {
+      updatedSpec.srcMigTokenRef = { ...planValues.sourceTokenRef };
+    }
+    if (planValues.targetTokenRef) {
+      updatedSpec.destMigTokenRef = { ...planValues.targetTokenRef };
+    }
   }
   if (updatedSpec.namespaces) {
     updatedSpec.namespaces = planValues.selectedNamespaces;
@@ -460,12 +463,16 @@ export function createInitialMigPlan(
         name: sourceClusterObj,
         namespace,
       },
-      srcMigTokenRef: { ...sourceTokenRef },
       destMigClusterRef: {
         name: destinationClusterObj,
         namespace,
       },
-      destMigTokenRef: { ...destinationTokenRef },
+      ...(NON_ADMIN_ENABLED
+        ? {
+            srcMigTokenRef: { ...sourceTokenRef },
+            destMigTokenRef: { ...destinationTokenRef },
+          }
+        : {}),
       migStorageRef: {
         name: storageObj,
         namespace,

--- a/src/sagas.ts
+++ b/src/sagas.ts
@@ -9,6 +9,7 @@ import tokenSagas from './app/token/duck/sagas';
 import { AuthActions } from './app/auth/duck/actions';
 import { setTokenExpiryHandler } from './client/client_factory';
 import { history } from './helpers';
+import { NON_ADMIN_ENABLED } from './TEMPORARY_GLOBAL_FLAGS';
 
 export default function* rootSaga() {
   function* appStarted() {
@@ -36,7 +37,6 @@ export default function* rootSaga() {
     commonSagas.watchPlanPolling(),
     commonSagas.watchClustersPolling(),
     commonSagas.watchStoragePolling(),
-    commonSagas.watchTokenPolling(),
     commonSagas.watchAlerts(),
     planSagas.watchStagePolling(),
     planSagas.watchMigrationPolling(),
@@ -68,8 +68,13 @@ export default function* rootSaga() {
     storageSagas.watchAddStorageRequest(),
     storageSagas.watchStorageAddEditStatus(),
     storageSagas.watchUpdateStorageRequest(),
-    tokenSagas.watchAddTokenRequest(),
-    tokenSagas.watchRemoveTokenRequest(),
     authSagas.watchAuthEvents(),
+    ...(NON_ADMIN_ENABLED
+      ? [
+          commonSagas.watchTokenPolling(),
+          tokenSagas.watchAddTokenRequest(),
+          tokenSagas.watchRemoveTokenRequest(),
+        ]
+      : []),
   ]);
 }


### PR DESCRIPTION
Closes https://github.com/konveyor/mig-ui/issues/960.

Adds a new file at `src/TEMPORARY_GLOBAL_FLAGS.ts` with a single boolean export `NON_ADMIN_ENABLED`, set to false. By default on master we will now have all non-admin-related features/controls disabled/hidden. Flipping the flag to true will re-enable everything (and restore the "WORK IN PROGRESS" banner in the header), so we can continue working on incomplete non-admin support without blocking a release.

When `NON_ADMIN_ENABLED` is false:
- Tokens page nav item and route will not be rendered
- Token polling will not run
- `state.auth.isAdmin` will always be true
- "Add token" action in clusters page will not be rendered
- Plan wizard will not have the source and target token field controls, initial values, or validation
- Sagas will not add source and target token fields to migplan objects
- "WORK IN PROGRESS" banner in the header will not be rendered
- Admin/non-admin role indicator in header will not be rendered
- Namespace selection controls will not be rendered and will no longer be required to use the UI
- Welcome screen route will not be rendered