### PR TITLE
Reduce bundle size by tree shaking, matching lodash version, & compression

### DIFF
--- a/deploy/main.js
+++ b/deploy/main.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const fs = require('fs');
 const moment = require('moment');
+const compression = require('compression');
 const { sanitizeMigMeta, getClusterAuth } = require('./oAuthHelpers');
 
 const migMetaFile = process.env['MIGMETA_FILE'] || '/srv/migmeta.json';
@@ -19,6 +20,7 @@ console.log('staticDir: ', staticDir);
 console.log('migMeta: ', migMeta);
 
 const app = express();
+app.use(compression());
 app.engine('ejs', require('ejs').renderFile);
 app.set('views', viewsDir);
 app.use(express.static(staticDir));

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "test": "yarn test:unit",
     "ci": "yarn lint && yarn test && yarn build",
     "mocks": "node scripts/gather-mocked-data.js",
-    "mocks:prune": "node scripts/gather-mocked-data.js prune"
+    "mocks:prune": "node scripts/gather-mocked-data.js prune",
+    "build:bundle-profile": "webpack --config config/webpack.prod.js --profile --json > stats.json",
+    "bundle-profile:analyze": "yarn build:bundle-profile && webpack-bundle-analyzer ./stats.json"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.0",
@@ -40,6 +42,7 @@
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "clean-webpack-plugin": "^2.0.1",
+    "compression": "^1.7.4",
     "concurrently": "^5.2.0",
     "css-loader": "^2.1.1",
     "eslint": "^6.8.0",
@@ -67,7 +70,7 @@
     "ts-loader": "^7.0.5",
     "typescript": "^3.9.5",
     "webpack": "^4.29.6",
-    "webpack-bundle-analyzer": "^3.3.2",
+    "webpack-bundle-analyzer": "^3.9.0",
     "webpack-cli": "^3.3.0",
     "webpack-dev-server": "^3.2.1"
   },
@@ -87,7 +90,7 @@
     "formik": "^2.1.4",
     "history": "^4.9.0",
     "jszip": "^3.2.2",
-    "lodash": "^4.17.14",
+    "lodash": "^4.17.19",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.26",
     "q": "^1.5.1",

--- a/src/app/common/components/ActiveNamespaceModal.tsx
+++ b/src/app/common/components/ActiveNamespaceModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext, useState } from 'react';
 import { Modal, Button, Title, BaseSizes, TextContent, Text, Form } from '@patternfly/react-core';
-import { CogIcon } from '@patternfly/react-icons';
+import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { AuthActions } from '../../auth/duck/actions';
 import { ClusterActions } from '../../cluster/duck/actions';

--- a/src/app/common/components/ConnectionStatusLabel.tsx
+++ b/src/app/common/components/ConnectionStatusLabel.tsx
@@ -1,8 +1,7 @@
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  OutlinedCircleIcon,
-} from '@patternfly/react-icons';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import OutlinedCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-circle-icon';
+
 import * as React from 'react';
 import { AddEditState } from '../../common/add_edit_state';
 import { Spinner, Flex, FlexItem } from '@patternfly/react-core';

--- a/src/app/common/components/ErrorModal.tsx
+++ b/src/app/common/components/ErrorModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext, useState } from 'react';
 import { Modal, Button, Grid, GridItem, Title, BaseSizes } from '@patternfly/react-core';
-import { ErrorCircleOIcon } from '@patternfly/react-icons';
+import ErrorCircleOIcon from '@patternfly/react-icons/dist/js/icons/error-circle-o-icon';
 import { useHistory } from 'react-router-dom';
 import { AlertActions } from '../duck/actions';
 import { connect } from 'react-redux';

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -9,8 +9,7 @@ import {
   DropdownToggle,
   DropdownItem,
 } from '@patternfly/react-core';
