### PR TITLE
Add TreeView and DebugResourcesModal components with mock data

### DIFF
--- a/src/app/common/components/TreeView/TreeView.module.scss
+++ b/src/app/common/components/TreeView/TreeView.module.scss
@@ -1,0 +1,194 @@
+// This is based on the unreleased PatternFly tree view CSS found at https://github.com/patternfly/patternfly/blob/master/src/patternfly/components/TreeView/tree-view.scss.
+// We should remove it after we upgrade our PatternFly dependencies and start using the real component.
+
+@mixin pf-text-overflow {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+$pf-c-tree-view--MaxNesting: 10;
+
+.pf-c-tree-view {
+  --pf-c-tree-view--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-tree-view--PaddingBottom: var(--pf-global--spacer--sm);
+
+  // Link base
+  --pf-c-tree-view__node--indent--base: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__node--nested-indent--base: var(--pf-global--spacer--lg);
+  --pf-c-tree-view__item--m-expandable__node--nested-indent--base: var(--pf-global--spacer--lg);
+
+  // Link
+  --pf-c-tree-view__node--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__node--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__node--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__node--PaddingLeft: var(--pf-c-tree-view__node--indent--base);
+  --pf-c-tree-view__node--Color: var(--pf-global--Color--100);
+  --pf-c-tree-view__node--m-current--Color: var(--pf-global--link--Color);
+  --pf-c-tree-view__node--m-current--FontWeight: var(--pf-global--FontWeight--bold);
+  --pf-c-tree-view__node--m-active--FontWeight: var(--pf-global--FontWeight--bold);
+
+  // link hover/focus
+  --pf-c-tree-view__node--hover--BackgroundColor: var(--pf-global--BackgroundColor--200);
+  --pf-c-tree-view__node--focus--BackgroundColor: var(--pf-global--palette--black-200);
+
+  // toggle 90degon
+  --pf-c-tree-view__node-toggle-icon--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__node-toggle-icon--MinWidth: var(--pf-global--spacer--lg);
+  --pf-c-tree-view__node-toggle-icon--MinHeight: var(--pf-c-tree-view__node-toggle--icon--MinWidth);
+
+  // check
+  --pf-c-tree-view__node-check--MarginRight: var(--pf-global--spacer--sm);
+
+  // badge
+  --pf-c-tree-view__node-count--MarginLeft: var(--pf-global--spacer--xs);
+  --pf-c-tree-view__node-count--c-badge--m-read--BackgroundColor: var(
+    --pf-global--disabled-color--200
+  );
+
+  // search
+  --pf-c-tree-view__search--PaddingTop: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__search--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__search--PaddingBottom: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__search--PaddingLeft: var(--pf-global--spacer--sm);
+
+  // icon
+  --pf-c-tree-view__node-icon--PaddingRight: var(--pf-global--spacer--sm);
+  --pf-c-tree-view__node-icon--Color: var(--pf-global--icon--Color--light);
+
+  // text
+  --pf-c-tree-view__node-text--max-lines: 1;
+
+  // action
+  --pf-c-tree-view__action--PaddingRight: var(--pf-global--spacer--md);
+  --pf-c-tree-view__action--PaddingLeft: var(--pf-global--spacer--md);
+  --pf-c-tree-view__action--Color: var(--pf-global--icon--Color--light);
+
+  padding-top: var(--pf-c-tree-view--PaddingTop);
+  padding-bottom: var(--pf-c-tree-view--PaddingBottom);
+}
+
+// stylelint-disable selector-max-class, selector-max-compound-selectors
+.pf-c-tree-view__list-item {
+  &.pf-m-expanded {
+    > .pf-c-tree-view__content > .pf-c-tree-view__node > .pf-c-tree-view__node-toggle-icon > i {
+      transform: rotate(90deg);
+    }
+  }
+
+  button {
+    background-color: transparent;
+  }
+}
+// stylelint-enable
+
+.pf-c-tree-view__node {
+  display: flex;
+  flex: 1 1;
+  align-items: center;
+  min-width: 0;
+  padding: var(--pf-c-tree-view__node--PaddingTop) var(--pf-c-tree-view__node--PaddingRight)
+    var(--pf-c-tree-view__node--PaddingBottom) var(--pf-c-tree-view__node--PaddingLeft);
+  color: var(--pf-c-tree-view__node--Color);
+  text-align: left;
+  border: 0;
+
+  &.pf-m-current {
+    --pf-c-tree-view__node--Color: var(--pf-c-tree-view__node--m-current--Color);
+
+    font-weight: var(--pf-c-tree-view__node--m-current--FontWeight);
+  }
+
+  &.pf-m-active {
+    font-weight: var(--pf-c-tree-view__node--m-active--FontWeight);
+  }
+
+  &:focus {
+    background-color: var(--pf-c-tree-view__node--focus--BackgroundColor);
+  }
+
+  .pf-c-tree-view__node-count {
+    margin-left: var(--pf-c-tree-view__node-count--MarginLeft);
+
+    .pf-c-badge.pf-m-read {
+      --pf-c-badge--m-read--BackgroundColor: var(
+        --pf-c-tree-view__node-count--c-badge--m-read--BackgroundColor
+      );
+    }
+  }
+}
+
+.pf-c-tree-view__node-check {
+  margin-right: var(--pf-c-tree-view__node-check--MarginRight);
+}
+
+.pf-c-tree-view__node-toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--pf-c-tree-view__node-toggle-icon--MinWidth);
+  min-height: var(--pf-c-tree-view__node-toggle-icon--MinHeight);
+  padding-right: var(--pf-c-tree-view__node-toggle-icon--PaddingRight);
+}
+
+.pf-c-tree-view__node-text {
+  @include pf-text-overflow;
+}
+
+.pf-c-tree-view__search {
+  padding: var(--pf-c-tree-view__search--PaddingTop) var(--pf-c-tree-view__search--PaddingRight)
+    var(--pf-c-tree-view__search--PaddingBottom) var(--pf-c-tree-view__search--PaddingLeft);
+}
+
+.pf-c-tree-view__node-icon {
+  padding-right: var(--pf-c-tree-view__node-icon--PaddingRight);
+  color: var(--pf-c-tree-view__node-icon--Color);
+}
+
+.pf-c-tree-view__content {
+  display: flex;
+
+  &:hover {
+    background-color: var(--pf-c-tree-view__node--hover--BackgroundColor);
+
+    .pf-c-tree-view__action {
+      display: block;
+      visibility: visible;
+    }
+  }
+}
+
+.pf-c-tree-view__action {
+  display: none;
+  padding-right: var(--pf-c-tree-view__action--PaddingRight);
+  padding-left: var(--pf-c-tree-view__action--PaddingLeft);
+  margin-left: auto;
+  color: var(--pf-c-tree-view__action--Color);
+  visibility: hidden;
+  border: 0;
+}
+
+// stylelint-disable no-duplicate-selectors
+.pf-c-tree-view__list-item {
+  $root: &;
+  $nested-item: &;
+
+  @for $i from 1 through $pf-c-tree-view--MaxNesting {
+    #{$nested-item} {
+      --pf-c-tree-view__node--PaddingLeft: calc(
+        var(--pf-c-tree-view__node--indent--base) +
+          (var(--pf-c-tree-view__node--nested-indent--base) * #{$i})
+      );
+    }
+
+    #{$nested-item}.pf-m-expandable {
+      --pf-c-tree-view__node--PaddingLeft: calc(
+        var(--pf-c-tree-view__node--indent--base) +
+          (var(--pf-c-tree-view__item--m-expandable__node--nested-indent--base) * #{$i})
+      );
+    }
+
+    $nested-item: $nested-item + ' ' + $root;
+  }
+}
+// stylelint-enable

