### PR TITLE
Fix conflict condition not being surfaced in plan status

### DIFF
--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -17,9 +17,9 @@ export const getPlanStatusText = (plan: IPlan) => {
     isPlanLocked,
   } = plan.PlanStatus;
   if (latestIsFailed) return `${latestType} Failed`;
+  if (hasConflictCondition) return conflictErrorMsg;
   if (hasNotReadyCondition || !hasReadyCondition) return 'Not Ready';
   if (hasClosedCondition) return 'Closed';
-  if (hasConflictCondition) return conflictErrorMsg;
   if (hasCancelingCondition) return `Canceling ${latestType}`;
   if (hasRunningMigrations) return `${latestType} Running`;
   if (hasCanceledCondition) return `${latestType} canceled`;


### PR DESCRIPTION
Moves the conflict condition above the not ready condition check. This fixes a regression causing the conflict status never to show. 

Before:
<img width="1157" alt="Screen Shot 2020-08-26 at 1 20 47 PM" src="https://user-images.githubusercontent.com/11218376/91336334-c3433780-e79f-11ea-9c39-f91bac6c0a86.png">
After:
<img width="1418" alt="Screen Shot 2020-08-26 at 1 26 00 PM" src="https://user-images.githubusercontent.com/11218376/91336332-c2aaa100-e79f-11ea-828b-e797db682684.png">
