### PR TITLE
Bug 1915702: Add check for empty step name when cancelling rollback

### DIFF
--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -371,7 +371,7 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
         });
 
         if (runningCondition || cancelingCondition) {
-          status.stepName = runningCondition.reason;
+          status.stepName = runningCondition?.reason || '';
           if (cancelingCondition) {
             status.stepName = 'Canceling' + status.stepName;
             status.isCanceling = true;


### PR DESCRIPTION

This fixed a bug causing a UI crash when a rollback was cancelled. There is a temporary controller state causing the reason field to be blank in status.  