--- a/src/app/common/components/TreeView/TreeView.tsx
+++ b/src/app/common/components/TreeView/TreeView.tsx
@@ -4,11 +4,9 @@
 // TODO: should maybe be able to override local expanded state with a property in the data items, maybe enabled with a top-level prop isControlled
 // TODO before PatternFly contribution: support for active items, search, checkboxes, icons, badges, actions
 
-import React, { useState } from 'react';
-import classNames from 'classnames';
-import { AngleRightIcon } from '@patternfly/react-icons';
-
-const styles = require('./TreeView.module');
+import React from 'react';
+import { TreeViewList } from './TreeViewList';
+import { TreeViewListItem } from './TreeViewListItem';
 
 export interface ITreeDataItem {
   name: string;
@@ -22,61 +20,23 @@ export interface ITreeViewProps {
   defaultAllExpanded?: boolean;
 }
 
-const TreeView: React.FunctionComponent<ITreeViewProps> = ({
+export const TreeView: React.FunctionComponent<ITreeViewProps> = ({
   data,
   isNested = false,
   defaultAllExpanded = false,
-}: ITreeViewProps) => {
-  const list = (
-    <ul className={styles['pf-c-tree-view__list']} role={isNested ? 'group' : 'tree'}>
-      {data.map((item) => (
-        <TreeViewItem item={item} key={item.name} defaultAllExpanded={defaultAllExpanded} />
-      ))}
-    </ul>
-  );
-  return isNested ? list : <div className={styles['pf-c-tree-view']}>{list}</div>;
-};
-
-export interface ITreeViewItemProps {
-  item: ITreeDataItem;
-  defaultAllExpanded?: boolean;
-}
-
-const TreeViewItem: React.FunctionComponent<ITreeViewItemProps> = ({
-  item,
-  defaultAllExpanded = false,
-}: ITreeViewItemProps) => {
-  const [isExpanded, setIsExpanded] = useState(item.defaultExpanded || defaultAllExpanded || false);
-  return (
-    <li
-      className={classNames(styles['pf-c-tree-view__list-item'], {
-        [styles['pf-m-expandable']]: !!item.children,
-        [styles['pf-m-expanded']]: isExpanded,
-      })}
-      {...(isExpanded && { ariaExpanded: 'true' })}
-      role="treeitem"
-      tabIndex={0}
-    >
-      <div className={styles['pf-c-tree-view__content']}>
-        <button
-          className={styles['pf-c-tree-view__node']}
-          onClick={() => {
-            if (item.children) setIsExpanded(!isExpanded);
-          }}
-        >
-          {item.children ? (
-            <span className={styles['pf-c-tree-view__node-toggle-icon']}>
-              <AngleRightIcon aria-hidden="true" />
-            </span>
-          ) : null}
-          <span className={styles['pf-c-tree-view__node-text']}>{item.name}</span>
-        </button>
-      </div>
-      {item.children && isExpanded ? (
-        <TreeView data={item.children} isNested defaultAllExpanded={defaultAllExpanded} />
-      ) : null}
-    </li>
-  );
-};
-
-export default TreeView;
+}: ITreeViewProps) => (
+  <TreeViewList isNested={isNested}>
+    {data.map((item) => (
+      <TreeViewListItem
+        key={item.name}
+        name={item.name}
+        defaultExpanded={defaultAllExpanded || item.defaultExpanded || false}
+        {...(item.children && {
+          children: (
+            <TreeView data={item.children} isNested defaultAllExpanded={defaultAllExpanded} />
+          ),
+        })}
+      />
+    ))}
+  </TreeViewList>
+);

--- a/src/app/common/components/TreeView/TreeView.tsx
+++ b/src/app/common/components/TreeView/TreeView.tsx
@@ -1,0 +1,82 @@
+// This is based on the unreleased PatternFly core (HTML) component here: https://patternfly-pr-3354.surge.sh/documentation/core/components/treeview
+// We should try to contribute this back to patternfly-react, or switch to the eventual patternfly-react component if someone else implements it.
+
+// TODO: should maybe be able to override local expanded state with a property in the data items, maybe enabled with a top-level prop isControlled
+// TODO before PatternFly contribution: support for active items, search, checkboxes, icons, badges, actions
+
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import { AngleRightIcon } from '@patternfly/react-icons';
+
+const styles = require('./TreeView.module');
+
+export interface ITreeDataItem {
+  name: string;
+  children?: ITreeDataItem[];
+  defaultExpanded?: boolean;
+}
+
+export interface ITreeViewProps {
+  data: ITreeDataItem[];
+  isNested?: boolean;
+  defaultAllExpanded?: boolean;
+}
+
+const TreeView: React.FunctionComponent<ITreeViewProps> = ({
+  data,
+  isNested = false,
+  defaultAllExpanded = false,
+}: ITreeViewProps) => {
+  const list = (
+    <ul className={styles['pf-c-tree-view__list']} role={isNested ? 'group' : 'tree'}>
+      {data.map((item) => (
+        <TreeViewItem item={item} key={item.name} defaultAllExpanded={defaultAllExpanded} />
+      ))}
+    </ul>
+  );
+  return isNested ? list : <div className={styles['pf-c-tree-view']}>{list}</div>;
+};
+
+export interface ITreeViewItemProps {
+  item: ITreeDataItem;
+  defaultAllExpanded?: boolean;
+}
+
+const TreeViewItem: React.FunctionComponent<ITreeViewItemProps> = ({
+  item,
+  defaultAllExpanded = false,
+}: ITreeViewItemProps) => {
+  const [isExpanded, setIsExpanded] = useState(item.defaultExpanded || defaultAllExpanded || false);
+  return (
+    <li
+      className={classNames(styles['pf-c-tree-view__list-item'], {
+        [styles['pf-m-expandable']]: !!item.children,
+        [styles['pf-m-expanded']]: isExpanded,
+      })}
+      {...(isExpanded && { ariaExpanded: 'true' })}
+      role="treeitem"
+      tabIndex={0}
+    >
+      <div className={styles['pf-c-tree-view__content']}>
+        <button
+          className={styles['pf-c-tree-view__node']}
+          onClick={() => {
+            if (item.children) setIsExpanded(!isExpanded);
+          }}
+        >
+          {item.children ? (
+            <span className={styles['pf-c-tree-view__node-toggle-icon']}>
+              <AngleRightIcon aria-hidden="true" />
+            </span>
+          ) : null}
+          <span className={styles['pf-c-tree-view__node-text']}>{item.name}</span>
+        </button>
+      </div>
+      {item.children && isExpanded ? (
+        <TreeView data={item.children} isNested defaultAllExpanded={defaultAllExpanded} />
+      ) : null}
+    </li>
+  );
+};
+
+export default TreeView;

--- a/src/app/common/components/TreeView/TreeViewList.tsx
+++ b/src/app/common/components/TreeView/TreeViewList.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const styles = require('./TreeView.module');
+
+export interface ITreeViewListProps {
+  isNested?: boolean;
+  children: React.ReactNode;
+}
+
+export const TreeViewList: React.FunctionComponent<ITreeViewListProps> = ({
+  isNested = false,
+  children,
+}: ITreeViewListProps) => {
+  const list = (
+    <ul className={styles['pf-c-tree-view__list']} role={isNested ? 'group' : 'tree'}>
+      {children}
+    </ul>
+  );
+  return isNested ? list : <div className={styles['pf-c-tree-view']}>{list}</div>;
+};

--- a/src/app/common/components/TreeView/TreeViewListItem.tsx
+++ b/src/app/common/components/TreeView/TreeViewListItem.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import { AngleRightIcon } from '@patternfly/react-icons';
+
+const styles = require('./TreeView.module');
+
+export interface ITreeViewListItemProps {
+  name: React.ReactNode;
+  defaultExpanded?: boolean;
+  children?: React.ReactNode;
+}
+
+export const TreeViewListItem: React.FunctionComponent<ITreeViewListItemProps> = ({
+  name,
+  defaultExpanded = false,
+  children = null,
+}: ITreeViewListItemProps) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  return (
+    <li
+      className={classNames(styles['pf-c-tree-view__list-item'], {
+        [styles['pf-m-expandable']]: !!children,
+        [styles['pf-m-expanded']]: isExpanded,
+      })}
+      {...(isExpanded && { ariaExpanded: 'true' })}
+      role="treeitem"
+      tabIndex={0}
+    >
+      <div className={styles['pf-c-tree-view__content']}>
+        <button
+          className={styles['pf-c-tree-view__node']}
+          onClick={() => {
+            if (children) setIsExpanded(!isExpanded);
+          }}
+        >
+          {children ? (
+            <span className={styles['pf-c-tree-view__node-toggle-icon']}>
+              <AngleRightIcon aria-hidden="true" />
+            </span>
+          ) : null}
+          <span className={styles['pf-c-tree-view__node-text']}>{name}</span>
+        </button>
+      </div>
+      {isExpanded ? children : null}
+    </li>
+  );
+};

