### PR TITLE
Skip MigPlan readiness check at PV discovery

### DIFF
--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -437,7 +437,7 @@ function* pvUpdatePoll(action) {
             // if plan done refreshing, hydrate redux store with updated controller data
             yield put(PlanActions.setCurrentPlan(updatedPlan));
             yield put(PlanActions.updatePlanList(updatedPlan));
-            yield put(PlanActions.startPlanStatusPolling(updatedPlan.metadata.name));
+            yield put(PlanActions.updateCurrentPlanStatus({ state: CurrentPlanState.Ready }));
             yield put(PlanActions.refreshAnalyticRequest(updatedPlan.metadata.name));
             yield put(PlanActions.pvUpdatePollStop());
           }
@@ -446,7 +446,7 @@ function* pvUpdatePoll(action) {
           if (updatedPlan.status) {
             yield put(PlanActions.setCurrentPlan(updatedPlan));
             yield put(PlanActions.updatePlanList(updatedPlan));
-            yield put(PlanActions.startPlanStatusPolling(updatedPlan.metadata.name));
+            yield put(PlanActions.updateCurrentPlanStatus({ state: CurrentPlanState.Ready }));
             yield put(PlanActions.pvUpdatePollStop());
           }
         }


### PR DESCRIPTION
This is a temporary measure that should be reversed after changes
are made to mig-controller so that MigPlan readiness does not
depend on Migration Registry readiness before the registry is needed.