### PR TITLE
MIG-119 : Drill down page for migration steps

### DIFF
--- a/src/app/home/HomeComponent.tsx
+++ b/src/app/home/HomeComponent.tsx
@@ -34,6 +34,7 @@ import { NON_ADMIN_ENABLED } from '../../TEMPORARY_GLOBAL_FLAGS';
 import { PlansContextProvider } from './pages/PlansPage/context';
 import { MigrationsPage } from './pages/PlansPage/pages/MigrationsPage';
 import { MigrationDetailsPage } from './pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage';
+import { MigrationStepDetailsPage } from './pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage';
 
 const mainContainerId = 'mig-ui-page-main-container';
 
@@ -137,6 +138,9 @@ const HomeComponent: React.FunctionComponent<IHomeComponentProps> = ({
                 </Route>
                 <Route exact path="/plans/:planName/migrations/:migrationID">
                   <MigrationDetailsPage />
+                </Route>
+                <Route exact path="/plans/:planName/migrations/:migrationID/:stepName">
+                  <MigrationStepDetailsPage />
                 </Route>
                 <Route exact path="/plans/:planName/debug">
                   <PlanDebugPage />

--- a/src/app/home/pages/PlansPage/components/PipelineSummary/PipelineSummary.tsx
+++ b/src/app/home/pages/PlansPage/components/PipelineSummary/PipelineSummary.tsx
@@ -4,7 +4,7 @@ import ResourcesFullIcon from '@patternfly/react-icons/dist/js/icons/resources-f
 import ResourcesAlmostFullIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-full-icon';
 import ResourcesAlmostEmptyIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-empty-icon';
 
-import { findCurrentStep, getPipelineSummaryTitle } from '../../helpers';
+import { getPipelineSummaryTitle } from '../../helpers';
 import { IMigrationStatus } from '../../../../../plan/duck/types';
 const classNames = require('classnames');
 const styles = require('./PipelineSummary.module');
@@ -82,44 +82,26 @@ const PipelineSummary: React.FunctionComponent<IPipelineSummaryProps> = ({
     return null;
   }
   const title = getPipelineSummaryTitle(status);
-  const { currentStep, currentStepIndex } = findCurrentStep(status?.pipeline || []);
-  if (status?.phase === 'Completed') {
-    return (
-      <Summary title={title}>
-        <Chain Face={ResourcesFullIcon} times={status.pipeline.length} color={successColor} />
-      </Summary>
-    );
-  } else if (currentStep?.started && !currentStep?.completed) {
-    return (
-      <Summary title={title}>
-        <Chain Face={ResourcesFullIcon} times={currentStepIndex} color={successColor} />
-        {currentStepIndex > 0 ? <Dash isReached={true} /> : null}
-        <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-          <ResourcesAlmostFullIcon color={status?.errors?.length ? dangerColor : infoColor} />
-        </FlexItem>
-        {currentStepIndex < status?.pipeline?.length - 1 ? (
+  return (
+    <Summary title={title}>
+      {status?.pipeline.map((step, index) => {
+        return (
           <>
-            <Dash isReached={false} />
-            <Chain
-              Face={ResourcesAlmostEmptyIcon}
-              times={status?.pipeline?.length - currentStepIndex - 1}
-              color={disabledColor}
-            />
+            {index != 0 ? <Dash key={step.name} isReached={step?.started ? true : false} /> : ''}
+            {!step?.started ? (
+              <Chain key={index} Face={ResourcesFullIcon} times={1} color={disabledColor} />
+            ) : step?.failed ? (
+              <Chain key={index} Face={ResourcesFullIcon} times={1} color={dangerColor} />
+            ) : step?.started && !step?.completed ? (
+              <Chain key={index} Face={ResourcesAlmostFullIcon} times={1} color={successColor} />
+            ) : (
+              <Chain key={index} Face={ResourcesFullIcon} times={1} color={successColor} />
+            )}
           </>
-        ) : null}
-      </Summary>
-    );
-  } else {
-    return (
-      <Summary title={title}>
-        <Chain
-          Face={ResourcesAlmostEmptyIcon}
-          times={status?.pipeline?.length}
-          color={disabledColor}
-        />
-      </Summary>
-    );
-  }
+        );
+      })}
+    </Summary>
+  );
 };
 
 export default PipelineSummary;

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -2,8 +2,10 @@ import { ProgressVariant } from '@patternfly/react-core';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 dayjs.extend(duration);
 dayjs.extend(relativeTime);
+dayjs.extend(customParseFormat);
 
 import { IMigration, IMigrationStatus, IPlan, IStep } from '../../../plan/duck/types';
 import { MigrationStepsType } from './types';
@@ -86,38 +88,138 @@ export const getPipelineSummaryTitle = (status: IMigrationStatus): string => {
 
 export interface IProgressInfoObj {
   percentComplete: number;
+  progressBarApplicable: boolean;
+  progressBarMessage: string;
   title: string;
   variant: ProgressVariant;
   isWarning: boolean;
 }
+
+export const showConsolidatedProgressBar = (step: IStep): boolean => {
+  return step.name == MigrationStepsType.Backup;
+};
+
+export interface IMigrationStepProgressObj {
+  metadata: string;
+  message: string;
+  duration: string;
+  progressVariant: ProgressVariant;
+  progressBarApplicable: boolean;
+  percentComplete: number;
+}
+
+// convertSItoBytes: converts SI units of storage into bytes
+// useful for percentage completion calculation
+const convertSItoBytes = (number: string, unit: string): number => {
+  const baseUnit = 1000;
+  const sizes = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+  const exponent = sizes.findIndex((i) => i === unit);
+  return exponent !== -1 ? Math.pow(baseUnit, exponent) * parseFloat(number) : 0;
+};
+
+// getMigrationStepProgress: parses each progress line and returns structured progress information
+// used for detailed drill down pages of migration steps
+// Progress messages from controller follow standard format of :
+// "<resource> <namespace>/<name>: <message>"
+// <message> above can contain volume transfer / backup progress in the form
+// "<number> <unit> out of <number> <unit> completed"
+// <unit> is a SI unit of size
+export const getMigrationStepProgress = (progressLine: string): IMigrationStepProgressObj => {
+  let percentComplete = 0,
+    progressBarApplicable = false;
+  let duration = '';
+
+  const metadataRegex = /(.*?):.*/;
+  const metadata = metadataRegex.test(progressLine) ? progressLine.match(metadataRegex)[1] : '';
+
+  const durationRegex = /\(([a-z0-9]+)\)$/;
+  const parsedDuration = durationRegex.test(progressLine)
+    ? progressLine.match(durationRegex)[1]
+    : '';
+  if (parsedDuration !== '') {
+    const elapsedTime = dayjs(parsedDuration, ['H[h]m[m]s[s]', 'm[m]s[s]', 's[s]']);
+    duration = dayjs.duration(elapsedTime.diff(dayjs('0h0m0s', 'H[h]m[m]s[s]'))).humanize();
+  }
+
+  const strippedMessage = progressLine.replace(durationRegex, '');
+
+  const messageRegex = /.*?: (.*)/;
+  const message = messageRegex.test(strippedMessage) ? strippedMessage.match(messageRegex)[1] : '';
+
+  const progressRegex = /.*?([\d\.]*) *(bytes|kB|MB|GB|TB|PB|EB)* out of (estimated total of| )*([\d\.]*) *(bytes|MB|kB|GB|TB|PB|EB)*/;
+
+  const failedRegex = /.*?[Ff]ailed/;
+
+  if (progressRegex.test(progressLine)) {
+    progressBarApplicable = true;
+    const matched = progressLine.match(progressRegex);
+    const completedSoFar = matched[1] ? matched[1] : '0';
+    const unitCompletedSoFar = matched[2] ? matched[2] : null;
+    const totalResources = matched[4] ? matched[4] : '100';
+    const unitTotalResources = matched[5] ? matched[5] : null;
+    if (unitTotalResources && unitCompletedSoFar) {
+      const completed = convertSItoBytes(completedSoFar, unitCompletedSoFar);
+      const total = convertSItoBytes(totalResources, unitTotalResources);
+      percentComplete = total !== 0 ? (completed / total) * 100 : 0;
+    } else {
+      const total = parseFloat(totalResources);
+      const completed = parseFloat(completedSoFar);
+      percentComplete = total !== 0 ? (completed / total) * 100 : 0;
+    }
+  }
+
+  const progressVariant = failedRegex.test(progressLine)
+    ? ProgressVariant.danger
+    : ProgressVariant.success;
+
+  return {
+    metadata: metadata,
+    message: message,
+    duration: duration,
+    progressVariant: progressVariant,
+    progressBarApplicable: progressBarApplicable,
+    percentComplete: percentComplete,
+  };
+};
+
 export const getProgressValues = (step: IStep, migration?: IMigration): IProgressInfoObj => {
-  // title={step.phase || migration.status.phase}
-  // if (step.started && !step.completed) {
-  //   return {
-  //     percentComplete: 100,
-  //     title: 'Complete',
-  //     variant: ProgressVariant.success,
-  //     isWarning: false,
-  //   };
-  // }else{
-  let titleText;
+  let titleText, progressVariant, duration;
+  let progressBarApplicable = false;
+  let progressBarMessage = '';
+  let percentComplete = 100;
   if (
     step.started &&
     !step.completed &&
     (migration.tableStatus.migrationState === 'error' || migration?.status?.errors?.length)
   ) {
     titleText = 'Error';
+    progressVariant = ProgressVariant.danger;
   } else if (step.started && !step.completed) {
-    titleText = step?.progress?.slice(-1).pop() || step.message || '';
+    titleText = step.message || step.phase || '';
   } else if (!step.started) {
     titleText = 'Not Started';
+  } else if (step.failed) {
+    titleText = 'Failed';
+    progressVariant = ProgressVariant.danger;
   } else if (step.completed) {
     titleText = 'Complete';
+    progressVariant = ProgressVariant.success;
   }
+
+  if (showConsolidatedProgressBar(step) && step.progress) {
+    const progress = getMigrationStepProgress(step.progress[0]);
+    duration = progress.duration;
+    percentComplete = progress.percentComplete;
+    progressBarMessage = step.completed ? progress.metadata : progress.message;
+    progressBarApplicable = progress.progressBarApplicable;
+  }
+
   return {
-    percentComplete: 100,
+    progressBarApplicable: progressBarApplicable,
+    progressBarMessage: progressBarMessage,
+    percentComplete: percentComplete,
     title: titleText,
-    variant: ProgressVariant.success,
+    variant: progressVariant,
     isWarning: false,
   };
 };

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -95,6 +95,43 @@ export interface IProgressInfoObj {
   isWarning: boolean;
 }
 
+// returns step details page title text based on step
+export const getStepPageTitle = (step: IStep): string => {
+  switch (step.name) {
+    case MigrationStepsType.Prepare:
+      return 'Preparing for migration';
+    case MigrationStepsType.Backup:
+      return 'Creating initial backup';
+    case MigrationStepsType.StageBackup:
+      return 'Creating stage backup';
+    case MigrationStepsType.StageRestore:
+      return 'Creating stage restore';
+    case MigrationStepsType.Restore:
+      return 'Creating final restore';
+    case MigrationStepsType.Cleanup:
+      return 'Cleaning up';
+    default:
+      return `${step.name} details`;
+  }
+};
+
+// parses golang timestamps
+export const formatGolangTimestamp = (timestamp: string): string => {
+  const formats = [
+    'YYYY-M-D[T]H:m:s[Z]',
+    'YYYY-MM-DD[T]HH:mm:ss[Z]',
+    'YYYY-M-D[T]HH:mm:ss[Z]',
+    'YYYY-MM-DD[T]H:m:s[Z]',
+  ];
+  let formattedTime;
+  try {
+    formattedTime = dayjs(timestamp, formats).format('D MMM YYYY, HH:mm:ss');
+  } catch (e) {
+    formattedTime = timestamp;
+  }
+  return formattedTime;
+};
+
 export const showConsolidatedProgressBar = (step: IStep): boolean => {
   return step.name == MigrationStepsType.Backup;
 };

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -19,6 +19,7 @@ import { PollingContext } from '../../../../duck/context';
 import { IMigration, IPlan } from '../../../../../plan/duck/types';
 import { planSelectors } from '../../../../../plan/duck';
 import MigrationDetailsTable from './MigrationDetailsTable';
+import { formatGolangTimestamp } from '../../helpers';
 
 interface IMigrationDetailsPageProps {
   planList: IPlan[];
@@ -40,7 +41,7 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
     .find((planItem: IPlan) => planItem.MigPlan.metadata.name === planName)
     ?.Migrations.find((migration: IMigration) => migration.metadata.name === migrationID);
 
-  const type = migration?.spec?.stage ? 'Stage' : 'Migration';
+  const type = migration?.spec?.stage ? 'Stage' : 'Final';
   return (
     <>
       <PageSection variant="light">
@@ -48,17 +49,15 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
           <BreadcrumbItem>
             <Link to="/plans">Plans</Link>
           </BreadcrumbItem>
-          <BreadcrumbItem to={`/plans/${planName}/migrations`}>
-            {planName} Migrations
-          </BreadcrumbItem>
+          <BreadcrumbItem to={`/plans/${planName}/migrations`}>{planName}</BreadcrumbItem>
           {!isFetchingInitialPlans && migration && (
             <BreadcrumbItem to="#" isActive>
-              {type} - {migration.status.startTimestamp}
+              {type} - {formatGolangTimestamp(migration.status.startTimestamp)}
             </BreadcrumbItem>
           )}
         </Breadcrumb>
         <Title headingLevel="h1" size="2xl">
-          Migration Details Page
+          Migration details
         </Title>
       </PageSection>
       {!isFetchingInitialPlans && migration && migration.status?.pipeline ? (

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationStepStatusIcon.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationStepStatusIcon.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
 import OutlinedCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
-import ResourcesAlmostEmptyIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-empty-icon';
+import ResourcesAlmostFullIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-full-icon';
 import ResourcesFullIcon from '@patternfly/react-icons/dist/js/icons/resources-full-icon';
 
 import { Popover, PopoverPosition } from '@patternfly/react-core';
@@ -42,6 +42,18 @@ const MigrationStepStatusIcon: React.FunctionComponent<IProps> = ({ migration, s
     );
     //   } else if () {
     //     return <Spinner size="md" />;
+  } else if (step.started && !step.completed) {
+    return (
+      <span className="pf-c-icon pf-m-success">
+        <ResourcesAlmostFullIcon />
+      </span>
+    );
+  } else if (step.failed) {
+    return (
+      <span className="pf-c-icon pf-m-danger">
+        <ExclamationCircleIcon />
+      </span>
+    );
   } else if (step.completed) {
     return (
       <span className="pf-c-icon pf-m-success">

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
@@ -19,6 +19,7 @@ import { IReduxState } from '../../../../../../reducers';
 import { IStep, IMigration, IPlan } from '../../../../../plan/duck/types';
 import { PlanActions, planSelectors } from '../../../../../plan/duck';
 import MigrationStepDetailsTable from './MigrationStepDetailsTable';
+import { getStepPageTitle, formatGolangTimestamp } from '../../helpers';
 
 interface IMigrationStepDetailsPageProps {
   planList: IPlan[];
@@ -51,22 +52,20 @@ const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetail
           <BreadcrumbItem>
             <Link to="/plans">Plans</Link>
           </BreadcrumbItem>
-          <BreadcrumbItem to={`/plans/${planName}/migrations`}>
-            {planName} Migrations
-          </BreadcrumbItem>
+          <BreadcrumbItem to={`/plans/${planName}/migrations`}>{planName}</BreadcrumbItem>
           {!isFetchingInitialPlans && migration && (
             <BreadcrumbItem to={`/plans/${planName}/migrations/${migration.metadata.name}`}>
-              {migrationType} Steps
+              {migrationType} - {formatGolangTimestamp(migration.status.startTimestamp)}
             </BreadcrumbItem>
           )}
           {!isFetchingInitialPlans && step && (
             <BreadcrumbItem to="#" isActive>
-              {step.name} - {step.started}
+              {step.name}
             </BreadcrumbItem>
           )}
         </Breadcrumb>
         <Title headingLevel="h1" size="2xl">
-          Step Details page
+          {getStepPageTitle(step)}
         </Title>
       </PageSection>
       {!isFetchingInitialPlans && step && migration && (

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsTable.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect } from 'react';
+import { Table, TableBody, TableHeader, cellWidth, sortable, IRow } from '@patternfly/react-table';
+import {
+  Bullseye,
+  EmptyState,
+  Title,
+  Progress,
+  ProgressSize,
+  Level,
+  LevelItem,
+  Pagination,
+} from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { IMigration, IStep } from '../../../../../plan/duck/types';
+import { usePaginationState } from '../../../../../common/duck/hooks/usePaginationState';
+import { getMigrationStepProgress, getElapsedTime } from '../../helpers';
+
+interface IStepProps {
+  step: IStep;
+  migration: IMigration;
+  id: string;
+}
+
+const MigrationStepDetailsTable: React.FunctionComponent<IStepProps> = ({ step, migration }) => {
+  const columns = [
+    { title: 'Resource (Namespace/Name)' },
+    { title: 'Elapsed time', transforms: [cellWidth(10)] },
+    {
+      title: 'Status',
+    },
+  ];
+
+  const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(
+    step.progress,
+    10
+  );
+
+  useEffect(() => setPageNumber(1), [setPageNumber]);
+
+  const rows: IRow[] = [];
+  currentPageItems.forEach((progress) => {
+    const stepProgressInfo = getMigrationStepProgress(progress);
+    const duration =
+      stepProgressInfo.duration === ''
+        ? getElapsedTime(step, migration)
+        : stepProgressInfo.duration;
+    if (stepProgressInfo.message !== '') {
+      rows.push({
+        cells: [
+          {
+            title: stepProgressInfo.metadata,
+          },
+          { title: duration },
+          {
+            title: stepProgressInfo.progressBarApplicable ? (
+              <Progress
+                value={stepProgressInfo.percentComplete}
+                title={stepProgressInfo.message}
+                size={ProgressSize.sm}
+                variant={stepProgressInfo.progressVariant}
+              />
+            ) : (
+              stepProgressInfo.message
+            ),
+          },
+        ],
+      });
+    }
+  });
+
+  return (
+    <>
+      {step.progress?.length > 0 ? (
+        <>
+          <Level>
+            <LevelItem />
+            <LevelItem>
+              <Pagination {...paginationProps} widgetId="migration-details-pagination-top" />
+            </LevelItem>
+          </Level>
+          <Table
+            aria-label="migration-analytics-table"
+            cells={columns}
+            rows={rows}
+            className={`${spacing.mtMd}`}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+
+          <Pagination
+            variant="bottom"
+            {...paginationProps}
+            widgetId="migration-details-table-pagination-top"
+          />
+        </>
+      ) : (
+        <Bullseye>
+          <EmptyState variant="small">
+            <Title headingLevel="h2" size="xl">
+              Detailed progress data not available.
+            </Title>
+          </EmptyState>
+        </Bullseye>
+      )}
+    </>
+  );
+};
+
+export default MigrationStepDetailsTable;

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/index.ts
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/index.ts
@@ -1,0 +1,1 @@
+export * from './MigrationStepDetailsPage';

--- a/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
@@ -1,13 +1,10 @@
-import React, { useContext, useEffect } from 'react';
-import { useParams, useHistory, Link } from 'react-router-dom';
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import dayjs from 'dayjs';
 import {
   PageSection,
-  Bullseye,
-  EmptyState,
-  Spinner,
   Title,
   Breadcrumb,
   BreadcrumbItem,
@@ -29,9 +26,8 @@ const BaseMigrationsPage: React.FunctionComponent<IMigrationsPageProps> = ({
 }: IMigrationsPageProps) => {
   const { planName } = useParams();
   const plan = planList.find((planItem: IPlan) => planItem.MigPlan.metadata.name === planName);
-  const history = useHistory();
+
   if (!plan) {
-    history.push('/');
     return null;
   }
 

--- a/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
@@ -43,7 +43,7 @@ const BaseMigrationsPage: React.FunctionComponent<IMigrationsPageProps> = ({
           </BreadcrumbItem>
         </Breadcrumb>
         <Title headingLevel="h1" size="2xl">
-          Migrations page
+          Migrations
         </Title>
       </PageSection>
       <PageSection>

--- a/src/app/home/pages/PlansPage/types.ts
+++ b/src/app/home/pages/PlansPage/types.ts
@@ -27,7 +27,7 @@ export enum MigrationStepsType {
   StageBackup = 'StageBackup',
   StageRestore = 'StageRestore',
   Restore = 'Restore',
-  Final = 'Final',
+  Cleanup = 'Cleanup',
   //Fake steps to show UI status
   NotStarted = 'NotStarted',
   Error = 'Error',


### PR DESCRIPTION
Fixes: #1041 

This PR:
- Depends on @ibolton336's PR #1053 
- Adds new drill down page for Migration "steps" details 
- Adds helpers to parse progress messages as reported in MigMigration Status
- Adds progress bars for Velero Backup / Volume Backups and Volume Restores
- Fixes minor issues with the pipeline summary view
- Fixes minor issues with the breadcrumbs in the drill down pages

![ui_3](https://user-images.githubusercontent.com/9839757/98954990-64eb4280-24cc-11eb-8e1a-a0b02daa1cb8.gif)

**Note** This pr doesn't address the Warning conditions on completed migmigrations. Ideally, PipelineSummaryView should turn orange and the message should say "Completed with warnings". 