### PR TITLE
DVM Progress

### DIFF
--- a/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
+++ b/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Table, TableBody, TableHeader, cellWidth, sortable, IRow } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import MigrationActions from './MigrationActions';
@@ -12,10 +12,6 @@ import {
   Pagination,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { Popover, PopoverPosition } from '@patternfly/react-core';
-import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
-
-const styles = require('./MigrationsTable.module');
 
 import { IMigration } from '../../../../plan/duck/types';
 import { useSortState } from '../../../../common/duck/hooks';

--- a/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
+++ b/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Table, TableBody, TableHeader, cellWidth, sortable, IRow } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import MigrationActions from './MigrationActions';

--- a/src/app/home/pages/PlansPage/components/PipelineSummary/PipelineSummary.tsx
+++ b/src/app/home/pages/PlansPage/components/PipelineSummary/PipelineSummary.tsx
@@ -18,6 +18,7 @@ interface IDashProps {
 const dangerColor = '#c9190b';
 const disabledColor = '#d2d2d2';
 const successColor = '#3e8635';
+const infoColor = '#2B9AF3';
 
 const dashReachedStyles = classNames(styles.dash, styles.dashReached);
 const dashNotReachedStyles = classNames(styles.dash, styles.dashNotReached);
@@ -122,11 +123,16 @@ const PipelineSummary: React.FunctionComponent<IPipelineSummaryProps> = ({
               return (
                 <>
                   {index != 0 ? (
-                    <Dash key={step.name} isReached={step?.started ? true : false} />
+                    <Dash
+                      key={step.name}
+                      isReached={step?.started || step?.skipped ? true : false}
+                    />
                   ) : (
                     ''
                   )}
-                  {!step?.started ? (
+                  {step?.skipped ? (
+                    <Chain key={index} Face={ResourcesFullIcon} times={1} color={infoColor} />
+                  ) : !step?.started ? (
                     <Chain key={index} Face={ResourcesFullIcon} times={1} color={disabledColor} />
                   ) : step?.failed || step?.isError ? (
                     <Chain key={index} Face={ResourcesFullIcon} times={1} color={dangerColor} />

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -224,7 +224,7 @@ export const getMigrationStepProgress = (progressLine: string): IStepProgressInf
 
   // Determine if the progress line indicates success / failure
   const failedRegex = /.*?[Ff]ail/;
-  const completedRegex = /.*?([Cc]omplete|[Ss]uccess)/;
+  const completedRegex = /.*?([Cc]omplete|[Ss]ucc(ess|eed))/;
   const progressVariant = failedRegex.test(progressLine)
     ? ProgressVariant.danger
     : ProgressVariant.success;
@@ -291,6 +291,7 @@ export const getProgressValues = (step: IStep, migration?: IMigration): IProgres
       ? progress.metadata
       : progress.progressMessage;
     progressValues.consolidatedProgress.progressBarApplicable = progress.progressBarApplicable;
+    progressValues.consolidatedProgress.progressVariant = progress.progressVariant;
   } else {
     step.progress?.forEach((progressMessage) => {
       const parsedProgress = getMigrationStepProgress(progressMessage);

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -8,7 +8,7 @@ dayjs.extend(relativeTime);
 dayjs.extend(customParseFormat);
 
 import { IMigration, IPlan, IStep } from '../../../plan/duck/types';
-import { MigrationStepsType } from './types';
+import { MigrationStepsType, IProgressInfoObj, IStepProgressInfo } from './types';
 
 export const getPlanStatusText = (plan: IPlan) => {
   const {
@@ -137,24 +137,6 @@ const convertSItoBytes = (number: string, unit: string): number => {
 export const showConsolidatedProgressBar = (step: IStep): boolean => {
   return step.name == MigrationStepsType.Backup;
 };
-
-export interface IProgressInfoObj {
-  title: string;
-  detailsAvailable: boolean;
-  consolidatedProgress: IStepProgressInfo;
-  detailedProgress: IStepProgressInfo[];
-}
-
-export interface IStepProgressInfo {
-  progressBarApplicable: boolean;
-  progressPercentage: number;
-  progressMessage: string;
-  progressVariant: ProgressVariant;
-  isFailed: boolean;
-  isCompleted: boolean;
-  metadata: string;
-  duration: string;
-}
 
 // getMigrationStepProgress: parses each progress line and returns structured progress information
 // used for detailed drill down pages of migration steps

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -30,13 +30,7 @@ interface IMigrationDetailsPageProps {
 
 const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPageProps> = ({
   planList,
-  isFetchingInitialPlans,
 }: IMigrationDetailsPageProps) => {
-  const pollingContext = useContext(PollingContext);
-  useEffect(() => {
-    pollingContext.startAllDefaultPolling();
-  }, []);
-
   const { planName, migrationID } = useParams();
   const migration = planList
     .find((planItem: IPlan) => planItem.MigPlan.metadata.name === planName)
@@ -51,8 +45,10 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
           <BreadcrumbItem>
             <Link to="/plans">Plans</Link>
           </BreadcrumbItem>
-          <BreadcrumbItem to={`/plans/${planName}/migrations`}>{planName}</BreadcrumbItem>
-          {!isFetchingInitialPlans && migration && (
+          <BreadcrumbItem>
+            <Link to={`/plans/${planName}/migrations`}>{planName}</Link>
+          </BreadcrumbItem>
+          {migration && (
             <BreadcrumbItem to="#" isActive>
               {type} - {formatGolangTimestamp(migration.status.startTimestamp)}
             </BreadcrumbItem>
@@ -94,7 +90,7 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
           </Alert>
         </PageSection>
       )}
-      {!isFetchingInitialPlans && migration && migration.status?.pipeline ? (
+      {migration && migration.status?.pipeline ? (
         <PageSection>
           <Card>
             <CardBody>
@@ -122,5 +118,4 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
 
 export const MigrationDetailsPage = connect((state: IReduxState) => ({
   planList: planSelectors.getPlansWithStatus(state),
-  isFetchingInitialPlans: state.plan.isFetchingInitialPlans,
 }))(BaseMigrationDetailsPage);

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
@@ -4,7 +4,8 @@ import { Bullseye, EmptyState, Title, Progress, ProgressSize } from '@patternfly
 import { useParams, Link } from 'react-router-dom';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IMigration, IStep } from '../../../../../plan/duck/types';
-import { getElapsedTime, getProgressValues, IProgressInfoObj } from '../../helpers';
+import { getElapsedTime, getProgressValues } from '../../helpers';
+import { IProgressInfoObj } from '../../types';
 import MigrationStepStatusIcon from './MigrationStepStatusIcon';
 const styles = require('./MigrationDetailsTable.module');
 

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
@@ -8,7 +8,6 @@ import {
   getElapsedTime,
   getProgressValues,
   IProgressInfoObj,
-  showConsolidatedProgressBar,
 } from '../../helpers';
 import MigrationStepStatusIcon from './MigrationStepStatusIcon';
 const styles = require('./MigrationDetailsTable.module');
@@ -50,22 +49,19 @@ const MigrationDetailsTable: React.FunctionComponent<IProps> = ({ migration }) =
         },
         {
           title:
-            showConsolidatedProgressBar(step) &&
-            progressInfo.progressBarApplicable &&
-            step.started &&
-            step.progress?.length > 0 ? (
+            progressInfo.consolidatedProgress.progressBarApplicable &&
+            !progressInfo.detailsAvailable ? (
               <>
                 {
                   <Progress
-                    value={progressInfo.percentComplete}
-                    title={progressInfo.progressBarMessage}
+                    value={progressInfo.consolidatedProgress.progressPercentage}
+                    title={progressInfo.consolidatedProgress.progressMessage}
                     size={ProgressSize.sm}
-                    variant={progressInfo.variant}
-                    className={progressInfo.isWarning && styles.warnProgressStyle}
+                    variant={progressInfo.consolidatedProgress.progressVariant}
                   />
                 }
               </>
-            ) : step.progress?.length > 0 ? (
+            ) : progressInfo.detailsAvailable ? (
               <>
                 <Link to={`/plans/${planName}/migrations/${migration.metadata.name}/${step.name}`}>
                   View Details

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
@@ -4,11 +4,7 @@ import { Bullseye, EmptyState, Title, Progress, ProgressSize } from '@patternfly
 import { useParams, Link } from 'react-router-dom';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IMigration, IStep } from '../../../../../plan/duck/types';
-import {
-  getElapsedTime,
-  getProgressValues,
-  IProgressInfoObj,
-} from '../../helpers';
+import { getElapsedTime, getProgressValues, IProgressInfoObj } from '../../helpers';
 import MigrationStepStatusIcon from './MigrationStepStatusIcon';
 const styles = require('./MigrationDetailsTable.module');
 
@@ -24,7 +20,7 @@ const MigrationDetailsTable: React.FunctionComponent<IProps> = ({ migration }) =
     { title: 'Elapsed time', transforms: [cellWidth(20)] },
     {
       title: 'Status',
-      transforms: [cellWidth(50)],
+      transforms: [cellWidth(30)],
     },
     '',
   ];

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationStepStatusIcon.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationStepStatusIcon.tsx
@@ -28,6 +28,13 @@ const MigrationStepStatusIcon: React.FunctionComponent<IProps> = ({ migration, s
         <ResourcesAlmostFullIcon />
       </span>
     );
+  } else if (step.skipped) {
+    return (
+      <span className="pf-c-icon pf-m-info">
+        <ResourcesFullIcon />
+      </span>
+    )
+    
   } else if (step.failed) {
     return (
       <span className="pf-c-icon pf-m-danger">

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationStepStatusIcon.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationStepStatusIcon.tsx
@@ -33,8 +33,7 @@ const MigrationStepStatusIcon: React.FunctionComponent<IProps> = ({ migration, s
       <span className="pf-c-icon pf-m-info">
         <ResourcesFullIcon />
       </span>
-    )
-    
+    );
   } else if (step.failed) {
     return (
       <span className="pf-c-icon pf-m-danger">

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
@@ -14,7 +14,6 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
-import { PollingContext } from '../../../../duck/context';
 import { IReduxState } from '../../../../../../reducers';
 import { IStep, IMigration, IPlan } from '../../../../../plan/duck/types';
 import { PlanActions, planSelectors } from '../../../../../plan/duck';
@@ -23,18 +22,11 @@ import { getStepPageTitle, formatGolangTimestamp } from '../../helpers';
 
 interface IMigrationStepDetailsPageProps {
   planList: IPlan[];
-  isFetchingInitialPlans: boolean;
 }
 
 const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetailsPageProps> = ({
   planList,
-  isFetchingInitialPlans,
 }: IMigrationStepDetailsPageProps) => {
-  const pollingContext = useContext(PollingContext);
-  useEffect(() => {
-    pollingContext.startAllDefaultPolling();
-  }, []);
-
   const { planName, migrationID, stepName } = useParams();
 
   const migration = planList
@@ -52,13 +44,17 @@ const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetail
           <BreadcrumbItem>
             <Link to="/plans">Plans</Link>
           </BreadcrumbItem>
-          <BreadcrumbItem to={`/plans/${planName}/migrations`}>{planName}</BreadcrumbItem>
-          {!isFetchingInitialPlans && migration && (
-            <BreadcrumbItem to={`/plans/${planName}/migrations/${migration.metadata.name}`}>
-              {migrationType} - {formatGolangTimestamp(migration.status.startTimestamp)}
+          <BreadcrumbItem>
+            <Link to={`/plans/${planName}/migrations`}>{planName}</Link>
+          </BreadcrumbItem>
+          {migration && (
+            <BreadcrumbItem>
+              <Link to={`/plans/${planName}/migrations/${migration.metadata.name}`}>
+                {migrationType} - {formatGolangTimestamp(migration.status.startTimestamp)}
+              </Link>
             </BreadcrumbItem>
           )}
-          {!isFetchingInitialPlans && step && (
+          {step && (
             <BreadcrumbItem to="#" isActive>
               {step.name}
             </BreadcrumbItem>
@@ -70,8 +66,7 @@ const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetail
           </Title>
         )}
       </PageSection>
-
-      {!isFetchingInitialPlans && step && migration && (
+      {step && migration && (
         <PageSection>
           <Card>
             <CardBody>
@@ -84,7 +79,7 @@ const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetail
           </Card>
         </PageSection>
       )}
-      {isFetchingInitialPlans && (
+      {!migration && (
         <PageSection>
           <Bullseye>
             <EmptyState variant="large">
@@ -105,7 +100,6 @@ const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetail
 export const MigrationStepDetailsPage = connect(
   (state: IReduxState) => ({
     planList: planSelectors.getPlansWithStatus(state),
-    isFetchingInitialPlans: state.plan.isFetchingInitialPlans,
   }),
   (dispatch) => ({
     refreshAnalyticRequest: (analyticName: string) =>

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
@@ -64,9 +64,11 @@ const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetail
             </BreadcrumbItem>
           )}
         </Breadcrumb>
-        <Title headingLevel="h1" size="2xl">
-          {getStepPageTitle(step)}
-        </Title>
+        {step && (
+          <Title headingLevel="h1" size="2xl">
+            {getStepPageTitle(step)}
+          </Title>
+        )}
       </PageSection>
 
       {!isFetchingInitialPlans && step && migration && (

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsTable.tsx
@@ -13,7 +13,8 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IMigration, IStep } from '../../../../../plan/duck/types';
 import { usePaginationState } from '../../../../../common/duck/hooks/usePaginationState';
-import { getProgressValues, getElapsedTime, IStepProgressInfo } from '../../helpers';
+import { getProgressValues, getElapsedTime } from '../../helpers';
+import { IStepProgressInfo } from '../../types';
 
 interface IStepProps {
   step: IStep;

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsTable.tsx
@@ -45,7 +45,7 @@ const MigrationStepDetailsTable: React.FunctionComponent<IStepProps> = ({ step, 
       stepProgressInfo.duration === ''
         ? getElapsedTime(step, migration)
         : stepProgressInfo.duration;
-    if (progressInfoObj.detailsAvailable) {
+    if (stepProgressInfo.metadata && stepProgressInfo.progressMessage) {
       rows.push({
         cells: [
           {

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsTable.tsx
@@ -13,7 +13,7 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IMigration, IStep } from '../../../../../plan/duck/types';
 import { usePaginationState } from '../../../../../common/duck/hooks/usePaginationState';
-import { getMigrationStepProgress, getElapsedTime } from '../../helpers';
+import { getProgressValues, getElapsedTime, IStepProgressInfo } from '../../helpers';
 
 interface IStepProps {
   step: IStep;
@@ -30,21 +30,22 @@ const MigrationStepDetailsTable: React.FunctionComponent<IStepProps> = ({ step, 
     },
   ];
 
+  const progressInfoObj = getProgressValues(step, migration);
+
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(
-    step.progress,
+    progressInfoObj.detailedProgress,
     10
   );
 
   useEffect(() => setPageNumber(1), [setPageNumber]);
 
   const rows: IRow[] = [];
-  currentPageItems.forEach((progress) => {
-    const stepProgressInfo = getMigrationStepProgress(progress);
+  currentPageItems.forEach((stepProgressInfo: IStepProgressInfo) => {
     const duration =
       stepProgressInfo.duration === ''
         ? getElapsedTime(step, migration)
         : stepProgressInfo.duration;
-    if (stepProgressInfo.message !== '') {
+    if (progressInfoObj.detailsAvailable) {
       rows.push({
         cells: [
           {
@@ -54,13 +55,13 @@ const MigrationStepDetailsTable: React.FunctionComponent<IStepProps> = ({ step, 
           {
             title: stepProgressInfo.progressBarApplicable ? (
               <Progress
-                value={stepProgressInfo.percentComplete}
-                title={stepProgressInfo.message}
+                value={stepProgressInfo.progressPercentage}
+                title={stepProgressInfo.progressMessage}
                 size={ProgressSize.sm}
                 variant={stepProgressInfo.progressVariant}
               />
             ) : (
-              stepProgressInfo.message
+              stepProgressInfo.progressMessage
             ),
             transforms: [cellWidth(30)],
           },

--- a/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
@@ -40,29 +40,25 @@ const BaseMigrationsPage: React.FunctionComponent<IMigrationsPageProps> = ({
           Migrations
         </Title>
       </PageSection>
-      {
-        !plan ? null : (
-          <PageSection>
-            <Card>
-              <CardBody>
-                <MigrationsTable
-                  type="Migrations"
-                  planName={planName}
-                  migrations={plan.Migrations}
-                  isPlanLocked={plan.PlanStatus.isPlanLocked}
-                  id="migrations-history-expansion-table"
-                />
-              </CardBody>
-            </Card>
-          </PageSection>
-        )
-      }
+      {!plan ? null : (
+        <PageSection>
+          <Card>
+            <CardBody>
+              <MigrationsTable
+                type="Migrations"
+                planName={planName}
+                migrations={plan.Migrations}
+                isPlanLocked={plan.PlanStatus.isPlanLocked}
+                id="migrations-history-expansion-table"
+              />
+            </CardBody>
+          </Card>
+        </PageSection>
+      )}
     </>
   );
 };
 
-export const MigrationsPage = connect(
-  (state: IReduxState) => ({
-    planList: planSelectors.getPlansWithStatus(state),
-  })
-)(BaseMigrationsPage);
+export const MigrationsPage = connect((state: IReduxState) => ({
+  planList: planSelectors.getPlansWithStatus(state),
+}))(BaseMigrationsPage);

--- a/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import dayjs from 'dayjs';
 import {
   PageSection,
   Title,
@@ -13,8 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { IReduxState } from '../../../../../../reducers';
 import { IPlan } from '../../../../../plan/duck/types';
-import { PlanActions, planSelectors } from '../../../../../plan/duck';
-import { PollingContext } from '../../../../duck/context';
+import { planSelectors } from '../../../../../plan/duck';
 import MigrationsTable from '../../components/MigrationsTable';
 
 interface IMigrationsPageProps {
@@ -26,10 +24,6 @@ const BaseMigrationsPage: React.FunctionComponent<IMigrationsPageProps> = ({
 }: IMigrationsPageProps) => {
   const { planName } = useParams();
   const plan = planList.find((planItem: IPlan) => planItem.MigPlan.metadata.name === planName);
-
-  if (!plan) {
-    return null;
-  }
 
   return (
     <>
@@ -46,30 +40,29 @@ const BaseMigrationsPage: React.FunctionComponent<IMigrationsPageProps> = ({
           Migrations
         </Title>
       </PageSection>
-      <PageSection>
-        <Card>
-          <CardBody>
-            <MigrationsTable
-              type="Migrations"
-              planName={planName}
-              migrations={plan.Migrations}
-              isPlanLocked={plan.PlanStatus.isPlanLocked}
-              id="migrations-history-expansion-table"
-            />
-          </CardBody>
-        </Card>
-      </PageSection>
+      {
+        !plan ? null : (
+          <PageSection>
+            <Card>
+              <CardBody>
+                <MigrationsTable
+                  type="Migrations"
+                  planName={planName}
+                  migrations={plan.Migrations}
+                  isPlanLocked={plan.PlanStatus.isPlanLocked}
+                  id="migrations-history-expansion-table"
+                />
+              </CardBody>
+            </Card>
+          </PageSection>
+        )
+      }
     </>
   );
 };
 
 export const MigrationsPage = connect(
   (state: IReduxState) => ({
-    isRefreshingAnalytic: state.plan.isRefreshingAnalytic,
     planList: planSelectors.getPlansWithStatus(state),
-  }),
-  (dispatch) => ({
-    refreshAnalyticRequest: (analyticName: string) =>
-      dispatch(PlanActions.refreshAnalyticRequest(analyticName)),
   })
 )(BaseMigrationsPage);

--- a/src/app/home/pages/PlansPage/types.ts
+++ b/src/app/home/pages/PlansPage/types.ts
@@ -1,4 +1,5 @@
 import { IMigMigration } from '../../../../client/resources/conversions';
+import { ProgressVariant } from '@patternfly/react-core';
 
 export interface IMigrationWithStatus extends IMigMigration {
   tableStatus: {
@@ -33,4 +34,22 @@ export enum MigrationStepsType {
   Error = 'Error',
   Completed = 'Completed',
   CompletedWithWarnings = 'Completed with warnings',
+}
+
+export interface IProgressInfoObj {
+  title: string;
+  detailsAvailable: boolean;
+  consolidatedProgress: IStepProgressInfo;
+  detailedProgress: IStepProgressInfo[];
+}
+
+export interface IStepProgressInfo {
+  progressBarApplicable: boolean;
+  progressPercentage: number;
+  progressMessage: string;
+  progressVariant: ProgressVariant;
+  isFailed: boolean;
+  isCompleted: boolean;
+  metadata: string;
+  duration: string;
 }

--- a/src/app/plan/duck/types.ts
+++ b/src/app/plan/duck/types.ts
@@ -112,6 +112,7 @@ export interface IStep {
   started?: string;
   completed: string;
   failed?: boolean;
+  skipped?: boolean;
   progress?: string[];
   isError?: boolean;
   isWarning?: boolean;


### PR DESCRIPTION
Closes #1070 

This PR : 
* Adds logic to parse DVM progress messages
![Screenshot from 2020-11-24 12-39-07](https://user-images.githubusercontent.com/9839757/100131498-1afe4700-2e52-11eb-9e26-d4f241c37505.png)

* Adds support for marking Migration steps 'skipped'
![Screenshot from 2020-11-23 16-26-31](https://user-images.githubusercontent.com/9839757/100017340-bf2bb380-2da8-11eb-8a4c-0de9c654eb2d.png)

![Screenshot from 2020-11-24 12-46-28](https://user-images.githubusercontent.com/9839757/100132237-1ede9900-2e53-11eb-984d-80afdc0014bc.png)

* Fixes helper logic to discard un-parseable progress messages for sanity
* De-duplicates logic for progress message parsing
* Fixes breadcrumbs not to reload the app
 