### PR TITLE
Fix miganalytics flashing when updating migmigration list

### DIFF
--- a/src/app/home/pages/PlansPage/components/PlansTable.tsx
+++ b/src/app/home/pages/PlansPage/components/PlansTable.tsx
@@ -218,9 +218,10 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                         {!isLoadingAnalytic && (
                           <Text component={TextVariants.small}>
                             Last updated:{` `}
-                            {moment(plan.PlanStatus.latestAnalyticTransitionTime)
-                              .local()
-                              .format('YYYY-MM-DD HH:mm:ss')}
+                            {moment(plan.PlanStatus.latestAnalyticTransitionTime).isValid &&
+                              moment(plan.PlanStatus.latestAnalyticTransitionTime)
+                                .local()
+                                .format('YYYY-MM-DD HH:mm:ss')}
                           </Text>
                         )}
                       </TextContent>

--- a/src/app/plan/duck/utils.ts
+++ b/src/app/plan/duck/utils.ts
@@ -26,7 +26,7 @@ function groupPlans(migPlans: any[], migMigrationRefs: any[], migAnalyticRefs: a
 }
 const groupPlan: any = (plan, response) => {
   const fullPlan = {
-    MigPlan: plan.MigPlan,
+    ...plan.MigPlan,
   };
   if (response.data.items.length > 0) {
     const sortMigrations = (migrationList) =>


### PR DESCRIPTION
Closes #1029 
Fixes an issue involving the redux state overriding miganalytics when updating the associated migration list for migplans.

Also fixes the invalid date message that shows up in miganalytics table when moment receives an invalid/null date. 

