### PR TITLE
Set selector value to false by default

### DIFF
--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -307,7 +307,7 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
       isPaused: false,
       isFailed: false,
       isSucceeded: false,
-      isSuccededWithWarnings: true,
+      isSuccededWithWarnings: false,
       isCanceled: false,
       isCanceling: false,
       migrationState: null,


### PR DESCRIPTION
This PR sets `isSuccededWithWarnings` selector value to false by default. 