### PR TITLE
Add polling context and paused effect

### DIFF
--- a/deploy/main.js
+++ b/deploy/main.js
@@ -33,18 +33,22 @@ app.get('/login', async (req, res, next) => {
   try {
     const clusterAuth = await getClusterAuth(migMeta);
     const authorizationUri = clusterAuth.authorizeURL({
-      redirect_uri: migMeta.oauth.redirectUrl,
-      // redirect_uri: migMeta.oauth.redirectUri,
+      // redirect_uri: migMeta.oauth.redirectUrl,
+      redirect_uri: migMeta.oauth.redirectUri,
       scope: migMeta.oauth.userScope,
     });
 
     res.redirect(authorizationUri);
   } catch (error) {
     console.error(error);
-    const params = new URLSearchParams({ error: JSON.stringify(error) });
-    const uri = `/handle-login?${params.toString()}`;
-    res.redirect(uri);
-    next(error);
+    if (error.response.statusText === 'Service Unavailable' || error.response.status === 503) {
+      res.status(503).send(error.response.data);
+    } else {
+      const params = new URLSearchParams({ error: JSON.stringify(error) });
+      const uri = `/handle-login?${params.toString()}`;
+      res.redirect(uri);
+      next(error);
+    }
   }
 });
 app.get('/login/callback', async (req, res, next) => {

--- a/deploy/main.js
+++ b/deploy/main.js
@@ -33,22 +33,18 @@ app.get('/login', async (req, res, next) => {
   try {
     const clusterAuth = await getClusterAuth(migMeta);
     const authorizationUri = clusterAuth.authorizeURL({
-      // redirect_uri: migMeta.oauth.redirectUrl,
-      redirect_uri: migMeta.oauth.redirectUri,
+      redirect_uri: migMeta.oauth.redirectUrl,
+      // redirect_uri: migMeta.oauth.redirectUri,
       scope: migMeta.oauth.userScope,
     });
 
     res.redirect(authorizationUri);
   } catch (error) {
     console.error(error);
-    if (error.response.statusText === 'Service Unavailable' || error.response.status === 503) {
-      res.status(503).send(error.response.data);
-    } else {
-      const params = new URLSearchParams({ error: JSON.stringify(error) });
-      const uri = `/handle-login?${params.toString()}`;
-      res.redirect(uri);
-      next(error);
-    }
+    const params = new URLSearchParams({ error: JSON.stringify(error) });
+    const uri = `/handle-login?${params.toString()}`;
+    res.redirect(uri);
+    next(error);
   }
 });
 app.get('/login/callback', async (req, res, next) => {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-json-view": "^1.19.1",
-    "react-redux": "^6.0.1",
+    "react-redux": "^7.2.2",
     "react-router-dom": "^5.1.2",
     "react-select": "^2.4.2",
     "react-table": "^6.10.0",

--- a/src/app/AppComponent.tsx
+++ b/src/app/AppComponent.tsx
@@ -8,12 +8,6 @@ import { history } from '../helpers';
 import { ConnectedRouter } from 'connected-react-router';
 import CertErrorComponent from './auth/CertErrorComponent';
 import OAuthLandingPage from './token/OAuthLandingPage';
-import { PollingContext } from './home/duck';
-import { StatusPollingInterval } from './common/duck/sagas';
-import { clusterSagas } from './cluster/duck';
-import { storageSagas } from './storage/duck';
-import { planSagas } from './plan/duck';
-import { tokenSagas } from './token/duck';
 import { ClusterActions } from './cluster/duck/actions';
 import { StorageActions } from './storage/duck/actions';
 import { PlanActions } from './plan/duck/actions';
@@ -21,11 +15,10 @@ import { TokenActions } from './token/duck/actions';
 import AlertModal from './common/components/AlertModal';
 import ErrorModal from './common/components/ErrorModal';
 import { ICluster } from './cluster/duck/types';
-import { NON_ADMIN_ENABLED } from '../TEMPORARY_GLOBAL_FLAGS';
 import { IDebugTreeNode, RAW_OBJECT_VIEW_ROUTE } from './debug/duck/types';
 import RawDebugObjectView from './debug/components/RawDebugObjectView';
 import AuthErrorComponent from './auth/AuthErrorComponent';
-
+import { PollingContextProvider } from './common/context/PollingContext';
 interface IProps {
   isLoggedIn?: boolean;
   warnMessage: any;
@@ -33,21 +26,6 @@ interface IProps {
   errorModalObject: any;
   successMessage: any;
   progressMessage: any;
-  startPlanPolling: (params) => void;
-  stopPlanPolling: () => void;
-  startStoragePolling: (params) => void;
-  stopStoragePolling: () => void;
-  startClusterPolling: (params) => void;
-  stopClusterPolling: () => void;
-  startTokenPolling: (params) => void;
-  stopTokenPolling: () => void;
-  startHookPolling: (params) => void;
-  stopHookPolling: () => void;
-  updateClusters: (updatedClusters) => void;
-  updateStorages: (updatedStorages) => void;
-  updatePlans: (updatedPlans) => void;
-  updateTokens: (updatedTokens) => void;
-  updateHooks: (updatedHooks) => void;
   clusterList: ICluster[];
   debugTree: IDebugTreeNode;
 }
@@ -59,167 +37,17 @@ const AppComponent: React.SFC<IProps> = ({
   progressMessage,
   warnMessage,
   isLoggedIn,
-  startPlanPolling,
-  stopPlanPolling,
-  startStoragePolling,
-  stopStoragePolling,
-  startClusterPolling,
-  stopClusterPolling,
-  startTokenPolling,
-  stopTokenPolling,
-  startHookPolling,
-  stopHookPolling,
-  updateClusters,
-  updateStorages,
-  updatePlans,
-  updateTokens,
-  updateHooks,
   clusterList,
   debugTree,
 }) => {
-  const handlePlanPoll = (response) => {
-    if (response) {
-      updatePlans(response.updatedPlans);
-      return true;
-    }
-    return false;
-  };
-
-  const handleClusterPoll = (response) => {
-    if (response) {
-      updateClusters(response.updatedClusters);
-      return true;
-    }
-    return false;
-  };
-
-  const handleStoragePoll = (response) => {
-    if (response) {
-      updateStorages(response.updatedStorages);
-      return true;
-    }
-    return false;
-  };
-
-  const handleTokenPoll = (response) => {
-    if (response) {
-      updateTokens(response.updatedTokens);
-      return true;
-    }
-    return false;
-  };
-
-  const handleHookPoll = (response) => {
-    if (response) {
-      updateHooks(response.updatedHooks);
-      return true;
-    }
-    return false;
-  };
-
-  const startDefaultPlanPolling = () => {
-    const planPollParams = {
-      asyncFetch: planSagas.fetchPlansGenerator,
-      callback: handlePlanPoll,
-      delay: StatusPollingInterval,
-      retryOnFailure: true,
-      retryAfter: 5,
-      stopAfterRetries: 2,
-      pollName: 'plan',
-    };
-    startPlanPolling(planPollParams);
-  };
-
-  const startDefaultClusterPolling = () => {
-    const clusterPollParams = {
-      asyncFetch: clusterSagas.fetchClustersGenerator,
-      callback: handleClusterPoll,
-      delay: StatusPollingInterval,
-      retryOnFailure: true,
-      retryAfter: 5,
-      stopAfterRetries: 2,
-      pollName: 'cluster',
-    };
-    startClusterPolling(clusterPollParams);
-  };
-
-  const startDefaultStoragePolling = () => {
-    const storagePollParams = {
-      asyncFetch: storageSagas.fetchStorageGenerator,
-      callback: handleStoragePoll,
-      delay: StatusPollingInterval,
-      retryOnFailure: true,
-      retryAfter: 5,
-      stopAfterRetries: 2,
-      pollName: 'storage',
-    };
-    startStoragePolling(storagePollParams);
-  };
-
-  const startDefaultTokenPolling = () => {
-    if (NON_ADMIN_ENABLED) {
-      const tokenPollParams = {
-        asyncFetch: tokenSagas.fetchTokensGenerator,
-        callback: handleTokenPoll,
-        delay: StatusPollingInterval,
-        retryOnFailure: true,
-        retryAfter: 5,
-        stopAfterRetries: 2,
-        pollName: 'token',
-      };
-      startTokenPolling(tokenPollParams);
-    }
-  };
-
-  const startDefaultHookPolling = () => {
-    const hookPollParams = {
-      asyncFetch: planSagas.fetchHooksGenerator,
-      callback: handleHookPoll,
-      delay: StatusPollingInterval,
-      retryOnFailure: true,
-      retryAfter: 5,
-      stopAfterRetries: 2,
-      pollName: 'hook',
-    };
-    startHookPolling(hookPollParams);
-  };
-
   return (
     <React.Fragment>
-      <AlertModal alertMessage={progressMessage} alertType="info" />
-      <AlertModal alertMessage={errorMessage} alertType="danger" />
-      <AlertModal alertMessage={successMessage} alertType="success" />
-      <AlertModal alertMessage={warnMessage} alertType="warning" />
-      <PollingContext.Provider
-        value={{
-          startDefaultClusterPolling: () => startDefaultClusterPolling(),
-          startDefaultStoragePolling: () => startDefaultStoragePolling(),
-          startDefaultPlanPolling: () => startDefaultPlanPolling(),
-          startDefaultTokenPolling: () => startDefaultTokenPolling(),
-          startDefaultHookPolling: () => startDefaultHookPolling(),
-          stopHookPolling: () => stopHookPolling(),
-          stopClusterPolling: () => stopClusterPolling(),
-          stopStoragePolling: () => stopStoragePolling(),
-          stopPlanPolling: () => stopPlanPolling(),
-          stopTokenPolling: () => stopTokenPolling(),
-          startAllDefaultPolling: () => {
-            startDefaultClusterPolling();
-            startDefaultStoragePolling();
-            startDefaultPlanPolling();
-            startDefaultTokenPolling();
-            startDefaultHookPolling();
-          },
-          stopAllPolling: () => {
-            stopClusterPolling();
-            stopStoragePolling();
-            stopPlanPolling();
-            stopTokenPolling();
-            stopHookPolling();
-          },
-        }}
-      >
+      <PollingContextProvider>
+        <AlertModal alertMessage={progressMessage} alertType="info" />
+        <AlertModal alertMessage={errorMessage} alertType="danger" />
+        <AlertModal alertMessage={successMessage} alertType="success" />
+        <AlertModal alertMessage={warnMessage} alertType="warning" />
         <ErrorModal errorModalObj={errorModalObject} isOpen />
-
         <ConnectedRouter history={history}>
           <Switch>
             <Route path="/handle-login" component={LoginHandlerComponent} />
@@ -240,7 +68,7 @@ const AppComponent: React.SFC<IProps> = ({
             />
           </Switch>
         </ConnectedRouter>
-      </PollingContext.Provider>
+      </PollingContextProvider>
     </React.Fragment>
   );
 };
@@ -256,21 +84,5 @@ export default connect(
     clusterList: state.cluster.clusterList,
     debugTree: state.debug.tree,
   }),
-  (dispatch) => ({
-    startPlanPolling: (params) => dispatch(PlanActions.startPlanPolling(params)),
-    stopPlanPolling: () => dispatch(PlanActions.stopPlanPolling()),
-    startStoragePolling: (params) => dispatch(StorageActions.startStoragePolling(params)),
-    stopStoragePolling: () => dispatch(StorageActions.stopStoragePolling()),
-    startClusterPolling: (params) => dispatch(ClusterActions.startClusterPolling(params)),
-    stopClusterPolling: () => dispatch(ClusterActions.stopClusterPolling()),
-    startTokenPolling: (params) => dispatch(TokenActions.startTokenPolling(params)),
-    stopTokenPolling: () => dispatch(TokenActions.stopTokenPolling()),
-    startHookPolling: (params) => dispatch(PlanActions.startHookPolling(params)),
-    stopHookPolling: () => dispatch(PlanActions.stopHookPolling()),
-    updateClusters: (updatedClusters) => dispatch(ClusterActions.updateClusters(updatedClusters)),
-    updateStorages: (updatedStorages) => dispatch(StorageActions.updateStorages(updatedStorages)),
-    updatePlans: (updatedPlans) => dispatch(PlanActions.updatePlans(updatedPlans)),
-    updateTokens: (updatedTokens) => dispatch(TokenActions.updateTokens(updatedTokens)),
-    updateHooks: (updatedHooks) => dispatch(PlanActions.updateHooks(updatedHooks)),
-  })
+  (dispatch) => ({})
 )(AppComponent);

--- a/src/app/common/components/ActiveNamespaceModal.tsx
+++ b/src/app/common/components/ActiveNamespaceModal.tsx
@@ -5,11 +5,11 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { AuthActions } from '../../auth/duck/actions';
 import { ClusterActions } from '../../cluster/duck/actions';
 import { connect } from 'react-redux';
-import { PollingContext } from '../../home/duck/context';
 import SimpleSelect from './SimpleSelect';
 import authSelectors from '../../auth/duck/selectors';
 import { history } from '../../../helpers';
 import { getActiveNamespaceFromStorage, setActiveNamespaceInStorage } from '../helpers';
+import { usePausedPollingEffect } from '../context/PollingContext';
 
 interface IProps {
   onHandleClose: () => void;
@@ -23,7 +23,7 @@ interface IProps {
 }
 
 const ActiveNamespaceModal: React.FunctionComponent<IProps> = (props) => {
-  const pollingContext = useContext(PollingContext);
+  usePausedPollingEffect();
   const [selectedActiveNamespace, setSelectedActiveNamespace] = useState<string>(null);
 
   const {
@@ -40,7 +40,6 @@ const ActiveNamespaceModal: React.FunctionComponent<IProps> = (props) => {
 
   useEffect(() => {
     fetchTenantNamespaces();
-    pollingContext.stopAllPolling();
     if (activeNamespace) {
       setSelectedActiveNamespace(activeNamespace);
     }

--- a/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
+++ b/src/app/common/components/AddEditTokenModal/AddEditTokenModal.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useContext, useRef } from 'react';
 import { connect } from 'react-redux';
 import { Modal } from '@patternfly/react-core';
-import { PollingContext } from '../../../home/duck/';
 import AddEditTokenForm from './AddEditTokenForm';
 import { ITokenFormValues, IToken } from '../../../token/duck/types';
 import { IReduxState } from '../../../../reducers';
@@ -16,6 +15,7 @@ import {
   IAddEditStatus,
   defaultAddEditStatus,
 } from '../../../common/add_edit_state';
+import { usePausedPollingEffect } from '../../context/PollingContext';
 
 interface IAddEditTokenModalProps {
   tokenAddEditStatus: IAddEditStatus;
@@ -56,6 +56,7 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
   associatedCluster,
   setAssociatedCluster,
 }: IAddEditTokenModalProps) => {
+  usePausedPollingEffect();
   const containerRef = useRef(document.createElement('div'));
   useEffect(() => {
     // Hack to make it possible to show this modal on top of the wizard...
@@ -64,15 +65,6 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
     return () => {
       document.body.removeChild(containerRef.current);
     };
-  }, []);
-
-  const pollingContext = useContext(PollingContext);
-
-  useEffect(() => {
-    if (isPolling && preventPollingWhileOpen) {
-      pollingContext.stopAllPolling();
-      return () => pollingContext.startAllDefaultPolling();
-    }
   }, []);
 
   const modalTitle = tokenAddEditStatus.mode === AddEditMode.Edit ? 'Edit token' : 'Add token';
@@ -102,7 +94,6 @@ const AddEditTokenModal: React.FunctionComponent<IAddEditTokenModalProps> = ({
     setCurrentToken(null);
     setAssociatedCluster(null);
     toggleAddEditTokenModal();
-    pollingContext.startAllDefaultPolling();
   };
 
   return (

--- a/src/app/common/components/ErrorModal.tsx
+++ b/src/app/common/components/ErrorModal.tsx
@@ -4,7 +4,8 @@ import ErrorCircleOIcon from '@patternfly/react-icons/dist/js/icons/error-circle
 import { useHistory } from 'react-router-dom';
 import { AlertActions } from '../duck/actions';
 import { connect } from 'react-redux';
-import { PollingContext } from '../../home/duck';
+import { usePausedPollingEffect } from '../../common/context/PollingContext';
+
 const styles = require('./ErrorModal.module');
 
 interface IProps {
@@ -16,7 +17,6 @@ interface IProps {
 
 const ErrorModal: React.FunctionComponent<IProps> = (props) => {
   const history = useHistory();
-  const pollingContext = useContext(PollingContext);
 
   const { isOpen, errorModalObj, clearErrors } = props;
   if (!errorModalObj) {
@@ -65,7 +65,6 @@ const ErrorModal: React.FunctionComponent<IProps> = (props) => {
                   variant="secondary"
                   onClick={() => {
                     clearErrors();
-                    pollingContext.startAllDefaultPolling();
                   }}
                 >
                   Cancel

--- a/src/app/common/components/ErrorModal.tsx
+++ b/src/app/common/components/ErrorModal.tsx
@@ -4,7 +4,6 @@ import ErrorCircleOIcon from '@patternfly/react-icons/dist/js/icons/error-circle
 import { useHistory } from 'react-router-dom';
 import { AlertActions } from '../duck/actions';
 import { connect } from 'react-redux';
-import { usePausedPollingEffect } from '../../common/context/PollingContext';
 
 const styles = require('./ErrorModal.module');
 

--- a/src/app/common/context/PollingContext.tsx
+++ b/src/app/common/context/PollingContext.tsx
@@ -1,0 +1,189 @@
+// import {
+//   AFTER_MUTATION_WINDOW,
+//   POLLING_INTERVAL,
+//   POLLING_INTERVAL_AFTER_MUTATION,
+// } from '@app/queries/constants';
+import * as React from 'react';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { clusterSagas } from '../../cluster/duck';
+import { ClusterActions } from '../../cluster/duck/actions';
+import { PlanActions, planSagas } from '../../plan/duck';
+import { storageSagas } from '../../storage/duck';
+import { StorageActions } from '../../storage/duck/actions';
+import { StatusPollingInterval } from '../duck/sagas';
+
+interface IPollingContext {
+  isPollingEnabled: boolean;
+  pausePolling: () => void;
+  resumePolling: () => void;
+  startDefaultClusterPolling: () => void;
+  startDefaultStoragePolling: () => void;
+  startDefaultPlanPolling: () => void;
+  startDefaultHookPolling: () => void;
+  stopHookPolling: () => void;
+  stopClusterPolling: () => void;
+  stopStoragePolling: () => void;
+  stopPlanPolling: () => void;
+}
+
+const PollingContext = React.createContext<IPollingContext>({
+  isPollingEnabled: true,
+  pausePolling: () => undefined,
+  resumePolling: () => undefined,
+  startDefaultClusterPolling: () => undefined,
+  startDefaultStoragePolling: () => undefined,
+  startDefaultPlanPolling: () => undefined,
+  startDefaultHookPolling: () => undefined,
+  stopHookPolling: () => undefined,
+  stopClusterPolling: () => undefined,
+  stopStoragePolling: () => undefined,
+  stopPlanPolling: () => undefined,
+});
+
+interface IPollingContextProviderProps {
+  children: React.ReactNode;
+}
+
+export const PollingContextProvider: React.FunctionComponent<IPollingContextProviderProps> = ({
+  children,
+}: IPollingContextProviderProps) => {
+  const [isPollingEnabled, setIsPollingEnabled] = React.useState(true);
+  const dispatch = useDispatch();
+
+  const handlePlanPoll = (response) => {
+    if (response) {
+      dispatch(PlanActions.updatePlans(response.updatedPlans));
+      return true;
+    }
+    return false;
+  };
+
+  const handleClusterPoll = (response) => {
+    if (response) {
+      dispatch(ClusterActions.updateClusters(response.updatedClusters));
+      return true;
+    }
+    return false;
+  };
+
+  const handleStoragePoll = (response) => {
+    if (response) {
+      dispatch(StorageActions.updateStorages(response.updatedStorages));
+      return true;
+    }
+    return false;
+  };
+
+  const handleHookPoll = (response) => {
+    if (response) {
+      dispatch(PlanActions.updateHooks(response.updatedHooks));
+      return true;
+    }
+    return false;
+  };
+
+  const startDefaultPlanPolling = () => {
+    const planPollParams = {
+      asyncFetch: planSagas.fetchPlansGenerator,
+      callback: handlePlanPoll,
+      delay: StatusPollingInterval,
+      retryOnFailure: true,
+      retryAfter: 5,
+      stopAfterRetries: 2,
+      pollName: 'plan',
+    };
+    dispatch(PlanActions.startPlanPolling(planPollParams));
+  };
+
+  const startDefaultClusterPolling = () => {
+    const clusterPollParams = {
+      asyncFetch: clusterSagas.fetchClustersGenerator,
+      callback: handleClusterPoll,
+      delay: StatusPollingInterval,
+      retryOnFailure: true,
+      retryAfter: 5,
+      stopAfterRetries: 2,
+      pollName: 'cluster',
+    };
+    dispatch(ClusterActions.startClusterPolling(clusterPollParams));
+  };
+
+  const startDefaultStoragePolling = () => {
+    const storagePollParams = {
+      asyncFetch: storageSagas.fetchStorageGenerator,
+      callback: handleStoragePoll,
+      delay: StatusPollingInterval,
+      retryOnFailure: true,
+      retryAfter: 5,
+      stopAfterRetries: 2,
+      pollName: 'storage',
+    };
+    dispatch(StorageActions.startStoragePolling(storagePollParams));
+  };
+
+  const startDefaultHookPolling = () => {
+    const hookPollParams = {
+      asyncFetch: planSagas.fetchHooksGenerator,
+      callback: handleHookPoll,
+      delay: StatusPollingInterval,
+      retryOnFailure: true,
+      retryAfter: 5,
+      stopAfterRetries: 2,
+      pollName: 'hook',
+    };
+    dispatch(PlanActions.startHookPolling(hookPollParams));
+  };
+  React.useEffect(() => {
+    startDefaultClusterPolling();
+    startDefaultStoragePolling();
+    startDefaultPlanPolling();
+    startDefaultHookPolling();
+  }, []);
+
+  return (
+    <PollingContext.Provider
+      value={{
+        isPollingEnabled,
+        startDefaultClusterPolling: () => startDefaultClusterPolling(),
+        startDefaultStoragePolling: () => startDefaultStoragePolling(),
+        startDefaultPlanPolling: () => startDefaultPlanPolling(),
+        startDefaultHookPolling: () => startDefaultHookPolling(),
+        stopHookPolling: () => dispatch(PlanActions.stopHookPolling()),
+        stopClusterPolling: () => dispatch(ClusterActions.stopClusterPolling()),
+        stopStoragePolling: () => dispatch(StorageActions.stopStoragePolling()),
+        stopPlanPolling: () => dispatch(PlanActions.stopPlanPolling()),
+        resumePolling: () => {
+          if (!isPollingEnabled) {
+            startDefaultClusterPolling();
+            startDefaultStoragePolling();
+            startDefaultPlanPolling();
+            startDefaultHookPolling();
+            setIsPollingEnabled(true);
+          }
+        },
+        pausePolling: () => {
+          if (isPollingEnabled) {
+            dispatch(ClusterActions.stopClusterPolling());
+            dispatch(StorageActions.stopStoragePolling());
+            dispatch(PlanActions.stopPlanPolling());
+            dispatch(PlanActions.stopHookPolling());
+            setIsPollingEnabled(false);
+          }
+        },
+      }}
+    >
+      {children}
+    </PollingContext.Provider>
+  );
+};
+
+export const usePollingContext = (): IPollingContext => React.useContext(PollingContext);
+
+export const usePausedPollingEffect = (): void => {
+  const { pausePolling, resumePolling } = usePollingContext();
+  React.useEffect(() => {
+    pausePolling();
+    return resumePolling;
+  }, [pausePolling, resumePolling]);
+};

--- a/src/app/common/context/PollingContext.tsx
+++ b/src/app/common/context/PollingContext.tsx
@@ -1,10 +1,4 @@
-// import {
-//   AFTER_MUTATION_WINDOW,
-//   POLLING_INTERVAL,
-//   POLLING_INTERVAL_AFTER_MUTATION,
-// } from '@app/queries/constants';
 import * as React from 'react';
-import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { clusterSagas } from '../../cluster/duck';
 import { ClusterActions } from '../../cluster/duck/actions';

--- a/src/app/common/context/index.ts
+++ b/src/app/common/context/index.ts
@@ -1,0 +1,1 @@
+export * from './PollingContext';

--- a/src/app/common/duck/sagas.ts
+++ b/src/app/common/duck/sagas.ts
@@ -29,12 +29,14 @@ function* poll(action) {
           name: params.pollName,
           errorMessage: 'error',
         };
-        yield put(AlertActions.alertErrorModal(alertModalObj));
-        yield put(AuthActions.certErrorOccurred(oauthMetaUrl));
-        yield put(PlanActions.stopPlanPolling());
-        yield put(ClusterActions.stopClusterPolling());
-        yield put(StorageActions.stopStoragePolling());
-        yield put(TokenActions.stopTokenPolling());
+        if (state.common.errorModalObject === null) {
+          yield put(AlertActions.alertErrorModal(alertModalObj));
+          yield put(AuthActions.certErrorOccurred(oauthMetaUrl));
+          yield put(PlanActions.stopPlanPolling());
+          yield put(ClusterActions.stopClusterPolling());
+          yield put(StorageActions.stopStoragePolling());
+          yield put(TokenActions.stopTokenPolling());
+        }
       }
       //TODO: Handle "secrets not found error" & any other fetch errors here
     }

--- a/src/app/home/HomeComponent.tsx
+++ b/src/app/home/HomeComponent.tsx
@@ -14,7 +14,6 @@ import {
   SkipToContent,
   Title,
 } from '@patternfly/react-core';
-import { PollingContext } from '../home/duck/context';
 import {
   ClustersPage,
   StoragesPage,
@@ -35,6 +34,7 @@ import { MigrationsPage } from './pages/PlansPage/pages/MigrationsPage';
 import { MigrationDetailsPage } from './pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage';
 import { MigrationStepDetailsPage } from './pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage';
 import { HooksPage } from './pages/HooksPage/HooksPage';
+import { usePollingContext } from '../common/context/PollingContext';
 
 const mainContainerId = 'mig-ui-page-main-container';
 
@@ -57,11 +57,6 @@ const HomeComponent: React.FunctionComponent<IHomeComponentProps> = ({
   clusterList,
   isHideWelcomeScreen,
 }: IHomeComponentProps) => {
-  const pollingContext = useContext(PollingContext);
-  useEffect(() => {
-    pollingContext.startAllDefaultPolling();
-  }, []);
-
   const nav = (
     <Nav aria-label="Page navigation" theme="dark">
       <NavList>

--- a/src/app/home/HomeComponent.tsx
+++ b/src/app/home/HomeComponent.tsx
@@ -1,19 +1,8 @@
-import React, { useEffect, useContext, useState } from 'react';
-import { history } from '../../helpers';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { useRouteMatch, Link, Switch, Route, Redirect } from 'react-router-dom';
 import { IReduxState } from '../../reducers';
-import {
-  Nav,
-  NavList,
-  NavItem,
-  Page,
-  PageSidebar,
-  PageHeader,
-  PageHeaderTools,
-  SkipToContent,
-  Title,
-} from '@patternfly/react-core';
+import { Nav, NavList, NavItem, Page, PageSidebar, SkipToContent } from '@patternfly/react-core';
 import {
   ClustersPage,
   StoragesPage,
@@ -34,7 +23,6 @@ import { MigrationsPage } from './pages/PlansPage/pages/MigrationsPage';
 import { MigrationDetailsPage } from './pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage';
 import { MigrationStepDetailsPage } from './pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage';
 import { HooksPage } from './pages/HooksPage/HooksPage';
-import { usePollingContext } from '../common/context/PollingContext';
 
 const mainContainerId = 'mig-ui-page-main-container';
 

--- a/src/app/home/duck/context.ts
+++ b/src/app/home/duck/context.ts
@@ -3,5 +3,4 @@ import React from 'react';
 export const PlanContext = React.createContext(null);
 export const ClusterContext = React.createContext(null);
 export const StorageContext = React.createContext(null);
-export const PollingContext = React.createContext(null);
 export const AppContext = React.createContext(null);

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -27,6 +27,7 @@ import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-c
 import { IMigCluster } from '../../../../../../client/resources/conversions';
 import { IClusterInfo } from '../../helpers';
 import { ICluster } from '../../../../../cluster/duck/types';
+import { usePausedPollingEffect } from '../../../../../common/context/PollingContext';
 
 const nameKey = 'name';
 const urlKey = 'url';
@@ -78,6 +79,7 @@ const valuesHaveUpdate = (values, currentCluster) => {
   );
 };
 const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) => {
+  usePausedPollingEffect();
   const {
     addEditStatus: currentStatus,
     currentCluster,
@@ -329,7 +331,6 @@ interface IOtherProps {
   checkConnection: (name) => void;
   initialClusterValues?: IClusterInfo;
 }
-
 const AddEditClusterForm = withFormik<IOtherProps, IFormValues>({
   mapPropsToValues: ({ initialClusterValues }) => {
     const values: IFormValues = {

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/index.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/index.tsx
@@ -10,7 +10,6 @@ import {
   AddEditState,
   IAddEditStatus,
 } from '../../../../../common/add_edit_state';
-import { PollingContext } from '../../../../duck/context';
 import { IReduxState } from '../../../../../../reducers';
 import { ICluster } from '../../../../../cluster/duck/types';
 import { IClusterInfo } from '../../helpers';
@@ -49,8 +48,6 @@ const AddEditClusterModal: React.FunctionComponent<IAddEditClusterModal> = ({
   setCurrentCluster,
 }: IAddEditClusterModal) => {
   if (!isAdmin) return null;
-
-  const pollingContext = useContext(PollingContext);
   const onAddEditSubmit = (clusterValues) => {
     switch (addEditStatus.mode) {
       case AddEditMode.Edit: {
@@ -69,18 +66,11 @@ const AddEditClusterModal: React.FunctionComponent<IAddEditClusterModal> = ({
     }
   };
 
-  useEffect(() => {
-    if (isOpen && isPolling) {
-      pollingContext.stopAllPolling();
-    }
-  });
-
   const handleClose = () => {
     resetAddEditState();
     cancelAddEditWatch();
     setCurrentCluster(null);
     onHandleClose();
-    pollingContext.startAllDefaultPolling();
   };
 
   const modalTitle = addEditStatus.mode === AddEditMode.Edit ? 'Edit cluster' : 'Add cluster';

--- a/src/app/home/pages/LogsPage/components/LogsContainer.tsx
+++ b/src/app/home/pages/LogsPage/components/LogsContainer.tsx
@@ -34,6 +34,8 @@ const LogsContainer: FunctionComponent<IProps> = ({
   archive,
   logErrorMsg,
 }) => {
+  usePausedPollingEffect();
+
   const [cluster, setCluster] = useState({
     label: 'controller',
     value: 'controller',
@@ -73,8 +75,6 @@ const LogsContainer: FunctionComponent<IProps> = ({
       downloadArchive(downloadLink);
     }
   }, [downloadLink]);
-
-  usePausedPollingEffect();
 
   if (logErrorMsg) {
     return (

--- a/src/app/home/pages/LogsPage/components/LogsContainer.tsx
+++ b/src/app/home/pages/LogsPage/components/LogsContainer.tsx
@@ -13,8 +13,7 @@ import {
   EmptyStateBody,
 } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-
-import { PollingContext } from '../../../duck/context';
+import { usePausedPollingEffect } from '../../../../common/context/PollingContext';
 
 interface IProps {
   planName: string;
@@ -46,12 +45,11 @@ const LogsContainer: FunctionComponent<IProps> = ({
       containerIndex: LogUnselected,
     },
   });
-  const pollingContext = useContext(PollingContext);
+
   const [downloadLink, setDownloadLink] = useState(null);
 
   useEffect(() => {
     requestReport(planName);
-    pollingContext.stopAllPolling();
   }, []);
 
   const downloadArchive = async (element) => {
@@ -75,6 +73,8 @@ const LogsContainer: FunctionComponent<IProps> = ({
       downloadArchive(downloadLink);
     }
   }, [downloadLink]);
+
+  usePausedPollingEffect();
 
   if (logErrorMsg) {
     return (

--- a/src/app/home/pages/PlansPage/components/Wizard/CopyOptionsForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/CopyOptionsForm.tsx
@@ -4,6 +4,7 @@ import { isEmpty } from 'lodash';
 import { IFormValues, IOtherProps } from './WizardContainer';
 import CopyOptionsTable from './CopyOptionsTable';
 import { IPlanPersistentVolume } from '../../../../../plan/duck/types';
+import { usePausedPollingEffect } from '../../../../../common/context';
 
 type ICopyOptionsFormProps = Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isFetchingPVList'>;
 
@@ -12,6 +13,7 @@ const CopyOptionsForm: React.FunctionComponent<ICopyOptionsFormProps> = ({
   currentPlan,
   isFetchingPVList,
 }: ICopyOptionsFormProps) => {
+  usePausedPollingEffect();
   const { setFieldValue, values } = useFormikContext<IFormValues>();
 
   const migPlanPvs = currentPlan.spec.persistentVolumes;

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -21,6 +21,7 @@ import { NON_ADMIN_ENABLED } from '../../../../../../TEMPORARY_GLOBAL_FLAGS';
 import { validatedState } from '../../../../../common/helpers';
 import { ICluster } from '../../../../../cluster/duck/types';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import { usePausedPollingEffect } from '../../../../../common/context';
 const styles = require('./GeneralForm.module');
 
 export type IGeneralFormProps = Pick<IOtherProps, 'clusterList' | 'storageList' | 'isEdit'>;
@@ -30,6 +31,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   storageList,
   isEdit,
 }: IGeneralFormProps) => {
+  usePausedPollingEffect();
   const {
     handleBlur,
     handleChange,

--- a/src/app/home/pages/PlansPage/components/Wizard/HooksStep.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/HooksStep.tsx
@@ -24,6 +24,7 @@ import { IMigMeta } from '../../../../../auth/duck/types';
 import { IMigPlan, IPlan, IPlanSpecHook } from '../../../../../plan/duck/types';
 import { IMigHook } from '../../../HooksPage/types';
 import { IHook } from '../../../../../../client/resources/conversions';
+import { usePausedPollingEffect } from '../../../../../common/context';
 
 const classNames = require('classnames');
 
@@ -49,6 +50,7 @@ interface IHooksStepBaseProps {
 }
 
 const HooksStep: React.FunctionComponent<IHooksStepBaseProps> = (props) => {
+  usePausedPollingEffect();
   const {
     updateHookRequest,
     addHookRequest,

--- a/src/app/home/pages/PlansPage/components/Wizard/HooksStep.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/HooksStep.tsx
@@ -51,6 +51,7 @@ interface IHooksStepBaseProps {
 
 const HooksStep: React.FunctionComponent<IHooksStepBaseProps> = (props) => {
   usePausedPollingEffect();
+
   const {
     updateHookRequest,
     addHookRequest,

--- a/src/app/home/pages/PlansPage/components/Wizard/MigrationOptions/MigrationOptionsForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/MigrationOptions/MigrationOptionsForm.tsx
@@ -18,6 +18,7 @@ import { useFormikContext } from 'formik';
 import { IFormValues, IOtherProps } from '../WizardContainer';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons';
+import { usePausedPollingEffect } from '../../../../../../common/context';
 
 type IMigrationOptionsFormProps = Pick<IOtherProps, 'clusterList' | 'currentPlan' | 'isEdit'>;
 
@@ -26,6 +27,7 @@ const MigrationOptionsForm: React.FunctionComponent<IMigrationOptionsFormProps> 
   currentPlan,
   isEdit,
 }: IMigrationOptionsFormProps) => {
+  usePausedPollingEffect();
   const indirectImageMigrationKey = 'indirectImageMigration';
   const indirectVolumeMigrationKey = 'indirectVolumeMigration';
 

--- a/src/app/home/pages/PlansPage/components/Wizard/MigrationOptions/MigrationOptionsForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/MigrationOptions/MigrationOptionsForm.tsx
@@ -28,6 +28,7 @@ const MigrationOptionsForm: React.FunctionComponent<IMigrationOptionsFormProps> 
   isEdit,
 }: IMigrationOptionsFormProps) => {
   usePausedPollingEffect();
+
   const indirectImageMigrationKey = 'indirectImageMigration';
   const indirectVolumeMigrationKey = 'indirectVolumeMigration';
 

--- a/src/app/home/pages/PlansPage/components/Wizard/NamespacesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/NamespacesForm.tsx
@@ -17,6 +17,7 @@ const NamespacesForm: React.FunctionComponent<INamespacesFormProps> = ({
   sourceClusterNamespaces,
 }: INamespacesFormProps) => {
   usePausedPollingEffect();
+
   const { setFieldValue, values } = useFormikContext<IFormValues>();
 
   useEffect(() => {

--- a/src/app/home/pages/PlansPage/components/Wizard/NamespacesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/NamespacesForm.tsx
@@ -4,6 +4,7 @@ import { IFormValues, IOtherProps } from './WizardContainer';
 import { Bullseye, EmptyState, Grid, GridItem, Title } from '@patternfly/react-core';
 import NamespacesTable from './NamespacesTable';
 import { Spinner } from '@patternfly/react-core';
+import { usePausedPollingEffect } from '../../../../../common/context';
 
 type INamespacesFormProps = Pick<
   IOtherProps,
@@ -15,6 +16,7 @@ const NamespacesForm: React.FunctionComponent<INamespacesFormProps> = ({
   isFetchingNamespaceList,
   sourceClusterNamespaces,
 }: INamespacesFormProps) => {
+  usePausedPollingEffect();
   const { setFieldValue, values } = useFormikContext<IFormValues>();
 
   useEffect(() => {

--- a/src/app/home/pages/PlansPage/components/Wizard/ResultsStep.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/ResultsStep.tsx
@@ -10,6 +10,7 @@ import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/excla
 import { useFormikContext } from 'formik';
 import { IFormValues } from './WizardContainer';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
+import { usePausedPollingEffect } from '../../../../../common/context';
 
 interface IProps {
   startPlanStatusPolling: (planName) => void;
@@ -26,6 +27,7 @@ const ResultsStep: React.FunctionComponent<IProps> = ({
   startPlanStatusPolling,
   onClose,
 }: IProps) => {
+  usePausedPollingEffect();
   const { values } = useFormikContext<IFormValues>();
 
   const handlePollRestart = () => {

--- a/src/app/home/pages/PlansPage/components/Wizard/ResultsStep.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/ResultsStep.tsx
@@ -28,6 +28,7 @@ const ResultsStep: React.FunctionComponent<IProps> = ({
   onClose,
 }: IProps) => {
   usePausedPollingEffect();
+
   const { values } = useFormikContext<IFormValues>();
 
   const handlePollRestart = () => {

--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
@@ -40,6 +40,7 @@ const VolumesForm: React.FunctionComponent<IVolumesFormProps> = ({
   isPollingStatus,
 }: IVolumesFormProps) => {
   usePausedPollingEffect();
+
   const { setFieldValue, values } = useFormikContext<IFormValues>();
 
   useEffect(() => {

--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { StatusIcon, StatusType } from '@konveyor/lib-ui';
 import { IPlanPersistentVolume } from '../../../../../plan/duck/types';
+import { usePausedPollingEffect } from '../../../../../common/context';
 
 const styles = require('./VolumesTable.module');
 
@@ -38,6 +39,7 @@ const VolumesForm: React.FunctionComponent<IVolumesFormProps> = ({
   pvDiscoveryRequest,
   isPollingStatus,
 }: IVolumesFormProps) => {
+  usePausedPollingEffect();
   const { setFieldValue, values } = useFormikContext<IFormValues>();
 
   useEffect(() => {

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -6,7 +6,6 @@ import VolumesForm from './VolumesForm';
 import CopyOptionsForm from './CopyOptionsForm';
 import HooksStep from './HooksStep';
 import ResultsStep from './ResultsStep';
-import { PollingContext } from '../../../../duck/context';
 import { useFormikContext } from 'formik';
 import { IOtherProps, IFormValues } from './WizardContainer';
 import { CurrentPlanState } from '../../../../../plan/duck/reducers';
@@ -20,7 +19,6 @@ import MigrationOptionsForm from './MigrationOptions/MigrationOptionsForm';
 
 const WizardComponent = (props: IOtherProps) => {
   const [stepIdReached, setStepIdReached] = useState(1);
-  const pollingContext = useContext(PollingContext);
   const [isAddHooksOpen, setIsAddHooksOpen] = useState(false);
 
   const { values, touched, errors, resetForm } = useFormikContext<IFormValues>();
@@ -82,19 +80,12 @@ const WizardComponent = (props: IOtherProps) => {
   const handleClose = () => {
     onHandleWizardModalClose();
     setStepIdReached(stepId.General);
-    pollingContext.startAllDefaultPolling();
     resetForm();
     resetCurrentPlan();
     stopPlanStatusPolling(values.planName);
     validatePlanPollStop();
     pvUpdatePollStop();
   };
-
-  useEffect(() => {
-    if (isOpen) {
-      pollingContext.stopAllPolling();
-    }
-  }, [isOpen]);
 
   const areFieldsTouchedAndValid = (fieldKeys: (keyof IFormValues)[]) =>
     fieldKeys.every((fieldKey) => !errors[fieldKey] && (touched[fieldKey] || isEdit === true));

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -17,7 +17,6 @@ import {
 import { Alert } from '@patternfly/react-core';
 
 import { IReduxState } from '../../../../../../reducers';
-import { PollingContext } from '../../../../duck/context';
 import { IMigration, IPlan } from '../../../../../plan/duck/types';
 import { planSelectors } from '../../../../../plan/duck';
 import MigrationDetailsTable from './MigrationDetailsTable';

--- a/src/app/home/pages/PlansPage/pages/NamespacesPage/NamespacesPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/NamespacesPage/NamespacesPage.tsx
@@ -27,6 +27,7 @@ import { IPlan } from '../../../../../plan/duck/types';
 import { PlanActions, planSelectors } from '../../../../../plan/duck';
 import AnalyticsTable from '../../components/AnalyticsTable';
 import dayjs from 'dayjs';
+import { PollingContext } from '../../../../duck/context';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
 interface INamespacesPageProps {

--- a/src/app/home/pages/PlansPage/pages/NamespacesPage/NamespacesPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/NamespacesPage/NamespacesPage.tsx
@@ -27,7 +27,6 @@ import { IPlan } from '../../../../../plan/duck/types';
 import { PlanActions, planSelectors } from '../../../../../plan/duck';
 import AnalyticsTable from '../../components/AnalyticsTable';
 import dayjs from 'dayjs';
-import { PollingContext } from '../../../../duck/context';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
 interface INamespacesPageProps {

--- a/src/app/home/pages/StoragesPage/StoragesPage.tsx
+++ b/src/app/home/pages/StoragesPage/StoragesPage.tsx
@@ -88,15 +88,13 @@ const StoragesPageBase: React.FunctionComponent<IStoragesPageBaseProps> = ({
                     removeStorage={removeStorage}
                   />
                 )}
-                {isAddEditModalOpen && (
-                  <AddEditStorageModal
-                    isOpen={isAddEditModalOpen}
-                    onHandleClose={() => {
-                      toggleAddEditModal();
-                      setCurrentStorage(null);
-                    }}
-                  />
-                )}
+                <AddEditStorageModal
+                  isOpen={isAddEditModalOpen}
+                  onHandleClose={() => {
+                    toggleAddEditModal();
+                    setCurrentStorage(null);
+                  }}
+                />
               </StorageContext.Provider>
             </CardBody>
           </Card>

--- a/src/app/home/pages/StoragesPage/StoragesPage.tsx
+++ b/src/app/home/pages/StoragesPage/StoragesPage.tsx
@@ -88,13 +88,15 @@ const StoragesPageBase: React.FunctionComponent<IStoragesPageBaseProps> = ({
                     removeStorage={removeStorage}
                   />
                 )}
-                <AddEditStorageModal
-                  isOpen={isAddEditModalOpen}
-                  onHandleClose={() => {
-                    toggleAddEditModal();
-                    setCurrentStorage(null);
-                  }}
-                />
+                {isAddEditModalOpen && (
+                  <AddEditStorageModal
+                    isOpen={isAddEditModalOpen}
+                    onHandleClose={() => {
+                      toggleAddEditModal();
+                      setCurrentStorage(null);
+                    }}
+                  />
+                )}
               </StorageContext.Provider>
             </CardBody>
           </Card>

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -22,6 +22,7 @@ interface IProviderOption extends OptionWithValue {
 
 const AddEditStorageForm = (props: IOtherProps) => {
   usePausedPollingEffect();
+
   const { storageList } = props;
   const storageContext = useContext(StorageContext);
   const storage = storageList.find(

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -6,6 +6,7 @@ import AzureForm from './ProviderForms/AzureForm';
 import { StorageContext } from '../../../../duck/context';
 import { IStorage } from '../../../../../storage/duck/types';
 import SimpleSelect, { OptionWithValue } from '../../../../../common/components/SimpleSelect';
+import { usePausedPollingEffect } from '../../../../../common/context/PollingContext';
 
 interface IOtherProps {
   onAddEditSubmit: any;
@@ -20,6 +21,7 @@ interface IProviderOption extends OptionWithValue {
 }
 
 const AddEditStorageForm = (props: IOtherProps) => {
+  usePausedPollingEffect();
   const { storageList } = props;
   const storageContext = useContext(StorageContext);
   const storage = storageList.find(

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/index.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/index.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import AddEditStorageForm from './AddEditStorageForm';
 import { StorageActions } from '../../../../../storage/duck/actions';
 import { Modal } from '@patternfly/react-core';
-import { PollingContext, StorageContext } from '../../../../duck/context';
+import { StorageContext } from '../../../../duck/context';
 import {
   AddEditMode,
   defaultAddEditStatus,
@@ -22,7 +22,6 @@ const AddEditStorageModal = ({
   initialStorageValues,
   ...props
 }) => {
-  const pollingContext = useContext(PollingContext);
   const storageContext = useContext(StorageContext);
 
   const onAddEditSubmit = (storageValues) => {
@@ -44,17 +43,10 @@ const AddEditStorageModal = ({
     }
   };
 
-  useEffect(() => {
-    if (isOpen && isPolling) {
-      pollingContext.stopAllPolling();
-    }
-  });
-
   const onClose = () => {
     props.cancelAddEditWatch();
     props.resetAddEditState();
     props.onHandleClose();
-    pollingContext.startAllDefaultPolling();
   };
 
   const modalTitle =

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,7 +342,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1":
+"@babel/runtime@^7.1.2":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
@@ -360,6 +360,13 @@
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.3.tgz#670d002655a7c366540c67f6fd3342cd09500364"
   integrity sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.1":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -4514,7 +4521,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -4867,13 +4874,6 @@ interpret@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
-
-invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -7581,7 +7581,7 @@ react-input-autosize@^2.2.1:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.12.0, react-is@^16.3.2, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7590,11 +7590,6 @@ react-is@^16.6.0:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
-
-react-is@^16.7.0, react-is@^16.8.2:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
-  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
 react-json-view@^1.19.1:
   version "1.19.1"
@@ -7611,17 +7606,16 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-redux@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-6.0.1.tgz#0d423e2c1cb10ada87293d47e7de7c329623ba4d"
-  integrity sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==
+react-redux@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.2.tgz#03862e803a30b6b9ef8582dadcc810947f74b736"
+  integrity sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==
   dependencies:
-    "@babel/runtime" "^7.3.1"
-    hoist-non-react-statics "^3.3.0"
-    invariant "^2.2.4"
+    "@babel/runtime" "^7.12.1"
+    hoist-non-react-statics "^3.3.2"
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
-    react-is "^16.8.2"
+    react-is "^16.13.1"
 
 react-router-dom@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
Closes https://github.com/konveyor/mig-ui/issues/1120 

This PR upgrades redux to the latest version. This is a non-breaking change. Version 7.2 introduces the  [redux hooks api](https://react-redux.js.org/api/hooks 
) which unlocks a variety of standard practices that have emerged in the react space. Namely using reusable hooks to handle side effects of an application. 

- Moves all start/stop polling logic out of the AppComponent.tsx file and into the PollingContext.tsx hook file. This new hook file exposes the PollingContextProvider wrapper around our app & the usePausedPollingEffect function. This function automatically handles starting and stopping polling across the app. To use it, simply add usePausedPollingEffect() at the top of a function component that needs to pause polling while it is mounted. 

This is made possible by redux 7.2 hooks api. This now allows us to directly fire redux actions from within a hook. 

