### PR TITLE
[BZ# 1909093] Fix progress bar regex to match messages provided by controller only

### DIFF
--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -209,11 +209,11 @@ export const getMigrationStepProgress = (progressLine: string): IStepProgressInf
   // Determine if the progress line indicates success / failure
   const failedRegex = /.*?[Ff]ail/;
   const completedRegex = /.*?([Cc]omplete|[Ss]ucc(ess|eed))/;
-  const progressVariant = failedRegex.test(progressLine)
+  const progressVariant = failedRegex.test(message)
     ? ProgressVariant.danger
     : ProgressVariant.success;
-  const isFailed = failedRegex.test(progressLine) ? true : false;
-  const isCompleted = completedRegex.test(progressLine) ? true : isFailed ? true : false;
+  const isFailed = failedRegex.test(message) ? true : false;
+  const isCompleted = completedRegex.test(message) ? true : isFailed ? true : false;
 
   return {
     metadata: metadata,


### PR DESCRIPTION
BZ# 1909093

This PR fixes an issue when an entire progress line contains keywords that match regex determining the color of the progress bar. 

Before:

![Screenshot from 2020-12-17 14-27-56](https://user-images.githubusercontent.com/9839757/102534001-20773780-4074-11eb-93a2-0f3efbe79874.png)

After:

![Screenshot from 2020-12-17 14-28-03](https://user-images.githubusercontent.com/9839757/102534013-253beb80-4074-11eb-9c3a-14b354a2c8dd.png)

