### PR TITLE
Bug 1920452: Do not show loading screen when pipeline is not available

### DIFF
--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -35,7 +35,7 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
   const migration = planList
     .find((planItem: IPlan) => planItem.MigPlan.metadata.name === planName)
     ?.Migrations.find((migration: IMigration) => migration.metadata.name === migrationID);
-  const isPausedCondition = migration.tableStatus.migrationState === 'paused';
+  const isPausedCondition = migration?.tableStatus.migrationState === 'paused';
   const isWarningCondition = migration?.tableStatus.migrationState === 'warn';
   const isErrorCondition = migration?.tableStatus.migrationState === 'error';
   const type = migration?.spec?.stage ? 'Stage' : 'Final';
@@ -51,7 +51,7 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
           </BreadcrumbItem>
           {migration && (
             <BreadcrumbItem to="#" isActive>
-              {type} - {formatGolangTimestamp(migration.status.startTimestamp)}
+              {type} - {formatGolangTimestamp(migration.status?.startTimestamp)}
             </BreadcrumbItem>
           )}
         </Breadcrumb>
@@ -110,6 +110,17 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
           <Card>
             <CardBody>
               <MigrationDetailsTable migration={migration} id="migration-details-table" />
+            </CardBody>
+          </Card>
+        </PageSection>
+      ) : migration?.tableStatus?.isCanceled ||
+        migration?.tableStatus?.isFailed ||
+        migration?.tableStatus?.isSucceeded ||
+        migration?.tableStatus?.isSuccededWithWarnings ? (
+        <PageSection>
+          <Card>
+            <CardBody>
+              This migration is completed but progress information is not available.
             </CardBody>
           </Card>
         </PageSection>

--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -307,6 +307,7 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
       isPaused: false,
       isFailed: false,
       isSucceeded: false,
+      isSuccededWithWarnings: true,
       isCanceled: false,
       isCanceling: false,
       migrationState: null,
@@ -358,6 +359,10 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
     // check if migration is already failed
     const failedCondition = migration.status?.conditions?.find((c) => {
       return c.type === 'Failed';
+    });
+    // check if migration is already failed
+    const succededWithWarnings = migration.status?.conditions?.find((c) => {
+      return c.type === 'SucceededWithWarnings';
     });
 
     const dvmBlockedCondition = migration.status?.conditions?.find((c) => {
@@ -436,6 +441,12 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
       status.migrationState = 'warn';
       status.warnings = status.warnings.concat(warningMessages);
       status.warnCondition = warnCondition?.message;
+      return status;
+    }
+
+    if (succededWithWarnings) {
+      status.isSuccededWithWarnings = true;
+      status.migrationState = 'success';
       return status;
     }
 

--- a/src/app/plan/duck/types.ts
+++ b/src/app/plan/duck/types.ts
@@ -81,6 +81,7 @@ export interface IMigration {
     end: string;
     isFailed: boolean;
     isSucceeded: boolean;
+    isSuccededWithWarnings: boolean;
     isCanceled: boolean;
     isCanceling: boolean;
     isPaused: boolean;


### PR DESCRIPTION
This PR updates migration details page to check whether pipeline field is available on a MigMigration. If it's not found but MigMigration is complete, it is likely that the MigMigration was created before MTC 1.4.0, when pipeline was not available on MigMigration status.