### PR TITLE
Bug fix - Fix small regression with warning condition being hidden on migmigration

### DIFF
--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -395,7 +395,6 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
       return status;
     }
 
-
     return status;
   };
   const plansWithMigrationStatus = plans.map((plan) => {

--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -378,12 +378,6 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
       return status;
     }
 
-    if (succeededCondition) {
-      status.isSucceeded = true;
-      status.migrationState = 'success';
-      return status;
-    }
-
     if (warnCondition) {
       const warningMessages = migration?.status?.conditions
         ?.filter((c) => c.category === 'Warn')
@@ -394,6 +388,13 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
       status.warnCondition = warnCondition?.message;
       return status;
     }
+
+    if (succeededCondition) {
+      status.isSucceeded = true;
+      status.migrationState = 'success';
+      return status;
+    }
+
 
     return status;
   };


### PR DESCRIPTION
This PR moves the check for warnings above the check for succeeded migrations to avoid swallowing the check for warnings on a migmigration. Currently if a migmigration has a warning, it is not displayed in the UI if there is a succeeded condition present. 

Fixes regression introduced with https://github.com/konveyor/mig-ui/commit/1ca0bd30e602ad3147fddb63901866c2348e24fa