--- a/src/app/common/components/TreeView/TreeViewListItem.tsx
+++ b/src/app/common/components/TreeView/TreeViewListItem.tsx
@@ -35,7 +35,9 @@ export const TreeViewListItem: React.FunctionComponent<ITreeViewListItemProps> =
         >
           {children ? (
             <span className={styles['pf-c-tree-view__node-toggle-icon']}>
-              <AngleRightIcon aria-hidden="true" />
+              <i>
+                <AngleRightIcon aria-hidden="true" />
+              </i>
             </span>
           ) : null}
           <span className={styles['pf-c-tree-view__node-text']}>{name}</span>

--- a/src/app/common/components/TreeView/index.ts
+++ b/src/app/common/components/TreeView/index.ts
@@ -1,0 +1,3 @@
+export * from './TreeView';
+export * from './TreeViewList';
+export * from './TreeViewListItem';

--- a/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
+++ b/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
@@ -73,7 +73,7 @@ const DebugResourcesModal: React.FunctionComponent<IDebugResourcesModalProps> = 
   <Modal
     id="debug-resources-modal"
     isSmall
-    title="Migration Plan Resources (DEBUG)"
+    title="Migration plan resources (DEBUG)"
     isOpen
     isFooterLeftAligned
     onClose={onClose}

