### PR TITLE
Revert "Skip MigPlan readiness check at PV discovery"

### DIFF
--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -436,7 +436,7 @@ function* pvUpdatePoll(action) {
             // if plan done refreshing, hydrate redux store with updated controller data
             yield put(PlanActions.setCurrentPlan(updatedPlan));
             yield put(PlanActions.updatePlanList(updatedPlan));
-            yield put(PlanActions.updateCurrentPlanStatus({ state: CurrentPlanState.Ready }));
+            yield put(PlanActions.startPlanStatusPolling(updatedPlan.metadata.name));
             yield put(PlanActions.refreshAnalyticRequest(updatedPlan.metadata.name));
             yield put(PlanActions.pvUpdatePollStop());
           }
@@ -445,7 +445,7 @@ function* pvUpdatePoll(action) {
           if (updatedPlan.status) {
             yield put(PlanActions.setCurrentPlan(updatedPlan));
             yield put(PlanActions.updatePlanList(updatedPlan));
-            yield put(PlanActions.updateCurrentPlanStatus({ state: CurrentPlanState.Ready }));
+            yield put(PlanActions.startPlanStatusPolling(updatedPlan.metadata.name));
             yield put(PlanActions.pvUpdatePollStop());
           }
         }


### PR DESCRIPTION
Reverts konveyor/mig-ui#1034

Now that MigPlan readiness is not tied to registry readiness, we can re-enable the MigPlan readiness check at PV discovery time.

Changes were made in mig-controller at https://github.com/konveyor/mig-controller/pull/717