-import { FilterIcon } from '@patternfly/react-icons';
-
+import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import { FilterControl } from './FilterControl';
 
 export enum FilterType {

--- a/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SearchFilterControl.tsx
@@ -6,7 +6,7 @@ import {
   Button,
   ButtonVariant,
 } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import { IFilterControlProps } from './FilterControl';
 import { ISearchFilterCategory } from './FilterToolbar';
 

--- a/src/app/common/components/KeyDisplayToggle.tsx
+++ b/src/app/common/components/KeyDisplayToggle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
-import { EyeSlashIcon, EyeIcon } from '@patternfly/react-icons';
-
+import EyeSlashIcon from '@patternfly/react-icons/dist/js/icons/eye-slash-icon';
+import EyeIcon from '@patternfly/react-icons/dist/js/icons/eye-icon';
 // TODO this is a good candidate for lib-ui
 
 interface IKeyDisplayToggleProps {

--- a/src/app/common/components/PageHeaderComponent.tsx
+++ b/src/app/common/components/PageHeaderComponent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { CogIcon, UserIcon } from '@patternfly/react-icons';
+import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
+import UserIcon from '@patternfly/react-icons/dist/js/icons/user-icon';
 import logoKonveyor from './logoKonveyor.svg';
 import logoRedHat from './logoRedHat.svg';
 import IconWithText from './IconWithText';

--- a/src/app/common/components/TableEmptyState.tsx
+++ b/src/app/common/components/TableEmptyState.tsx
@@ -10,7 +10,7 @@ import {
   EmptyStateBody,
   Button,
 } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 
 export interface ITableEmptyStateProps {

--- a/src/app/home/pages/ClustersPage/ClustersPage.tsx
+++ b/src/app/home/pages/ClustersPage/ClustersPage.tsx
@@ -14,7 +14,8 @@ import {
   Spinner,
   EmptyStateBody,
 } from '@patternfly/react-core';
-import { AddCircleOIcon, SearchIcon } from '@patternfly/react-icons';
+import AddCircleOIcon from '@patternfly/react-icons/dist/js/icons/add-circle-o-icon';
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { ClusterContext } from '../../duck/context';
 import clusterSelectors from '../../../cluster/duck/selectors';

--- a/src/app/home/pages/ClustersPage/components/ClustersTable.tsx
+++ b/src/app/home/pages/ClustersPage/components/ClustersTable.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Button, Pagination, Level, LevelItem } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, sortable, classNames } from '@patternfly/react-table';
-import { LinkIcon } from '@patternfly/react-icons';
+import LinkIcon from '@patternfly/react-icons/dist/js/icons/link-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
 import { usePaginationState, useSortState } from '../../../../common/duck/hooks';

--- a/src/app/home/pages/LogsPage/components/LogsContainer.tsx
+++ b/src/app/home/pages/LogsPage/components/LogsContainer.tsx
@@ -12,7 +12,8 @@ import {
   Title,
   EmptyStateBody,
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+
 import { PollingContext } from '../../../duck/context';
 
 interface IProps {

--- a/src/app/home/pages/PlansPage/PlansPage.tsx
+++ b/src/app/home/pages/PlansPage/PlansPage.tsx
@@ -13,7 +13,7 @@ import {
   Bullseye,
   Spinner,
 } from '@patternfly/react-core';
-import { AddCircleOIcon } from '@patternfly/react-icons';
+import AddCircleOIcon from '@patternfly/react-icons/dist/js/icons/add-circle-o-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IAddPlanDisabledObjModel } from './types';
 import { PlanContext } from '../../duck/context';

--- a/src/app/home/pages/PlansPage/components/AnalyticsTable.tsx
+++ b/src/app/home/pages/PlansPage/components/AnalyticsTable.tsx
@@ -20,7 +20,7 @@ import {
   Tooltip,
   TooltipPosition,
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IAnalytic } from '../../../../plan/duck/types';
 import ReactJson from 'react-json-view';

--- a/src/app/home/pages/PlansPage/components/PlanStatusIcon.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanStatusIcon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import {
-  OutlinedCircleIcon,
-  ResourcesAlmostEmptyIcon,
-  ResourcesFullIcon,
-  WarningTriangleIcon,
-  ExclamationCircleIcon,
-} from '@patternfly/react-icons';
+
+import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
+import OutlinedCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import ResourcesAlmostEmptyIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-empty-icon';
+import ResourcesFullIcon from '@patternfly/react-icons/dist/js/icons/resources-full-icon';
+
 import { Popover, PopoverPosition } from '@patternfly/react-core';
 
 import { Spinner } from '@patternfly/react-core';

--- a/src/app/home/pages/PlansPage/components/PlansTable.tsx
+++ b/src/app/home/pages/PlansPage/components/PlansTable.tsx
@@ -12,15 +12,14 @@ import {
   Flex,
   FlexItem,
   TextVariants,
-  PopoverPosition,
-  Popover,
-  Spinner,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IAddPlanDisabledObjModel } from '../types';
 import AddPlanDisabledTooltip from './AddPlanDisabledTooltip';
 import { compoundExpand, Table, TableHeader, TableBody, sortable } from '@patternfly/react-table';
-import { MigrationIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import MigrationIcon from '@patternfly/react-icons/dist/js/icons/migration-icon';
+
 import PlanStatus from './PlanStatus';
 import PlanActions from './PlanActions';
 import MigrationsTable from './MigrationsTable';

--- a/src/app/home/pages/PlansPage/components/Wizard/ConditionsGrid.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/ConditionsGrid.tsx
@@ -13,12 +13,10 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
-import {
-  IconSize,
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+
 const styles = require('./ResultsStep.module');
 
 interface IConditionsGridProps {
@@ -39,17 +37,17 @@ const ConditionsGrid: React.FunctionComponent<IConditionsGridProps> = ({
         <GridItem span={1} className={alignment.textAlignRight}>
           {condition.type === 'Ready' && (
             <span className="pf-c-icon pf-m-success">
-              <CheckCircleIcon size={IconSize.sm} />
+              <CheckCircleIcon size={'sm'} />
             </span>
           )}
           {condition.type === 'Warn' && (
             <span className="pf-c-icon pf-m-warning">
-              <ExclamationTriangleIcon size={IconSize.sm} />
+              <ExclamationTriangleIcon size={'sm'} />
             </span>
           )}
           {condition.type === 'Error' && (
             <span className="pf-c-icon pf-m-danger">
-              <ExclamationCircleIcon size={IconSize.sm} />
+              <ExclamationCircleIcon size={'sm'} />
             </span>
           )}
         </GridItem>
@@ -65,7 +63,7 @@ const ConditionsGrid: React.FunctionComponent<IConditionsGridProps> = ({
                     <Flex>
                       <FlexItem>
                         <span className="pf-c-icon pf-m-warning">
-                          <ExclamationTriangleIcon size={IconSize.sm} />
+                          <ExclamationTriangleIcon size={'sm'} />
                         </span>
                       </FlexItem>
                       <FlexItem>

--- a/src/app/home/pages/PlansPage/components/Wizard/CopyOptionsTable.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/CopyOptionsTable.tsx
@@ -23,11 +23,10 @@ import {
   BaseSizes,
 } from '@patternfly/react-core';
 import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
-import {
-  InfoCircleIcon,
-  QuestionCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
+import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import { useFilterState, useSortState, usePaginationState } from '../../../../../common/duck/hooks';

--- a/src/app/home/pages/PlansPage/components/Wizard/HooksFormComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/HooksFormComponent.tsx
@@ -17,7 +17,7 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { AddEditMode, addEditButtonText } from '../../../../../common/add_edit_state';
-import { QuestionCircleIcon } from '@patternfly/react-icons';
+import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import SimpleSelect from '../../../../../common/components/SimpleSelect';
 import { validatedState } from '../../../../../common/helpers';
 const classNames = require('classnames');

--- a/src/app/home/pages/PlansPage/components/Wizard/HooksStep.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/HooksStep.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { Spinner } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 import { connect } from 'react-redux';
 
 import {

--- a/src/app/home/pages/PlansPage/components/Wizard/ResultsStep.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/ResultsStep.tsx
@@ -4,12 +4,9 @@ import { Bullseye, Title, Button, Flex } from '@patternfly/react-core';
 import ConditionsGrid from './ConditionsGrid';
 import { ICurrentPlanStatus, CurrentPlanState } from '../../../../../plan/duck/reducers';
 import { Spinner } from '@patternfly/react-core';
-import {
-  IconSize,
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import { useFormikContext } from 'formik';
 import { IFormValues } from './WizardContainer';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
@@ -42,20 +39,20 @@ const ResultsStep: React.FunctionComponent<IProps> = ({
       case CurrentPlanState.Ready:
         return (
           <span className="pf-c-icon pf-m-success">
-            <CheckCircleIcon size={IconSize.xl} />
+            <CheckCircleIcon size={'xl'} />
           </span>
         );
       case CurrentPlanState.Critical:
       case CurrentPlanState.TimedOut:
         return (
           <span className="pf-c-icon pf-m-danger">
-            <ExclamationCircleIcon size={IconSize.xl} />
+            <ExclamationCircleIcon size={'xl'} />
           </span>
         );
       case CurrentPlanState.Warn:
         return (
           <span className="pf-c-icon pf-m-warning">
-            <ExclamationTriangleIcon size={IconSize.xl} />
+            <ExclamationTriangleIcon size={'xl'} />
           </span>
         );
       default:

--- a/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/TokenSelect.tsx
@@ -9,7 +9,7 @@ import {
   FlexItem,
   Spinner,
 } from '@patternfly/react-core';
-import { CheckIcon } from '@patternfly/react-icons';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import flexStyles from '@patternfly/react-styles/css/layouts/Flex/flex';
 import SimpleSelect, {

--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesTable.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesTable.tsx
@@ -20,7 +20,7 @@ import {
 } from '@patternfly/react-core';
 import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
 import ReactJson from 'react-json-view';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import SimpleSelect, { OptionWithValue } from '../../../../../common/components/SimpleSelect';
 import { useFilterState, useSortState, usePaginationState } from '../../../../../common/duck/hooks';

--- a/src/app/home/pages/StoragesPage/StoragesPage.tsx
+++ b/src/app/home/pages/StoragesPage/StoragesPage.tsx
@@ -13,7 +13,7 @@ import {
   Bullseye,
   Spinner,
 } from '@patternfly/react-core';
-import { AddCircleOIcon } from '@patternfly/react-icons';
+import AddCircleOIcon from '@patternfly/react-icons/dist/js/icons/add-circle-o-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { StorageContext } from '../../duck/context';
 import storageSelectors from '../../../storage/duck/selectors';

--- a/src/app/home/pages/StoragesPage/components/StoragesTable.tsx
+++ b/src/app/home/pages/StoragesPage/components/StoragesTable.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Button, Pagination, Level, LevelItem } from '@patternfly/react-core';
 import { Table, TableHeader, TableBody, sortable, classNames } from '@patternfly/react-table';
-import { LinkIcon } from '@patternfly/react-icons';
+import LinkIcon from '@patternfly/react-icons/dist/js/icons/link-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
 import { useSortState, usePaginationState } from '../../../../common/duck/hooks';

--- a/src/app/home/pages/TokensPage/TokensPage.tsx
+++ b/src/app/home/pages/TokensPage/TokensPage.tsx
@@ -13,7 +13,8 @@ import {
   Title,
   Spinner,
 } from '@patternfly/react-core';
-import { WrenchIcon, AddCircleOIcon } from '@patternfly/react-icons';
+import WrenchIcon from '@patternfly/react-icons/dist/js/icons/wrench-icon';
+import AddCircleOIcon from '@patternfly/react-icons/dist/js/icons/add-circle-o-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import clusterSelectors from '../../../cluster/duck/selectors';
 import TokensTable from './components/TokensTable';

--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -32,7 +32,6 @@ import { AuthActions } from '../../auth/duck/actions';
 import { push } from 'connected-react-router';
 import planUtils from './utils';
 import { createAddEditStatus, AddEditState, AddEditMode } from '../../common/add_edit_state';
-import _ from 'lodash';
 import { NON_ADMIN_ENABLED } from '../../../TEMPORARY_GLOBAL_FLAGS';
 import { IReduxState } from '../../../reducers';
 import Q from 'q';

--- a/src/app/token/OAuthLandingPage.tsx
+++ b/src/app/token/OAuthLandingPage.tsx
@@ -12,7 +12,7 @@ import {
   Text,
   Spinner,
 } from '@patternfly/react-core';
-import { LockIcon } from '@patternfly/react-icons';
+import LockIcon from '@patternfly/react-icons/dist/js/icons/lock-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import PageHeaderComponent from '../common/components/PageHeaderComponent';
 

--- a/src/client/__tests__/kube_store.test.ts
+++ b/src/client/__tests__/kube_store.test.ts
@@ -1,6 +1,6 @@
-import _ from 'lodash';
 import { KubeStore, LocalStorageMockedDataKey } from '../kube_store';
 import { MigResource, MigResourceKind } from '../resources';
+import { isEqual } from 'lodash';
 
 const examplePlan = {
   apiVersion: 'migration.openshift.io/v1alpha1',
@@ -57,7 +57,7 @@ test('Test NamespacedResource setResource', () => {
     JSON.stringify({ clusters: { [hostCluster]: {} } })
   );
   store.setResource(migResource, planName, examplePlan);
-  expect(_.isEqual(JSON.stringify(expected), localStorage.getItem(LocalStorageMockedDataKey))).toBe(
+  expect(isEqual(JSON.stringify(expected), localStorage.getItem(LocalStorageMockedDataKey))).toBe(
     true
   );
   localStorage.clear();

--- a/src/client/kube_store/index.ts
+++ b/src/client/kube_store/index.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { KubeResource } from '../resources';
 import { MigResource, MigResourceKind } from '../resources/mig';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,20 +1411,10 @@ acorn-jsx@^5.1.0:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
   integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
 
-acorn-walk@^6.1.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
-  integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
-
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
-
-acorn@^6.0.7:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
-  integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
 acorn@^6.4.1:
   version "6.4.1"
@@ -9760,13 +9750,13 @@ webidl-conversions@^6.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
-webpack-bundle-analyzer@^3.3.2:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.0.tgz#39b3a8f829ca044682bc6f9e011c95deb554aefd"
-  integrity sha512-orUfvVYEfBMDXgEKAKVvab5iQ2wXneIEorGNsyuOyVYpjYrI7CUOhhXNDd3huMwQ3vNNWWlGP+hzflMFYNzi2g==
+webpack-bundle-analyzer@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz#f6f94db108fb574e415ad313de41a2707d33ef3c"
+  integrity sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==
   dependencies:
-    acorn "^6.0.7"
-    acorn-walk "^6.1.1"
+    acorn "^7.1.1"
+    acorn-walk "^7.1.1"
     bfj "^6.1.1"
     chalk "^2.4.1"
     commander "^2.18.0"
@@ -9774,7 +9764,7 @@ webpack-bundle-analyzer@^3.3.2:
     express "^4.16.3"
     filesize "^3.6.1"
     gzip-size "^5.0.0"
-    lodash "^4.17.15"
+    lodash "^4.17.19"
     mkdirp "^0.5.1"
     opener "^1.5.1"
     ws "^6.0.0"


### PR DESCRIPTION
After some feedback from Xin Jiang (QE), we decided to look into reducing the bundle size in prod images. This PR includes tree shaking pf icons & lodash imports, adds express compression for production requests [compression info], (http://expressjs.com/en/resources/middleware/compression.html), and pulls in a bundle analysis tool for further evaluation. Thanks to Mike & Zack from UXD for helping out with this. Hopefully this will help QE's testing process & overall load times.

