### PR TITLE
Update storage form to show proper type when editing for azure/gcp

### DIFF
--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -83,6 +83,10 @@ const AddEditStorageForm = (props: IOtherProps) => {
       if (awsS3Annotation === 'true' || (awsS3Annotation !== 'false' && !s3Url)) {
         provider = 'aws-s3';
       }
+    } else if (storage.MigStorage.spec.backupStorageProvider === 'azure') {
+      provider = 'azure';
+    } else if (storage.MigStorage.spec.backupStorageProvider === 'gcp') {
+      provider = 'gcp';
     }
   }
 


### PR DESCRIPTION
Fixes [BZ 1882061](https://bugzilla.redhat.com/show_bug.cgi?id=1882061)

- When editing, we werent setting the provider type for the storage before rendering the storage form. This PR fixes this for GCP/Azure provider types.