### PR TITLE
[WIP] Pipeline updates for migration succeded with warnings

### DIFF
--- a/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
+++ b/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
@@ -6,15 +6,15 @@ import {
   Bullseye,
   EmptyState,
   Title,
-  Progress,
-  ProgressSize,
-  ProgressVariant,
   Spinner,
   Level,
   LevelItem,
   Pagination,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { Popover, PopoverPosition } from '@patternfly/react-core';
+import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
+
 const styles = require('./MigrationsTable.module');
 
 import { IMigration } from '../../../../plan/duck/types';
@@ -45,9 +45,10 @@ const MigrationsTable: React.FunctionComponent<IProps> = ({
     { title: 'Type', transforms: [sortable] },
     { title: 'Start Time', transforms: [sortable] },
     { title: 'End Time', transforms: [sortable] },
+    { title: '', transforms: [cellWidth(10)] },
     {
       title: 'Status',
-      transforms: [cellWidth(30)],
+      transforms: [cellWidth(40)],
     },
     '',
   ];
@@ -55,16 +56,12 @@ const MigrationsTable: React.FunctionComponent<IProps> = ({
   const { sortBy, onSort, sortedItems } = useSortState(migrations, getSortValues);
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
   useEffect(() => setPageNumber(1), [sortBy, setPageNumber]);
-
   const rows: IRow[] = [];
   currentPageItems.forEach((migration) => {
-    const { tableStatus } = migration;
     const type = migration.spec.stage ? 'Stage' : 'Migration';
-    const getMigrationPipelineStatus = (migrationStatus) => {
-      return migrationStatus;
-    };
-
-    rows.push({
+    const { tableStatus } = migration;
+    const isWarningCondition = tableStatus?.migrationState === 'warn';
+    const warnings = rows.push({
       cells: [
         {
           title: (
@@ -77,7 +74,33 @@ const MigrationsTable: React.FunctionComponent<IProps> = ({
         { title: migration.tableStatus.start },
         { title: migration.tableStatus.end },
         {
-          title: <PipelineSummary status={getMigrationPipelineStatus(migration?.status)} />,
+          title: isWarningCondition && (
+            <Popover
+              position={PopoverPosition.top}
+              bodyContent={tableStatus?.warnings?.map((warning, idx) => {
+                return (
+                  <>
+                    {warning}
+                    <br />
+                  </>
+                );
+              })}
+              aria-label="warning-details"
+              closeBtnAriaLabel="close-warning-details"
+              maxWidth="200rem"
+            >
+              <span className="pf-c-icon pf-m-warning">
+                <WarningTriangleIcon />
+              </span>
+            </Popover>
+          ),
+        },
+        {
+          title: (
+            <>
+              <PipelineSummary migration={migration} />
+            </>
+          ),
         },
         {
           title: <MigrationActions migration={migration} />,

--- a/src/app/home/pages/PlansPage/components/PipelineSummary/PipelineSummary.tsx
+++ b/src/app/home/pages/PlansPage/components/PipelineSummary/PipelineSummary.tsx
@@ -1,26 +1,26 @@
 import * as React from 'react';
+
 import { Flex, FlexItem, Text } from '@patternfly/react-core';
 import ResourcesFullIcon from '@patternfly/react-icons/dist/js/icons/resources-full-icon';
 import ResourcesAlmostFullIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-full-icon';
-import ResourcesAlmostEmptyIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-empty-icon';
 
 import { getPipelineSummaryTitle } from '../../helpers';
-import { IMigrationStatus } from '../../../../../plan/duck/types';
+import { IMigration } from '../../../../../plan/duck/types';
 const classNames = require('classnames');
 const styles = require('./PipelineSummary.module');
 
 interface IDashProps {
   isReached: boolean;
+  isWarning?: boolean;
 }
 const dangerColor = '#c9190b';
 const disabledColor = '#d2d2d2';
-const infoColor = '#2b9af3';
 const successColor = '#3e8635';
 
 const dashReachedStyles = classNames(styles.dash, styles.dashReached);
 const dashNotReachedStyles = classNames(styles.dash, styles.dashNotReached);
 
-const Dash: React.FunctionComponent<IDashProps> = ({ isReached }: IDashProps) => {
+const Dash: React.FunctionComponent<IDashProps> = ({ isReached, isWarning }: IDashProps) => {
   return (
     <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
       {isReached ? <div className={dashReachedStyles} /> : <div className={dashNotReachedStyles} />}
@@ -72,35 +72,38 @@ const Summary: React.FunctionComponent<ISummaryProps> = ({ title, children }: IS
 );
 
 interface IPipelineSummaryProps {
-  status: IMigrationStatus;
+  migration: IMigration;
 }
 
 const PipelineSummary: React.FunctionComponent<IPipelineSummaryProps> = ({
-  status,
+  migration,
 }: IPipelineSummaryProps) => {
+  const { status, tableStatus } = migration;
   if (!status || !status?.pipeline) {
     return null;
   }
-  const title = getPipelineSummaryTitle(status);
+  const title = getPipelineSummaryTitle(migration);
   return (
-    <Summary title={title}>
-      {status?.pipeline.map((step, index) => {
-        return (
-          <>
-            {index != 0 ? <Dash key={step.name} isReached={step?.started ? true : false} /> : ''}
-            {!step?.started ? (
-              <Chain key={index} Face={ResourcesFullIcon} times={1} color={disabledColor} />
-            ) : step?.failed ? (
-              <Chain key={index} Face={ResourcesFullIcon} times={1} color={dangerColor} />
-            ) : step?.started && !step?.completed ? (
-              <Chain key={index} Face={ResourcesAlmostFullIcon} times={1} color={successColor} />
-            ) : (
-              <Chain key={index} Face={ResourcesFullIcon} times={1} color={successColor} />
-            )}
-          </>
-        );
-      })}
-    </Summary>
+    <>
+      <Summary title={title}>
+        {status?.pipeline.map((step, index) => {
+          return (
+            <>
+              {index != 0 ? <Dash key={step.name} isReached={step?.started ? true : false} /> : ''}
+              {!step?.started ? (
+                <Chain key={index} Face={ResourcesFullIcon} times={1} color={disabledColor} />
+              ) : step?.failed ? (
+                <Chain key={index} Face={ResourcesFullIcon} times={1} color={dangerColor} />
+              ) : step?.started && !step?.completed ? (
+                <Chain key={index} Face={ResourcesAlmostFullIcon} times={1} color={successColor} />
+              ) : (
+                <Chain key={index} Face={ResourcesFullIcon} times={1} color={successColor} />
+              )}
+            </>
+          );
+        })}
+      </Summary>
+    </>
   );
 };
 

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -70,9 +70,13 @@ export const findCurrentStep = (
   return { currentStep, currentStepIndex };
 };
 
-export const getPipelineSummaryTitle = (status: IMigrationStatus): string => {
+export const getPipelineSummaryTitle = (migration: IMigration): string => {
+  const { status, tableStatus } = migration;
   const { currentStep } = findCurrentStep(status?.pipeline || []);
   if (status?.phase === 'Completed') {
+    if (tableStatus?.migrationState === 'warn') {
+      return MigrationStepsType.CompletedWithWarnings;
+    }
     return MigrationStepsType.Completed;
   }
   if (currentStep?.started && !currentStep?.completed) {

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -14,6 +14,8 @@ import {
   Spinner,
   CardBody,
 } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core';
+
 import { IReduxState } from '../../../../../../reducers';
 import { PollingContext } from '../../../../duck/context';
 import { IMigration, IPlan } from '../../../../../plan/duck/types';
@@ -41,6 +43,7 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
     .find((planItem: IPlan) => planItem.MigPlan.metadata.name === planName)
     ?.Migrations.find((migration: IMigration) => migration.metadata.name === migrationID);
 
+  const isWarningCondition = migration?.tableStatus?.migrationState === 'warn';
   const type = migration?.spec?.stage ? 'Stage' : 'Final';
   return (
     <>
@@ -60,6 +63,20 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
           Migration details
         </Title>
       </PageSection>
+      {isWarningCondition && (
+        <PageSection>
+          <Alert variant="warning" isInline title="This migration has following warning conditions">
+            {migration?.tableStatus?.warnings?.map((warning, idx) => {
+              return (
+                <>
+                  {warning}
+                  <br />
+                </>
+              );
+            })}
+          </Alert>
+        </PageSection>
+      )}
       {!isFetchingInitialPlans && migration && migration.status?.pipeline ? (
         <PageSection>
           <Card>

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
@@ -39,17 +39,8 @@ const MigrationDetailsTable: React.FunctionComponent<IProps> = ({ migration }) =
     '',
   ];
 
-  const filteredPipelineSteps = migration.status.pipeline.filter((step: IStep) => {
-    const regex = RegExp('((?:^|W)Restore(?:$|W))|((?:^|W)Backup(?:$|W))', 'i');
-    const isStageRelatedStep = regex.test(step.name);
-    if (!isStageRelatedStep) {
-      return step.name;
-    }
-  });
-  const type = migration.spec.stage ? 'Stage' : 'Migration';
-
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(
-    migration.spec.stage ? filteredPipelineSteps : migration.status.pipeline,
+    migration.status.pipeline,
     10
   );
   useEffect(() => setPageNumber(1), [setPageNumber]);

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationStepStatusIcon.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationStepStatusIcon.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 
-import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
 import OutlinedCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import ResourcesAlmostFullIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-full-icon';
 import ResourcesFullIcon from '@patternfly/react-icons/dist/js/icons/resources-full-icon';
 
-import { Popover, PopoverPosition } from '@patternfly/react-core';
-
-import { Spinner } from '@patternfly/react-core';
 import { IMigration, IStep } from '../../../../../plan/duck/types';
 
 interface IProps {
@@ -26,22 +22,6 @@ const MigrationStepStatusIcon: React.FunctionComponent<IProps> = ({ migration, s
         <ExclamationCircleIcon />
       </span>
     );
-  } else if (migrationState === 'warn') {
-    return (
-      <Popover
-        position={PopoverPosition.top}
-        bodyContent="This migration has a warning condition."
-        aria-label="warning-details"
-        closeBtnAriaLabel="close-warning-details"
-        maxWidth="200rem"
-      >
-        <span className="pf-c-icon pf-m-warning">
-          <WarningTriangleIcon />
-        </span>
-      </Popover>
-    );
-    //   } else if () {
-    //     return <Spinner size="md" />;
   } else if (step.started && !step.completed) {
     return (
       <span className="pf-c-icon pf-m-success">
@@ -60,12 +40,6 @@ const MigrationStepStatusIcon: React.FunctionComponent<IProps> = ({ migration, s
         <ResourcesFullIcon />
       </span>
     );
-    //   } else if (hasSucceededStage) {
-    //     return (
-    //       <span className="pf-c-icon pf-m-success">
-    //         <ResourcesAlmostEmptyIcon />
-    //       </span>
-    // );
   } else {
     return (
       <span className="pf-c-icon pf-m-info">

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
@@ -68,6 +68,7 @@ const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetail
           {getStepPageTitle(step)}
         </Title>
       </PageSection>
+
       {!isFetchingInitialPlans && step && migration && (
         <PageSection>
           <Card>

--- a/src/app/home/pages/PlansPage/types.ts
+++ b/src/app/home/pages/PlansPage/types.ts
@@ -32,4 +32,5 @@ export enum MigrationStepsType {
   NotStarted = 'NotStarted',
   Error = 'Error',
   Completed = 'Completed',
+  CompletedWithWarnings = 'Completed with warnings',
 }

--- a/src/app/plan/duck/types.ts
+++ b/src/app/plan/duck/types.ts
@@ -88,6 +88,7 @@ export interface IMigration {
     progress: number;
     start: string;
     stepName: string;
+    warnings: string[];
   };
 }
 


### PR DESCRIPTION
Closes #1069 

This PR 
* Adds a warning icon with popover on the Pipeline summary view to indicate migration succeded with warnings:

![Screenshot from 2020-11-19 11-53-28](https://user-images.githubusercontent.com/9839757/99697818-13a7f980-2a5e-11eb-93f1-563ca5026ae5.png)

* Adds Alert on the migration details page to indicate the warnings and prints warnings in the alert

![Screenshot from 2020-11-19 11-53-36](https://user-images.githubusercontent.com/9839757/99697662-ed825980-2a5d-11eb-9d18-8a32fba98093.png)


Remaining work:
* Show similar Alert for Critical conditions raised during in-progress migration
* Adjust the distance between warning icon and Pipeline summary view as per Mockups