--- a/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
+++ b/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal, Button } from '@patternfly/react-core';
-import TreeView, { ITreeDataItem } from '../../../../common/components/TreeView/TreeView';
+import { TreeView, ITreeDataItem } from '../../../../common/components/TreeView';
 
 // TODO replace this dummy data with real data from redux
 // This example came from https://github.com/konveyor/enhancements/pull/2/files

--- a/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
+++ b/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
@@ -71,11 +71,10 @@ const DebugResourcesModal: React.FunctionComponent<IDebugResourcesModalProps> = 
   onClose,
 }: IDebugResourcesModalProps) => (
   <Modal
+    variant="small"
     id="debug-resources-modal"
-    isSmall
     title="Migration plan resources (DEBUG)"
     isOpen
-    isFooterLeftAligned
     onClose={onClose}
     actions={[
       <Button key="close" variant="primary" onClick={onClose}>

--- a/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
+++ b/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Modal, Button } from '@patternfly/react-core';
+import TreeView, { ITreeDataItem } from '../../../../common/components/TreeView/TreeView';
+
+// TODO replace this dummy data with real data from redux
+// This example came from https://github.com/konveyor/enhancements/pull/2/files
+const DUMMY_DEBUG_DATA: ITreeDataItem[] = [
+  {
+    name: 'MigPlan: openshift-migration/myplan',
+    children: [
+      { name: 'MigCluster: openshift-migration/mycluster' },
+      { name: 'MigStorage: openshift-migration/mystorage' },
+      { name: 'MigHook: openshift-migration/myhook1' },
+      { name: 'MigHook: openshift-migration/myhook2' },
+      { name: 'BackupStorageLocation: openshift-migration/mybsl' },
+      { name: 'VolumeSnapshotLocation: openshift-migration/myvsl' },
+      {
+        name: 'MigMigration: openshift-migration/mystagemigration',
+        children: [
+          {
+            name: 'Backup: openshift-migration/StageBackup1',
+            children: [
+              { name: 'PodVolumeBackup: openshift-migration/mypvb1' },
+              { name: 'PodVolumeBackup: openshift-migration/mypvb2' },
+              { name: 'PodVolumeBackup: openshift-migration/mypvb3' },
+            ],
+          },
+          {
+            name: 'Restore: openshift-migration/StageRestore1',
+            children: [
+              { name: 'PodVolumeRestore: openshift-migration/mypvr1' },
+              { name: 'PodVolumeRestore: openshift-migration/mypvr2' },
+              { name: 'PodVolumeRestore: openshift-migration/mypvr3' },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'MigMigration: openshift-migration/myfinalmigration',
+        children: [
+          { name: 'Backup: openshift-migration/FinalBackup2' },
+          {
+            name: 'Backup: openshift-migration/StageBackup2',
+            children: [
+              { name: 'PodVolumeBackup: openshift-migration/mypvb4' },
+              { name: 'PodVolumeBackup: openshift-migration/mypvb5' },
+              { name: 'PodVolumeBackup: openshift-migration/mypvb6' },
+            ],
+          },
+          {
+            name: 'Restore: openshift-migration/StageRestore2',
+            children: [
+              { name: 'PodVolumeRestore: openshift-migration/mypvr7' },
+              { name: 'PodVolumeRestore: openshift-migration/mypvr8' },
+              { name: 'PodVolumeRestore: openshift-migration/mypvr9' },
+            ],
+          },
+          { name: 'Restore: openshift-migration/FinalRestore2' },
+        ],
+      },
+    ],
+  },
+];
+
+interface IDebugResourcesModalProps {
+  onClose: () => void;
+}
+
+const DebugResourcesModal: React.FunctionComponent<IDebugResourcesModalProps> = ({
+  onClose,
+}: IDebugResourcesModalProps) => (
+  <Modal
+    id="debug-resources-modal"
+    isSmall
+    title="Migration Plan Resources (DEBUG)"
+    isOpen
+    isFooterLeftAligned
+    onClose={onClose}
+    actions={[
+      <Button key="close" variant="primary" onClick={onClose}>
+        Close
+      </Button>,
+    ]}
+  >
+    <TreeView data={DUMMY_DEBUG_DATA} defaultAllExpanded />
+  </Modal>
+);
+
+export default DebugResourcesModal;

--- a/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
+++ b/src/app/home/pages/PlansPage/components/DebugResourcesModal.tsx
@@ -7,6 +7,7 @@ import { TreeView, ITreeDataItem } from '../../../../common/components/TreeView'
 const DUMMY_DEBUG_DATA: ITreeDataItem[] = [
   {
     name: 'MigPlan: openshift-migration/myplan',
+    defaultExpanded: true,
     children: [
       { name: 'MigCluster: openshift-migration/mycluster' },
       { name: 'MigStorage: openshift-migration/mystorage' },
@@ -82,7 +83,7 @@ const DebugResourcesModal: React.FunctionComponent<IDebugResourcesModalProps> = 
       </Button>,
     ]}
   >
-    <TreeView data={DUMMY_DEBUG_DATA} defaultAllExpanded />
+    <TreeView data={DUMMY_DEBUG_DATA} />
   </Modal>
 );
 

--- a/src/app/home/pages/PlansPage/components/PlanActions.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanActions.tsx
@@ -14,7 +14,6 @@ import MigrateModal from './MigrateModal';
 import { withRouter } from 'react-router-dom';
 import WizardContainer from './Wizard/WizardContainer';
 import ConfirmModal from '../../../../common/components/ConfirmModal';
-import TreeView from '../../../../common/components/TreeView/TreeView';
 import DebugResourcesModal from './DebugResourcesModal';
 
 const PlanActions = ({ plan, history }) => {

--- a/src/app/home/pages/PlansPage/components/PlanActions.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanActions.tsx
@@ -14,11 +14,14 @@ import MigrateModal from './MigrateModal';
 import { withRouter } from 'react-router-dom';
 import WizardContainer from './Wizard/WizardContainer';
 import ConfirmModal from '../../../../common/components/ConfirmModal';
+import TreeView from '../../../../common/components/TreeView/TreeView';
+import DebugResourcesModal from './DebugResourcesModal';
 
 const PlanActions = ({ plan, history }) => {
   const [isMigrateModalOpen, toggleMigrateModalOpen] = useOpenModal(false);
   const [isDeleteModalOpen, toggleDeleteModalOpen] = useOpenModal(false);
   const [isEditWizardOpen, toggleEditWizardOpen] = useOpenModal(false);
+  const [isDebugResourcesModalOpen, toggleDebugResourcesModal] = useOpenModal(false);
   const planContext = useContext(PlanContext);
   const {
     hasClosedCondition,
@@ -103,6 +106,15 @@ const PlanActions = ({ plan, history }) => {
     >
       Logs
     </DropdownItem>,
+    <DropdownItem
+      key="debugResourcesModal"
+      onClick={() => {
+        setKebabIsOpen(false);
+        toggleDebugResourcesModal();
+      }}
+    >
+      View migration plan resources (DEBUG)
+    </DropdownItem>,
   ];
   return (
     <Flex>
@@ -140,6 +152,10 @@ const PlanActions = ({ plan, history }) => {
           }}
           id="confirm-plan-removal"
         />
+
+        {isDebugResourcesModalOpen ? (
+          <DebugResourcesModal onClose={toggleDebugResourcesModal} />
+        ) : null}
       </FlexItem>
     </Flex>
   );


### PR DESCRIPTION
Based on a discussion with @eriknelson and @vconzola, we needed a way to present a migration plan's associated resources as a tree view for debug purposes (detailed here: https://github.com/konveyor/enhancements/pull/2/files)

Initially I started by using an off-the-shelf tree component since the PatternFly TreeView component is not yet available, but I realized that I could implement a true PatternFly tree view after all by copying [the unreleased CSS](https://github.com/patternfly/patternfly/pull/3354). We don't need the advanced features (search, checkboxes, icons, badges, actions), so the HTML structure itself is not very complex and it makes for a fairly small component. I made a few tweaks to the copied CSS so that we can use it with our current version of PatternFly.

I intend to eventually add those missing features to this TreeView component and contribute it upstream to PatternFly, assuming someone else doesn't beat me to the React implementation. Either way, we'll be able to upgrade PatternFly and swap in that official component once it's available, without changing the look and feel.

This implementation uses mock data, we'll need to swap in real data from Redux when that's available. Perhaps we should comment out this new action button and merge this PR, then reveal it in another PR when the real data is available.

# Screens

The new view is in a modal accessible from the kebab menu on a migration plan:
<img width="471" alt="Screenshot 2020-08-05 18 02 36" src="https://user-images.githubusercontent.com/811963/89476671-5832b200-d759-11ea-8cc1-8c70266f7b68.png">

And here it is:
<img width="585" alt="Screenshot 2020-08-05 20 27 07" src="https://user-images.githubusercontent.com/811963/89476980-148c7800-d75a-11ea-8e26-5cbf9486d0ab.png">


