### PR TITLE
Bug 1921898: Add a warn condition for generic warnings on a plan

### DIFF
--- a/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
+++ b/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
@@ -120,7 +120,7 @@ const MigrationsTable: React.FunctionComponent<IProps> = ({
             </LevelItem>
           </Level>
           <Table
-            aria-label="migration-analytics-table"
+            aria-label="migrations-table"
             cells={columns}
             rows={rows}
             onSort={onSort}

--- a/src/app/home/pages/PlansPage/components/PlanStatusIcon.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanStatusIcon.tsx
@@ -10,6 +10,8 @@ import { Popover, PopoverPosition } from '@patternfly/react-core';
 
 import { Spinner } from '@patternfly/react-core';
 import { IPlan } from '../../../../plan/duck/types';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 interface IProps {
   plan: IPlan;
@@ -25,6 +27,7 @@ const PlanStatusIcon: React.FunctionComponent<IProps> = ({ plan }) => {
     hasConflictCondition,
     latestIsFailed,
     hasCriticalCondition,
+    hasWarnCondition,
   } = plan.PlanStatus;
 
   if (latestIsFailed || hasCriticalCondition) {
@@ -42,19 +45,28 @@ const PlanStatusIcon: React.FunctionComponent<IProps> = ({ plan }) => {
         closeBtnAriaLabel="close-warning-details"
         maxWidth="200rem"
       >
-        <span className="pf-c-icon pf-m-warning">
-          <WarningTriangleIcon />
+        <span className={`pf-c-icon pf-m-warning`}>
+          <ExclamationTriangleIcon />
         </span>
       </Popover>
     );
   } else if (hasNotReadyCondition) {
     return (
-      <span className="pf-c-icon pf-m-warning">
-        <WarningTriangleIcon />
+      <span className={`pf-c-icon pf-m-warning`}>
+        <ExclamationTriangleIcon />
       </span>
     );
   } else if (hasRunningMigrations || isPlanLocked) {
     return <Spinner size="md" />;
+  } else if (
+    (hasSucceededMigration && hasWarnCondition) ||
+    (hasSucceededStage && hasWarnCondition)
+  ) {
+    return (
+      <span className={`pf-c-icon pf-m-warning`}>
+        <ExclamationTriangleIcon />
+      </span>
+    );
   } else if (hasSucceededMigration) {
     return (
       <span className="pf-c-icon pf-m-success">

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -27,6 +27,7 @@ export const getPlanStatusText = (plan: IPlan) => {
     hasConflictCondition,
     conflictErrorMsg,
     isPlanLocked,
+    hasWarnCondition,
   } = plan.PlanStatus;
   if (latestIsFailed) return `${latestType} Failed`;
   if (hasCriticalCondition) return `${latestType} Failed`;
@@ -37,6 +38,7 @@ export const getPlanStatusText = (plan: IPlan) => {
   if (hasRunningMigrations) return `${latestType} Running`;
   if (hasCanceledCondition) return `${latestType} canceled`;
   if (hasSucceededRollback) return 'Rollback succeeded';
+  if (hasSucceededMigration && hasWarnCondition) return 'Migration completed with warnings';
   if (hasSucceededMigration) return 'Migration succeeded';
   if (hasSucceededStage) return 'Stage succeeded';
   if (hasReadyCondition) return 'Ready';

--- a/src/app/plan/duck/helpers.ts
+++ b/src/app/plan/duck/helpers.ts
@@ -14,6 +14,7 @@ interface ILatestMigrationConditionStatuses {
   hasCancelingCondition: boolean;
   hasCanceledCondition: boolean;
   hasCriticalCondition: boolean;
+  hasWarnCondition: boolean;
 }
 interface ILatestAnalyticConditionStatuses {
   latestAnalyticTransitionTime: string;
@@ -36,6 +37,7 @@ export const filterLatestMigrationConditions = (
   hasCriticalCondition: conditions.some((c) => c.category === 'Critical'),
   hasCancelingCondition: conditions.some((c) => c.type === 'Canceling'),
   hasCanceledCondition: conditions.some((c) => c.type === 'Canceled'),
+  hasWarnCondition: conditions.some((c) => c.category === 'Warn'),
 });
 
 export const filterLatestAnalyticConditions = (

--- a/src/app/plan/duck/types.ts
+++ b/src/app/plan/duck/types.ts
@@ -155,6 +155,7 @@ export interface IPlan {
     hasSucceededMigration: boolean;
     hasSucceededStage: boolean;
     hasSucceededRollback: boolean;
+    hasWarnCondition: boolean;
     isPlanLocked: boolean;
     latestType: string;
     latestIsFailed: boolean;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11218376/106150176-0dfb1e00-6149-11eb-86e3-00c5ef524db3.png)

This PR adds a plan status text & icon in the plans table for plans with migrations that have a succeeded & warning condition on them. Eventually we would like to move to this model https://github.com/konveyor/lib-ui/issues/47 to provide more transparency on plan status.

Closes #1109 