### PR TITLE
Early discovery service cert acceptance

### DIFF
--- a/src/app/AppComponent.tsx
+++ b/src/app/AppComponent.tsx
@@ -46,7 +46,6 @@ interface IProps {
   updateTokens: (updatedTokens) => void;
   clusterList: ICluster[];
   debugTree: IDebugTreeNode;
-  initializeDiscoveryService: () => void;
 }
 
 const AppComponent: React.SFC<IProps> = ({
@@ -70,13 +69,7 @@ const AppComponent: React.SFC<IProps> = ({
   updateTokens,
   clusterList,
   debugTree,
-  initializeDiscoveryService,
 }) => {
-  // Early prompt for discovery service cert acceptace if it hasn't already been accepted
-  useEffect(() => {
-    initializeDiscoveryService();
-  }, []);
-
   const handlePlanPoll = (response) => {
     if (response) {
       updatePlans(response.updatedPlans);
@@ -231,7 +224,6 @@ export default connect(
     debugTree: state.debug.tree,
   }),
   (dispatch) => ({
-    initializeDiscoveryService: () => dispatch(ClusterActions.initializeDiscoveryCert()),
     startPlanPolling: (params) => dispatch(PlanActions.startPlanPolling(params)),
     stopPlanPolling: () => dispatch(PlanActions.stopPlanPolling()),
     startStoragePolling: (params) => dispatch(StorageActions.startStoragePolling(params)),

--- a/src/app/AppComponent.tsx
+++ b/src/app/AppComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import HomeComponent from './home/HomeComponent';
 import LoginComponent from './auth/LoginComponent';
 import { Route, Switch } from 'react-router-dom';
@@ -46,6 +46,7 @@ interface IProps {
   updateTokens: (updatedTokens) => void;
   clusterList: ICluster[];
   debugTree: IDebugTreeNode;
+  initializeDiscoveryService: () => void;
 }
 
 const AppComponent: React.SFC<IProps> = ({
@@ -69,7 +70,13 @@ const AppComponent: React.SFC<IProps> = ({
   updateTokens,
   clusterList,
   debugTree,
+  initializeDiscoveryService,
 }) => {
+  // Early prompt for discovery service cert acceptace if it hasn't already been accepted
+  useEffect(() => {
+    initializeDiscoveryService();
+  }, []);
+
   const handlePlanPoll = (response) => {
     if (response) {
       updatePlans(response.updatedPlans);
@@ -224,6 +231,7 @@ export default connect(
     debugTree: state.debug.tree,
   }),
   (dispatch) => ({
+    initializeDiscoveryService: () => dispatch(ClusterActions.initializeDiscoveryCert()),
     startPlanPolling: (params) => dispatch(PlanActions.startPlanPolling(params)),
     stopPlanPolling: () => dispatch(PlanActions.stopPlanPolling()),
     startStoragePolling: (params) => dispatch(StorageActions.startStoragePolling(params)),

--- a/src/app/cluster/duck/actions.ts
+++ b/src/app/cluster/duck/actions.ts
@@ -22,7 +22,12 @@ export const ClusterActionTypes = {
   CLUSTER_POLL_START: 'CLUSTER_POLL_START',
   CLUSTER_POLL_STOP: 'CLUSTER_POLL_STOP',
   SET_CURRENT_CLUSTER: 'SET_CURRENT_CLUSTER',
+  INIT_DISCOVERY_CERT: 'INIT_DISCOVERY_CERT',
 };
+
+const initializeDiscoveryCert = () => ({
+  type: ClusterActionTypes.INIT_DISCOVERY_CERT,
+});
 
 const updateClusters = (updatedClusters: IMigCluster[]) => ({
   type: ClusterActionTypes.UPDATE_CLUSTERS,
@@ -33,7 +38,6 @@ const addClusterSuccess = (newCluster: IMigCluster) => ({
   type: ClusterActionTypes.ADD_CLUSTER_SUCCESS,
   newCluster,
 });
-
 const addClusterFailure = (error) => ({
   type: ClusterActionTypes.ADD_CLUSTER_FAILURE,
   error,
@@ -131,4 +135,5 @@ export const ClusterActions = {
   startClusterPolling,
   stopClusterPolling,
   setCurrentCluster,
+  initializeDiscoveryCert,
 };

--- a/src/sagas.ts
+++ b/src/sagas.ts
@@ -70,6 +70,7 @@ export default function* rootSaga() {
     clusterSagas.watchAddClusterRequest(),
     clusterSagas.watchUpdateClusterRequest(),
     clusterSagas.watchClusterAddEditStatus(),
+    clusterSagas.watchInitDiscoveryCert(),
     storageSagas.watchRemoveStorageRequest(),
     storageSagas.watchAddStorageRequest(),
     storageSagas.watchStorageAddEditStatus(),

--- a/src/sagas.ts
+++ b/src/sagas.ts
@@ -11,6 +11,7 @@ import { AuthActions } from './app/auth/duck/actions';
 import { setTokenExpiryHandler } from './client/client_factory';
 import { history } from './helpers';
 import { NON_ADMIN_ENABLED } from './TEMPORARY_GLOBAL_FLAGS';
+import { ClusterActions } from './app/cluster/duck/actions';
 
 export default function* rootSaga() {
   function* appStarted() {
@@ -23,6 +24,8 @@ export default function* rootSaga() {
     if (migMeta) {
       yield put(AuthActions.initMigMeta(migMeta));
       yield put(AuthActions.initFromStorage());
+      // Early prompt for discovery service cert acceptance if it hasn't already been accepted
+      yield put(ClusterActions.initializeDiscoveryCert());
     }
 
     // Configure token expiry behavior


### PR DESCRIPTION
Closes #1004 

It's been agreed that it's a better experience for users to accept the
discovery service cert as part of app initialization with the rest of
the certificates that have to be accepted instead of having it interrupt
the middle of plan creation.

Because the debug tree feature also depends on this cert acceptance,
it's a good time to bump the initial call to app initialization. This PR
introduces the check during app init, and makes sure to wait until the
actual host MigCluster has been loaded, since it's actually possible the
name of that cluster will differ from the default value.