### PR TITLE
fix secret reference for update cluster request

### DIFF
--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -294,7 +294,7 @@ function* updateClusterRequest(action) {
   );
   const updatedMigClusterSecretResult = yield client.get(
     secretResource,
-    getClusterRes.data.spec.secretRef.name
+    getClusterRes.data.spec.serviceAccountSecretRef.name
   );
   const currentCluster = {
     MigCluster: getClusterRes.data,


### PR DESCRIPTION
This is a small regression from the latest changes to the add/edit cluster flow. Currently a cluster update fails due to the wrong reference to an existing secret on a cluster. This PR will fix this bug.