### PR TITLE
Global hooks bug fix - Exposes src/target selection in add/edit global hook form 

### DIFF
--- a/src/app/common/duck/utils.ts
+++ b/src/app/common/duck/utils.ts
@@ -30,6 +30,7 @@ export const isSelfSignedCertError = (err) => {
 };
 
 export const isTimeoutError = (err) => {
+  //TODO: We should do some type checking here. Have seen the toJSON() conversion fail. Maybe use stringify.
   const e = err.toJSON();
   return e.code && e.code === 206;
 };

--- a/src/app/home/pages/PlansPage/components/Wizard/HooksFormComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/HooksFormComponent.tsx
@@ -379,175 +379,189 @@ const HooksFormComponent: React.FunctionComponent<
             </Grid>
           </FormGroup>
         </GridItem>
+        <GridItem className={spacing.mtMd}>
+          <FormGroup label="Run in" fieldId="run-in-group">
+            <Grid>
+              <GridItem className={spacing.mtSm}>
+                <Radio
+                  isChecked={values.clusterType === HooksClusterType.Source}
+                  name={clusterTypeKey}
+                  onChange={formikHandleChange}
+                  label="Source cluster"
+                  id="source-cluster-radio"
+                  value={HooksClusterType.Source}
+                  isDisabled={
+                    selectedExistingHook ||
+                    (hookAddEditStatus.mode === AddEditMode.Edit && currentPlan)
+                  }
+                />
+              </GridItem>
+              <GridItem className={spacing.mtSm}>
+                <Radio
+                  isChecked={values.clusterType === HooksClusterType.Destination}
+                  name={clusterTypeKey}
+                  onChange={formikHandleChange}
+                  label="Target cluster"
+                  id="target-cluster-radio"
+                  value={HooksClusterType.Destination}
+                  isDisabled={
+                    selectedExistingHook ||
+                    (hookAddEditStatus.mode === AddEditMode.Edit && currentPlan)
+                  }
+                />
+              </GridItem>
+            </Grid>
+          </FormGroup>
+        </GridItem>
+
         {currentPlan && (
           <>
-            <GridItem className={spacing.mtMd}>
-              <FormGroup label="Run in" fieldId="run-in-group">
-                <Grid>
-                  <GridItem className={spacing.mtSm}>
-                    <Radio
-                      isChecked={values.clusterType === HooksClusterType.Source}
-                      name={clusterTypeKey}
-                      onChange={formikHandleChange}
-                      label="Source cluster"
-                      id="source-cluster-radio"
-                      value={HooksClusterType.Source}
-                    />
-                  </GridItem>
-                  {values.clusterType === HooksClusterType.Source && (
-                    <React.Fragment>
-                      <GridItem className={spacing.mtSm}>
-                        <FormGroup
-                          label="Service account name"
-                          isRequired
-                          fieldId={srcServiceAccountNameKey}
-                          helperTextInvalid={
-                            touched.srcServiceAccountName && errors.srcServiceAccountName
-                          }
-                          validated={validatedState(
-                            touched.srcServiceAccountName,
-                            errors.srcServiceAccountName
-                          )}
-                        >
-                          <Tooltip
-                            position={TooltipPosition.right}
-                            content={
-                              <div>Service account name used to run the executable hook.</div>
-                            }
-                          >
-                            <span className={spacing.mlSm}>
-                              <QuestionCircleIcon />
-                            </span>
-                          </Tooltip>
+            {values.clusterType === HooksClusterType.Source && (
+              <React.Fragment>
+                <GridItem className={spacing.mtSm}>
+                  <FormGroup
+                    label="Service account name"
+                    isRequired
+                    fieldId={srcServiceAccountNameKey}
+                    helperTextInvalid={
+                      touched.srcServiceAccountName && errors.srcServiceAccountName
+                    }
+                    validated={validatedState(
+                      touched.srcServiceAccountName,
+                      errors.srcServiceAccountName
+                    )}
+                  >
+                    <Tooltip
+                      position={TooltipPosition.right}
+                      content={<div>Service account name used to run the executable hook.</div>}
+                    >
+                      <span className={spacing.mlSm}>
+                        <QuestionCircleIcon />
+                      </span>
+                    </Tooltip>
 
-                          {/*
+                    {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
-                          <TextInput
-                            onChange={formikHandleChange}
-                            onInput={formikSetFieldTouched(srcServiceAccountNameKey)}
-                            onBlur={handleBlur}
-                            value={values.srcServiceAccountName}
-                            name={srcServiceAccountNameKey}
-                            type="text"
-                            id="src-service-account-name-input"
-                            validated={validatedState(
-                              touched.srcServiceAccountName,
-                              errors.srcServiceAccountName
-                            )}
-                          />
-                        </FormGroup>
-                      </GridItem>
-                      <GridItem className={spacing.mtSm}>
-                        <FormGroup
-                          label="Service account namespace"
-                          isRequired
-                          fieldId={srcServiceAccountNamespaceKey}
-                          helperTextInvalid={
-                            touched.srcServiceAccountNamespace && errors.srcServiceAccountNamespace
-                          }
-                          validated={validatedState(
-                            touched.srcServiceAccountNamespace,
-                            errors.srcServiceAccountNamespace
-                          )}
-                        >
-                          {/*
-          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
-                          <TextInput
-                            onChange={formikHandleChange}
-                            onInput={formikSetFieldTouched(srcServiceAccountNamespaceKey)}
-                            onBlur={handleBlur}
-                            value={values.srcServiceAccountNamespace}
-                            name={srcServiceAccountNamespaceKey}
-                            type="text"
-                            id="src-service-account-namespace-input"
-                            validated={validatedState(
-                              touched.srcServiceAccountNamespace,
-                              errors.srcServiceAccountNamespace
-                            )}
-                          />
-                        </FormGroup>
-                      </GridItem>
-                    </React.Fragment>
-                  )}
-                  <GridItem className={spacing.mtSm}>
-                    <Radio
-                      isChecked={values.clusterType === HooksClusterType.Destination}
-                      name={clusterTypeKey}
+                    <TextInput
                       onChange={formikHandleChange}
-                      label="Target cluster"
-                      id="target-cluster-radio"
-                      value={HooksClusterType.Destination}
+                      onInput={formikSetFieldTouched(srcServiceAccountNameKey)}
+                      onBlur={handleBlur}
+                      value={values.srcServiceAccountName}
+                      name={srcServiceAccountNameKey}
+                      type="text"
+                      id="src-service-account-name-input"
+                      validated={validatedState(
+                        touched.srcServiceAccountName,
+                        errors.srcServiceAccountName
+                      )}
                     />
-                  </GridItem>
-                  {values.clusterType === HooksClusterType.Destination && (
-                    <React.Fragment>
-                      <GridItem className={spacing.mtSm}>
-                        <FormGroup
-                          label="Service account name"
-                          isRequired
-                          fieldId={destServiceAccountNameKey}
-                          helperTextInvalid={
-                            touched.destServiceAccountName && errors.destServiceAccountName
-                          }
-                          validated={validatedState(
-                            touched.destServiceAccountName,
-                            errors.destServiceAccountName
-                          )}
-                        >
-                          {/*
+                  </FormGroup>
+                </GridItem>
+                <GridItem className={spacing.mtSm}>
+                  <FormGroup
+                    label="Service account namespace"
+                    isRequired
+                    fieldId={srcServiceAccountNamespaceKey}
+                    helperTextInvalid={
+                      touched.srcServiceAccountNamespace && errors.srcServiceAccountNamespace
+                    }
+                    validated={validatedState(
+                      touched.srcServiceAccountNamespace,
+                      errors.srcServiceAccountNamespace
+                    )}
+                  >
+                    {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
-                          <TextInput
-                            onChange={formikHandleChange}
-                            onInput={formikSetFieldTouched(destServiceAccountNameKey)}
-                            onBlur={handleBlur}
-                            value={values.destServiceAccountName}
-                            name={destServiceAccountNameKey}
-                            type="text"
-                            id="dest-service-account-name-input"
-                            validated={validatedState(
-                              touched.destServiceAccountName,
-                              errors.destServiceAccountName
-                            )}
-                          />
-                        </FormGroup>
-                      </GridItem>
-                      <GridItem className={spacing.mtSm}>
-                        <FormGroup
-                          label="Service account namespace"
-                          isRequired
-                          fieldId="destServiceAccountNamespace"
-                          helperTextInvalid={
-                            touched.destServiceAccountNamespace &&
-                            errors.destServiceAccountNamespace
-                          }
-                          validated={validatedState(
-                            touched.destServiceAccountNamespace,
-                            errors.destServiceAccountNamespace
-                          )}
-                        >
-                          {/*
+                    <TextInput
+                      onChange={formikHandleChange}
+                      onInput={formikSetFieldTouched(srcServiceAccountNamespaceKey)}
+                      onBlur={handleBlur}
+                      value={values.srcServiceAccountNamespace}
+                      name={srcServiceAccountNamespaceKey}
+                      type="text"
+                      id="src-service-account-namespace-input"
+                      validated={validatedState(
+                        touched.srcServiceAccountNamespace,
+                        errors.srcServiceAccountNamespace
+                      )}
+                    />
+                  </FormGroup>
+                </GridItem>
+              </React.Fragment>
+            )}
+            {values.clusterType === HooksClusterType.Destination && (
+              <React.Fragment>
+                <GridItem className={spacing.mtSm}>
+                  <FormGroup
+                    label="Service account name"
+                    isRequired
+                    fieldId={destServiceAccountNameKey}
+                    helperTextInvalid={
+                      touched.destServiceAccountName && errors.destServiceAccountName
+                    }
+                    validated={validatedState(
+                      touched.destServiceAccountName,
+                      errors.destServiceAccountName
+                    )}
+                  >
+                    <Tooltip
+                      position={TooltipPosition.right}
+                      content={<div>Service account name used to run the executable hook.</div>}
+                    >
+                      <span className={spacing.mlSm}>
+                        <QuestionCircleIcon />
+                      </span>
+                    </Tooltip>
+
+                    {/*
           // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
-                          <TextInput
-                            onChange={formikHandleChange}
-                            onInput={formikSetFieldTouched(destServiceAccountNamespaceKey)}
-                            onBlur={handleBlur}
-                            value={values.destServiceAccountNamespace}
-                            name={destServiceAccountNamespaceKey}
-                            type="text"
-                            id="dest-service-account-namespace-input"
-                            validated={validatedState(
-                              touched.destServiceAccountNamespace,
-                              errors.destServiceAccountNamespace
-                            )}
-                          />
-                        </FormGroup>
-                      </GridItem>
-                    </React.Fragment>
-                  )}
-                </Grid>
-              </FormGroup>
-            </GridItem>
-            )
+                    <TextInput
+                      onChange={formikHandleChange}
+                      onInput={formikSetFieldTouched(destServiceAccountNameKey)}
+                      onBlur={handleBlur}
+                      value={values.destServiceAccountName}
+                      name={destServiceAccountNameKey}
+                      type="text"
+                      id="dest-service-account-name-input"
+                      validated={validatedState(
+                        touched.destServiceAccountName,
+                        errors.destServiceAccountName
+                      )}
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem className={spacing.mtSm}>
+                  <FormGroup
+                    label="Service account namespace"
+                    isRequired
+                    fieldId="destServiceAccountNamespace"
+                    helperTextInvalid={
+                      touched.destServiceAccountNamespace && errors.destServiceAccountNamespace
+                    }
+                    validated={validatedState(
+                      touched.destServiceAccountNamespace,
+                      errors.destServiceAccountNamespace
+                    )}
+                  >
+                    {/*
+          // @ts-ignore issue: https://github.com/konveyor/mig-ui/issues/747 */}
+                    <TextInput
+                      onChange={formikHandleChange}
+                      onInput={formikSetFieldTouched(destServiceAccountNamespaceKey)}
+                      onBlur={handleBlur}
+                      value={values.destServiceAccountNamespace}
+                      name={destServiceAccountNamespaceKey}
+                      type="text"
+                      id="dest-service-account-namespace-input"
+                      validated={validatedState(
+                        touched.destServiceAccountNamespace,
+                        errors.destServiceAccountNamespace
+                      )}
+                    />
+                  </FormGroup>
+                </GridItem>
+              </React.Fragment>
+            )}
             <GridItem className={spacing.mtMd}>
               <FormGroup
                 label="Migration step when the hook should be run"

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -146,7 +146,7 @@ const WizardComponent = (props: IOtherProps) => {
           />
         </WizardStepContainer>
       ),
-      enableNext: !errors.selectedNamespaces,
+      enableNext: !errors.selectedNamespaces && !isFetchingNamespaceList,
       canJumpTo: stepIdReached >= stepId.Namespaces,
     },
     {

--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -188,8 +188,13 @@ function* namespaceFetchRequest(action) {
   const namespaces: DiscoveryResource = new NamespaceDiscovery(action.clusterName);
   try {
     const res = yield discoveryClient.get(namespaces);
-    const namespaceResourceList = res.data.resources;
-    yield put(PlanActions.namespaceFetchSuccess(namespaceResourceList));
+    const namespaceResourceList = res?.data?.resources;
+    if (namespaceResourceList) {
+      yield put(PlanActions.namespaceFetchSuccess(namespaceResourceList));
+    } else {
+      const error = { type: 'new error', error: 'Unknown error.' };
+      throw error;
+    }
   } catch (err) {
     if (utils.isTimeoutError(err)) {
       yield put(AlertActions.alertErrorTimeout('Timed out while fetching namespaces'));


### PR DESCRIPTION
Closes https://github.com/konveyor/mig-ui/issues/1121 

![image](https://user-images.githubusercontent.com/11218376/109660999-82a1ed80-7b37-11eb-8d72-ecab888a59d6.png)

Disabled src/target selection for adding an existing hook to a plan or editing an existing hook inside a plan. 


![image](https://user-images.githubusercontent.com/11218376/109661777-563aa100-7b38-11eb-9d46-437b1061a24b.png)

SA name & namespace fields conditionally render based on src/destination selection. 
![image](https://user-images.githubusercontent.com/11218376/109661870-6eaabb80-7b38-11eb-8af3-c2a13144cec0.png)
