### PR TITLE
Debug view enhancements (#1116)

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -61,17 +61,28 @@ const webpackConfig = {
     path: __dirname + '../dist',
     filename: '[name].bundle.js',
     publicPath: '/',
+    pathinfo: false,
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.scss'],
   },
+  optimization: {
+    removeAvailableModules: false,
+    removeEmptyChunks: false,
+    splitChunks: false,
+  },
+  mode: 'none',
   devtool: 'eval-cheap-module-source-map',
   module: {
     rules: [
       {
         test: /\.tsx?$/,
         exclude: /node_modules/,
-        use: 'ts-loader',
+        loader: 'ts-loader',
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
       },
       {
         test: /\.module\.s(a|c)ss$/,

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -20,6 +20,7 @@ module.exports = (env) => {
 
   return {
     entry: './src/index.tsx',
+    mode: 'production',
     output: {
       path: path.resolve(__dirname, '../dist'),
       filename: 'app.bundle.js',

--- a/src/app/common/context/PollingContext.tsx
+++ b/src/app/common/context/PollingContext.tsx
@@ -6,7 +6,15 @@ import { PlanActions, planSagas } from '../../plan/duck';
 import { storageSagas } from '../../storage/duck';
 import { StorageActions } from '../../storage/duck/actions';
 import { StatusPollingInterval } from '../duck/sagas';
-
+interface IPollingParams {
+  asyncFetch: (action: any) => void;
+  callback: (response: any) => boolean;
+  delay: number;
+  retryOnFailure: boolean;
+  retryAfter: number;
+  stopAfterRetries: number;
+  pollName: string;
+}
 interface IPollingContext {
   isPollingEnabled: boolean;
   pausePolling: () => void;
@@ -78,7 +86,7 @@ export const PollingContextProvider: React.FunctionComponent<IPollingContextProv
   };
 
   const startDefaultPlanPolling = () => {
-    const planPollParams = {
+    const planPollParams: IPollingParams = {
       asyncFetch: planSagas.fetchPlansGenerator,
       callback: handlePlanPoll,
       delay: StatusPollingInterval,
@@ -91,7 +99,7 @@ export const PollingContextProvider: React.FunctionComponent<IPollingContextProv
   };
 
   const startDefaultClusterPolling = () => {
-    const clusterPollParams = {
+    const clusterPollParams: IPollingParams = {
       asyncFetch: clusterSagas.fetchClustersGenerator,
       callback: handleClusterPoll,
       delay: StatusPollingInterval,
@@ -104,7 +112,7 @@ export const PollingContextProvider: React.FunctionComponent<IPollingContextProv
   };
 
   const startDefaultStoragePolling = () => {
-    const storagePollParams = {
+    const storagePollParams: IPollingParams = {
       asyncFetch: storageSagas.fetchStorageGenerator,
       callback: handleStoragePoll,
       delay: StatusPollingInterval,
@@ -117,7 +125,7 @@ export const PollingContextProvider: React.FunctionComponent<IPollingContextProv
   };
 
   const startDefaultHookPolling = () => {
-    const hookPollParams = {
+    const hookPollParams: IPollingParams = {
       asyncFetch: planSagas.fetchHooksGenerator,
       callback: handleHookPoll,
       delay: StatusPollingInterval,

--- a/src/app/debug/components/RawDebugObjectView.tsx
+++ b/src/app/debug/components/RawDebugObjectView.tsx
@@ -1,24 +1,110 @@
-import React, { useEffect } from 'react';
+import {
+  PageSection,
+  Alert,
+  Card,
+  CardHeader,
+  Title,
+  Popover,
+  PopoverPosition,
+  CardExpandableContent,
+  Bullseye,
+  EmptyState,
+  Spinner,
+  CardBody,
+  Split,
+  CardActions,
+  Checkbox,
+  Dropdown,
+  KebabToggle,
+  Button,
+} from '@patternfly/react-core';
+import { QuestionCircleIcon, TimesIcon } from '@patternfly/react-icons';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import React, { useState } from 'react';
 import ReactJson from 'react-json-view';
 import { useDispatch, useSelector } from 'react-redux';
-import { debugObjectFetchRequest } from '../duck/slice';
-import { DEBUG_PATH_SEARCH_KEY } from '../duck/types';
+import { clearJSONView } from '../duck/slice';
 
 const RawDebugObjectView: React.FunctionComponent = () => {
-  const dispatch = useDispatch();
+  const [isOpen, setIsOpen] = useState(true);
   const debug = useSelector((state) => state.debug);
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const decodedURI = decodeURI(params.get(DEBUG_PATH_SEARCH_KEY));
-    dispatch(debugObjectFetchRequest(decodedURI));
-    // Value in the array really should be the path that's getting submitted
-    // via a query param. Better way to do this via prop?
-  }, []);
-
+  const dispatch = useDispatch();
+  const closeJSONView = () => {
+    dispatch(clearJSONView());
+  };
   return (
-    <div>
-      {debug.isLoading ? 'Loading...' : <ReactJson src={debug.objJson} enableClipboard={true} />}
-    </div>
+    <>
+      <PageSection>
+        {debug.errMsg ? (
+          <Alert variant="danger" title={`Error loading JSON`}>
+            <p>{debug.errMsg}</p>
+          </Alert>
+        ) : (
+          <Card id="image-card" isExpanded={isOpen}>
+            <CardHeader
+              onExpand={() => {
+                setIsOpen(!isOpen);
+              }}
+              toggleButtonProps={{
+                id: 'toggle-button',
+                'aria-label': 'debug-details',
+                'aria-expanded': isOpen,
+              }}
+            >
+              <Title headingLevel="h1" size="xl" className={spacing.mrLg}>
+                Resource JSON view
+              </Title>
+              <Popover
+                position={PopoverPosition.bottom}
+                bodyContent={
+                  <>
+                    <Title headingLevel="h2" size="xl">
+                      <>JSON view</>
+                    </Title>
+                    <p className={spacing.mtMd}>View the JSON for the selected resource.</p>
+                  </>
+                }
+                aria-label="json-view"
+                closeBtnAriaLabel="close--details"
+                maxWidth="30rem"
+              >
+                <span>
+                  <span className="pf-c-icon pf-m-info">
+                    <QuestionCircleIcon size="md" />
+                  </span>
+                </span>
+              </Popover>
+              <CardActions>
+                <Button variant="plain" aria-label="Action" onClick={() => closeJSONView()}>
+                  <TimesIcon />
+                </Button>
+              </CardActions>
+            </CardHeader>
+            <CardExpandableContent>
+              <div>
+                {debug.isLoadingJSONObject ? (
+                  <Bullseye>
+                    <EmptyState variant="large">
+                      <div className="pf-c-empty-state__icon">
+                        <Spinner size="xl" />
+                      </div>
+                      <Title headingLevel="h2" size="xl">
+                        Loading...
+                      </Title>
+                    </EmptyState>
+                  </Bullseye>
+                ) : (
+                  <CardBody>
+                    <Split hasGutter></Split>
+                    <ReactJson src={debug.objJson} enableClipboard={true} />
+                  </CardBody>
+                )}
+              </div>
+            </CardExpandableContent>
+          </Card>
+        )}
+      </PageSection>
+    </>
   );
 };
 export default RawDebugObjectView;

--- a/src/app/debug/components/TreeViewStatusIcon.tsx
+++ b/src/app/debug/components/TreeViewStatusIcon.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import { Flex, FlexItem, Popover, PopoverPosition, Spinner } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { DebugStatusType, IDebugRefWithStatus } from '../duck/types';
+import OutlinedCircleIcon from '@patternfly/react-icons/dist/js/icons/outlined-circle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import { IMigration, IPlan } from '../../plan/duck/types';
+import MigrationStatusIcon from '../../home/pages/PlansPage/components/MigrationStatusIcon';
+import { getPipelineSummaryTitle } from '../../home/pages/PlansPage/helpers';
+const classNames = require('classnames');
+
+interface IProps {
+  debugRef: IDebugRefWithStatus;
+  plans: IPlan[];
+}
+
+const getIcon = (debugRef: IDebugRefWithStatus, plans: IPlan[]) => {
+  const matchingMigrationRef: IMigration[] = [];
+  plans?.forEach((plan) => {
+    const foundMigration: IMigration = plan.Migrations.find(
+      (m) => m.metadata.name === debugRef?.refName
+    );
+    if (foundMigration) {
+      matchingMigrationRef.push(foundMigration);
+    }
+  });
+  if (debugRef.resourceKind === 'Migration') {
+    const title = getPipelineSummaryTitle(matchingMigrationRef[0] || null);
+    return (
+      <>
+        <MigrationStatusIcon migration={matchingMigrationRef[0]} />
+        <span className={spacing.mlSm}>{title}</span>
+      </>
+    );
+  }
+  switch (debugRef?.debugResourceStatus?.currentStatus) {
+    case DebugStatusType.Running:
+      return (
+        <>
+          <Spinner size="sm"></Spinner>
+          <span className={spacing.mlSm}>Active</span>
+        </>
+      );
+    case DebugStatusType.Failure:
+      return (
+        <>
+          <span className="pf-c-icon pf-m-danger">
+            <ExclamationCircleIcon />
+          </span>
+          <span className={spacing.mlSm}>Failed</span>
+        </>
+      );
+    case DebugStatusType.Warning:
+      return (
+        <>
+          <span className="pf-c-icon pf-m-warning">
+            <ExclamationTriangleIcon />
+          </span>
+          <span className={spacing.mlSm}>Warning</span>
+        </>
+      );
+
+    case DebugStatusType.Completed:
+      return (
+        <FlexItem>
+          <span id="debug-ref-successful-icon" className="pf-c-icon pf-m-success">
+            <CheckCircleIcon />
+          </span>
+          <span className={spacing.mlSm}>Completed</span>
+        </FlexItem>
+      );
+    default: {
+      return <></>;
+    }
+  }
+};
+
+const TreeViewStatusIcon: React.FunctionComponent<IProps> = ({ debugRef, plans }) => {
+  return getIcon(debugRef, plans);
+};
+
+export default TreeViewStatusIcon;

--- a/src/app/debug/duck/index.ts
+++ b/src/app/debug/duck/index.ts
@@ -1,4 +1,5 @@
 import debugReducer from './slice';
 export { default as debugSagas } from './sagas';
 export { IDebugReducerState } from './slice';
+export { default as debugSelectors } from './selectors';
 export default debugReducer;

--- a/src/app/debug/duck/selectors.ts
+++ b/src/app/debug/duck/selectors.ts
@@ -1,0 +1,221 @@
+import { createSelector } from 'reselect';
+import {
+  DebugStatusType,
+  IDebugRefRes,
+  IDebugRefWithStatus,
+  IDerivedDebugStatusObject,
+} from './types';
+
+const debugRefsSelector = (state) => state.debug.debugRefs.map((r) => r);
+
+const getDebugRefsWithStatus = createSelector([debugRefsSelector], (debugRefs: IDebugRefRes[]) => {
+  const refsWithStatus: IDebugRefWithStatus[] = debugRefs.map((ref) => {
+    const statusObject = {
+      ...getResourceStatus(ref),
+    };
+
+    return {
+      ...ref?.value.data?.object,
+      refName: ref?.value.data?.name,
+      debugResourceStatus: statusObject,
+      resourceKind: ref.kind,
+    };
+  });
+
+  return refsWithStatus;
+});
+
+const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject => {
+  const warningConditionTypes = ['Critical', 'Error', 'Warn'];
+  const checkListContainsString = (val: string, stringList: Array<string>) => {
+    if (stringList.indexOf(val) > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+  switch (debugRef.kind) {
+    case 'Backup': {
+      const { errors, warnings, phase } = debugRef.value.data.object.status;
+      const hasWarning = warnings?.length > 0 || phase === 'PartiallyFailed';
+      const hasFailure = errors?.length > 0 || phase === 'Failed';
+      const hasCompleted = phase === 'Completed';
+      const hasRunning = phase === 'InProgress';
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'Restore': {
+      const { errors, warnings, phase } = debugRef.value.data.object.status;
+      const hasWarning = warnings?.length > 0 || phase === 'PartiallyFailed';
+      const hasFailure = errors?.length > 0 || phase === 'Failed';
+      const hasCompleted = phase === 'Completed';
+      const hasRunning = phase === 'InProgress';
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'PodVolumeBackup': {
+      const { phase } = debugRef.value.data.object.status;
+      const hasWarning = phase === 'PartiallyFailed';
+      const hasFailure = phase === 'Failed';
+      const hasCompleted = phase === 'Completed';
+      const hasRunning = phase === 'InProgress';
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'PodVolumeRestore': {
+      const { errors, warnings, phase } = debugRef.value.data.object.status;
+      const hasWarning = phase === 'PartiallyFailed';
+      const hasFailure = phase === 'Failed';
+      const hasCompleted = phase === 'Completed';
+      const hasRunning = phase === 'InProgress';
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'DirectImageMigration': {
+      const { conditions } = debugRef.value.data.object.status;
+      const hasWarning = conditions?.some((c) =>
+        checkListContainsString(c.category, warningConditionTypes)
+      );
+      const hasFailure = conditions?.some((c) => c.type === 'Failed');
+      const hasCompleted = conditions?.some((c) =>
+        checkListContainsString(c.type, ['Completed', 'Succeeded'])
+      );
+      const hasRunning = conditions?.some((c) => c.type === 'Running');
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'DirectVolumeMigration': {
+      const { conditions } = debugRef.value.data.object.status;
+      const hasWarning = conditions?.some((c) =>
+        checkListContainsString(c.category, warningConditionTypes)
+      );
+      const hasFailure = conditions?.some((c) => c.type === 'Failed');
+      const hasCompleted = conditions?.some((c) =>
+        checkListContainsString(c.type, ['Completed', 'Succeeded'])
+      );
+      const hasRunning = conditions?.some((c) => c.type === 'Running');
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'DirectImageStreamMigration': {
+      const { conditions } = debugRef.value.data.object.status;
+      const hasWarning = conditions?.some((c) =>
+        checkListContainsString(c.category, warningConditionTypes)
+      );
+      const hasFailure = conditions?.some((c) => c.type === 'Failed');
+      const hasCompleted = conditions?.some((c) =>
+        checkListContainsString(c.type, ['Completed', 'Succeeded'])
+      );
+      const hasRunning = conditions?.some((c) => c.type === 'Running');
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'DirectVolumeMigrationProgress': {
+      const { conditions } = debugRef.value.data.object.status;
+      const hasWarning = conditions?.some((c) =>
+        checkListContainsString(c.category, warningConditionTypes)
+      );
+      const hasFailure = conditions?.some((c) =>
+        checkListContainsString(c.type, ['InvalidPod', 'InvalidPodRef'])
+      );
+      const hasCompleted = false;
+      const hasRunning = false;
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'Migration': {
+      const { conditions } = debugRef.value.data.object.status;
+      const hasWarning = conditions?.some((c) =>
+        checkListContainsString(c.category, warningConditionTypes)
+      );
+      const hasFailure = conditions?.some((c) => c.type === 'Failed');
+      const hasCompleted = conditions?.some((c) =>
+        checkListContainsString(c.type, ['Succeeded', 'Completed'])
+      );
+      const hasRunning = conditions?.some((c) => c.type === 'Running');
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+    case 'Plan': {
+      const { conditions } = debugRef.value.data.object.status;
+      const hasWarning = conditions?.some((c) =>
+        checkListContainsString(c.category, warningConditionTypes)
+      );
+      const hasFailure = conditions?.some((c) => c.type === 'Failed');
+      const hasCompleted = conditions?.some((c) =>
+        checkListContainsString(c.type, ['Succeeded', 'Completed'])
+      );
+      const hasRunning = conditions?.some((c) => c.type === 'Running');
+      return {
+        hasWarning,
+        hasFailure,
+        hasCompleted,
+        hasRunning,
+        currentStatus: calculateCurrentStatus(hasWarning, hasFailure, hasCompleted, hasRunning),
+      };
+    }
+  }
+};
+
+const calculateCurrentStatus = (hasWarning, hasFailure, hasCompleted, hasRunning) => {
+  let currentStatus;
+  if (hasRunning) {
+    currentStatus = DebugStatusType.Running;
+  } else if (hasFailure) {
+    currentStatus = DebugStatusType.Failure;
+  } else if (hasWarning) {
+    currentStatus = DebugStatusType.Warning;
+  } else if (hasCompleted) {
+    currentStatus = DebugStatusType.Completed;
+  }
+  return currentStatus;
+};
+
+export default {
+  getDebugRefsWithStatus,
+};

--- a/src/app/debug/duck/types.ts
+++ b/src/app/debug/duck/types.ts
@@ -1,9 +1,43 @@
+import { IStatus } from '../../plan/duck/types';
+
 export interface IDebugTreeNode {
   kind: string;
   namespace: string;
   name: string;
   objectLink: string;
   children: IDebugTreeNode[];
+}
+export interface IDebugRefRes {
+  kind: string;
+  value: any;
+}
+export interface IDebugRefWithStatus {
+  apiVersion: string;
+  kind?: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+  };
+  spec: any;
+  status?: any;
+  refName?: string;
+  debugResourceStatus?: IDerivedDebugStatusObject;
+  resourceKind: string;
+}
+
+export interface IDerivedDebugStatusObject {
+  hasWarning: boolean;
+  hasFailure: boolean;
+  hasCompleted: boolean;
+  hasRunning: boolean;
+  currentStatus: DebugStatusType;
+}
+export enum DebugStatusType {
+  Warning = 'Warning',
+  Failure = 'Failure',
+  Running = 'Running',
+  Completed = 'Completed',
 }
 
 export const DEBUG_PATH_SEARCH_KEY = 'objPath';

--- a/src/app/debug/duck/utils.module.scss
+++ b/src/app/debug/duck/utils.module.scss
@@ -1,0 +1,22 @@
+.treeID {
+  flex: 1 0 auto;
+}
+
+.statusIcon {
+  flex: 1 0 auto;
+}
+
+.alignStatus {
+  width: 10em;
+  margin-left: auto;
+  text-align: left;
+}
+
+.activeHighlight {
+  background-color: #bee1f4;
+  padding: 10px;
+  border: #bee1f4 solid 1px;
+  border-radius: 7px;
+  margin: 5px;
+  font-weight: bold;
+}

--- a/src/app/debug/duck/utils.tsx
+++ b/src/app/debug/duck/utils.tsx
@@ -1,25 +1,49 @@
 import React from 'react';
-import { TreeViewDataItem } from '@patternfly/react-core';
-import { IDebugTreeNode } from './types';
+import { Flex, FlexItem, TreeViewDataItem } from '@patternfly/react-core';
+import { IDebugRefRes, IDebugRefWithStatus, IDebugTreeNode } from './types';
 import crawl from 'tree-crawl';
 import TreeActionsDropdown from '../../home/pages/PlanDebugPage/components/TreeActionsDropdown';
+import TreeViewStatusIcon from '../components/TreeViewStatusIcon';
+import PlanStatus from '../../home/pages/PlansPage/components/PlanStatus';
+import { IMigration, IPlan } from '../../plan/duck/types';
+import MigrationStatusIcon from '../../home/pages/PlansPage/components/MigrationStatusIcon';
+import { IMigrationWithStatus } from '../../home/pages/PlansPage/types';
+const uuidv1 = require('uuid/v1');
+const styles = require('./utils.module').default;
 
 const getShallowPropsForNode = (
   rawNode: IDebugTreeNode,
-  viewRawDebugObject: (node: IDebugTreeNode) => void
+  debugRefs: IDebugRefWithStatus[],
+  plans: IPlan[]
 ): TreeViewDataItem => {
+  const matchingPlanRef = plans?.find((plan) => plan.MigPlan.metadata.name === rawNode?.name);
+  const matchingDebugRef = debugRefs?.find((ref) => ref?.refName === rawNode?.name);
   return {
-    name: `${rawNode.kind}: ${rawNode.namespace}/${rawNode.name}`,
-    action: <TreeActionsDropdown rawNode={rawNode} viewRawDebugObject={viewRawDebugObject} />,
+    id: rawNode.name,
+    name: (
+      <Flex className={matchingDebugRef?.debugResourceStatus?.hasRunning && styles.activeHighlight}>
+        <FlexItem
+          className={styles.treeID}
+        >{`${rawNode.kind}: ${rawNode.namespace}/${rawNode.name}`}</FlexItem>
+        {matchingDebugRef?.resourceKind === 'Plan' ? (
+          <FlexItem>
+            <PlanStatus plan={matchingPlanRef} />
+          </FlexItem>
+        ) : (
+          <FlexItem className={styles.statusIcon}>
+            <div className={styles.alignStatus}>
+              <TreeViewStatusIcon plans={plans} debugRef={matchingDebugRef} />
+            </div>
+          </FlexItem>
+        )}
+      </Flex>
+    ),
+    action: <TreeActionsDropdown rawNode={rawNode} />,
   };
 };
 
-const convertNode = (
-  rawNode: IDebugTreeNode,
-  ctx,
-  viewRawDebugObject: (node: IDebugTreeNode) => void
-): void => {
-  const outNode: TreeViewDataItem = getShallowPropsForNode(rawNode, viewRawDebugObject);
+const convertNode = (rawNode: IDebugTreeNode, ctx, debugRefs, plans): void => {
+  const outNode: TreeViewDataItem = getShallowPropsForNode(rawNode, debugRefs, plans);
 
   if (rawNode.children) {
     outNode.children = rawNode.children;
@@ -34,7 +58,8 @@ const convertNode = (
 
 export const convertRawTreeToViewTree = (
   inTree: IDebugTreeNode,
-  viewRawDebugObject: (node: IDebugTreeNode) => void
+  debugRefs: IDebugRefWithStatus[],
+  plans: IPlan[]
 ): TreeViewDataItem[] => {
   // Deep clone. Not the most efficient, but easy and we're not going for
   // blazing performance here.
@@ -42,15 +67,18 @@ export const convertRawTreeToViewTree = (
 
   crawl(
     workingTree,
-    (rawNode: IDebugTreeNode, ctx) => convertNode(rawNode, ctx, viewRawDebugObject),
-    { order: 'pre' }
+    (rawNode: IDebugTreeNode, ctx) => convertNode(rawNode, ctx, debugRefs, plans),
+    {
+      order: 'pre',
+    }
   );
 
   // Doesn't seem to be an easy way from within the crawler to replace
   // the root node, so doing that here and just bringing in the rest of it
   return [
     {
-      ...getShallowPropsForNode(workingTree, viewRawDebugObject),
+      id: uuidv1(),
+      ...getShallowPropsForNode(workingTree, debugRefs, plans),
       children: workingTree.children,
       defaultExpanded: true,
     },

--- a/src/app/home/HomeComponent.tsx
+++ b/src/app/home/HomeComponent.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { Link, Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { ClustersPage, StoragesPage, PlansPage, PlanDebugPage, LogsPage } from './pages';
 import { NamespacesPage } from './pages/PlansPage/pages/NamespacesPage';
 import RefreshRoute from '../auth/RefreshRoute';
 import { MigrationsPage } from './pages/PlansPage/pages/MigrationsPage';
 import { HooksPage } from './pages/HooksPage/HooksPage';
-import { MigrationDetailsPage } from './pages/PlansPage/pages/MigrationDetailsPage';
-import { MigrationStepDetailsPage } from './pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage';
+import RawDebugObjectView from '../debug/components/RawDebugObjectView';
 
 const HomeComponent: React.FunctionComponent = () => {
+  const debug = useSelector((state) => state.debug);
   return (
     <Switch>
       <Route exact path="/">
@@ -28,22 +29,15 @@ const HomeComponent: React.FunctionComponent = () => {
           <Route exact path="/plans/:planName/namespaces">
             <NamespacesPage />
           </Route>
-          <Route exact path="/plans/:planName/migrations">
+          <Route path="/plans/:planName/migrations">
             <MigrationsPage />
-          </Route>
-          <Route exact path="/plans/:planName/migrations/:migrationID">
-            <MigrationDetailsPage />
-          </Route>
-          <Route exact path="/plans/:planName/migrations/:migrationID/:stepName">
-            <MigrationStepDetailsPage />
-          </Route>
-          <Route exact path="/plans/:planName/debug">
             <PlanDebugPage />
+            {debug.objJson && <RawDebugObjectView />}
           </Route>
           <Route exact path="/hooks">
             <HooksPage />
           </Route>
-          <RefreshRoute exact path="/logs/:planId" component={LogsPage} />
+          <RefreshRoute exact path="/logs/:planId" isLoggedIn component={LogsPage} />
           <Route path="*">
             <Redirect to="/" />
           </Route>

--- a/src/app/home/pages/PlanDebugPage/components/TreeActionsDropdown.tsx
+++ b/src/app/home/pages/PlanDebugPage/components/TreeActionsDropdown.tsx
@@ -5,6 +5,8 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IDebugTreeNode } from '../../../../debug/duck/types';
 import { getOCCommandAndClusterType } from '../helpers';
 import { AlertActions } from '../../../../common/duck/actions';
+import { useDispatch, useSelector } from 'react-redux';
+import { debugObjectFetchRequest } from '../../../../debug/duck/slice';
 
 interface ITreeActionsDropdownProps {
   rawNode: IDebugTreeNode;
@@ -14,9 +16,9 @@ interface ITreeActionsDropdownProps {
 
 const TreeActionsDropdown: React.FunctionComponent<ITreeActionsDropdownProps> = ({
   rawNode,
-  viewRawDebugObject,
   copiedToClipboard,
 }: ITreeActionsDropdownProps) => {
+  const dispatch = useDispatch();
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
   const [clusterType, setClusterType] = useState('');
 
@@ -63,7 +65,7 @@ const TreeActionsDropdown: React.FunctionComponent<ITreeActionsDropdownProps> = 
           key="view-raw"
           onClick={() => {
             setKebabIsOpen(false);
-            viewRawDebugObject(rawNode);
+            dispatch(debugObjectFetchRequest(rawNode.objectLink));
           }}
         >
           View JSON

--- a/src/app/home/pages/PlansPage/components/MigrationActions.tsx
+++ b/src/app/home/pages/PlansPage/components/MigrationActions.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useContext } from 'react';
-import { PlanContext } from '../../../duck/context';
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
 import {
   KebabToggle,
   DropdownItem,
@@ -9,18 +9,15 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 import { IMigration } from '../../../../plan/duck/types';
+import { PlanActions } from '../../../../plan/duck';
 
 interface IProps {
   migration: IMigration;
-  handleMigrationCancelRequest: (name: string) => void;
 }
 
-const MigrationActions: React.FunctionComponent<IProps> = ({
-  migration,
-  handleMigrationCancelRequest,
-}) => {
+const MigrationActions: React.FunctionComponent<IProps> = ({ migration }) => {
   const [kebabIsOpen, setKebabIsOpen] = useState(false);
-  const planContext = useContext(PlanContext);
+  const dispatch = useDispatch();
 
   return (
     <Flex>
@@ -36,7 +33,7 @@ const MigrationActions: React.FunctionComponent<IProps> = ({
                 <DropdownItem
                   onClick={() => {
                     setKebabIsOpen(false);
-                    handleMigrationCancelRequest(migration.metadata.name);
+                    dispatch(PlanActions.migrationCancelRequest(migration.metadata.name));
                   }}
                   key={`cancelMigration-${migration.metadata.name}`}
                   isDisabled={

--- a/src/app/home/pages/PlansPage/components/MigrationStatusIcon.tsx
+++ b/src/app/home/pages/PlansPage/components/MigrationStatusIcon.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Popover, PopoverPosition } from '@patternfly/react-core';
+
+import { IMigration } from '../../../../plan/duck/types';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import ErrorCircleOIcon from '@patternfly/react-icons/dist/js/icons/error-circle-o-icon';
+
+interface IProps {
+  migration: IMigration;
+}
+
+const MigrationStatusIcon: React.FunctionComponent<IProps> = ({ migration }) => {
+  if (!migration) {
+    return null;
+  } else {
+    return (
+      <>
+        {migration?.tableStatus.isFailed && (
+          <Popover
+            position={PopoverPosition.top}
+            bodyContent={<>{migration.tableStatus.errorCondition}</>}
+            aria-label="pipeline-error-details"
+            closeBtnAriaLabel="close--details"
+            maxWidth="30rem"
+          >
+            <span className="pf-c-icon pf-m-danger">
+              <ErrorCircleOIcon
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              />
+            </span>
+          </Popover>
+        )}
+        {migration?.tableStatus.warnCondition && (
+          <Popover
+            position={PopoverPosition.top}
+            bodyContent={<>{migration.tableStatus.warnCondition}</>}
+            aria-label="pipeline-warning-details"
+            closeBtnAriaLabel="close--details"
+            maxWidth="30rem"
+          >
+            <span className={`pf-c-icon pf-m-warning `}>
+              <ExclamationTriangleIcon
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              />
+            </span>
+          </Popover>
+        )}
+        {migration?.tableStatus.isPostponed && (
+          <Popover
+            position={PopoverPosition.top}
+            bodyContent={<>{migration.tableStatus.errorCondition}</>}
+            aria-label="pipeline-warning-details"
+            closeBtnAriaLabel="close--details"
+            maxWidth="30rem"
+          >
+            <span className={`pf-c-icon pf-m-warning`}>
+              <ExclamationTriangleIcon
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+              />
+            </span>
+          </Popover>
+        )}
+      </>
+    );
+  }
+};
+
+export default MigrationStatusIcon;

--- a/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
+++ b/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
@@ -24,14 +24,12 @@ interface IProps {
   type: string;
   isPlanLocked: boolean;
   planName: string;
-  handleMigrationCancelRequest: (name: string) => void;
 }
 
 const MigrationsTable: React.FunctionComponent<IProps> = ({
   migrations,
   isPlanLocked,
   planName,
-  handleMigrationCancelRequest,
 }) => {
   const getSortValues = (migration: any) => {
     const type = migration.spec.stage ? 'Stage' : 'Migration';
@@ -79,12 +77,7 @@ const MigrationsTable: React.FunctionComponent<IProps> = ({
           ),
         },
         {
-          title: (
-            <MigrationActions
-              handleMigrationCancelRequest={handleMigrationCancelRequest}
-              migration={migration}
-            />
-          ),
+          title: <MigrationActions migration={migration} />,
           props: {
             className: 'pf-c-table__action',
           },

--- a/src/app/home/pages/PlansPage/components/PipelineSummary/PipelineSummary.tsx
+++ b/src/app/home/pages/PlansPage/components/PipelineSummary/PipelineSummary.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 
-import { Flex, FlexItem, Popover, PopoverPosition, Text } from '@patternfly/react-core';
+import { Flex, FlexItem, Text } from '@patternfly/react-core';
 import ResourcesFullIcon from '@patternfly/react-icons/dist/js/icons/resources-full-icon';
 import ResourcesAlmostFullIcon from '@patternfly/react-icons/dist/js/icons/resources-almost-full-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { getPipelineSummaryTitle } from '../../helpers';
 import { IMigration } from '../../../../../plan/duck/types';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import ErrorCircleOIcon from '@patternfly/react-icons/dist/js/icons/error-circle-o-icon';
+import MigrationStatusIcon from '../MigrationStatusIcon';
 
 const classNames = require('classnames');
 const styles = require('./PipelineSummary.module').default;
@@ -87,45 +86,7 @@ const PipelineSummary: React.FunctionComponent<IPipelineSummaryProps> = ({
     <>
       <Flex>
         <FlexItem className={`${spacing.mrSm} `}>
-          {migration.tableStatus.isFailed && (
-            <Popover
-              position={PopoverPosition.top}
-              bodyContent={<>{migration.tableStatus.errorCondition}</>}
-              aria-label="pipeline-error-details"
-              closeBtnAriaLabel="close--details"
-              maxWidth="30rem"
-            >
-              <span className="pf-c-icon pf-m-danger">
-                <ErrorCircleOIcon />
-              </span>
-            </Popover>
-          )}
-          {migration.tableStatus.warnCondition && (
-            <Popover
-              position={PopoverPosition.top}
-              bodyContent={<>{migration.tableStatus.warnCondition}</>}
-              aria-label="pipeline-warning-details"
-              closeBtnAriaLabel="close--details"
-              maxWidth="30rem"
-            >
-              <span className={`pf-c-icon pf-m-warning ${spacing.plSm} `}>
-                <ExclamationTriangleIcon />
-              </span>
-            </Popover>
-          )}
-          {migration.tableStatus.isPostponed && (
-            <Popover
-              position={PopoverPosition.top}
-              bodyContent={<>{migration.tableStatus.errorCondition}</>}
-              aria-label="pipeline-warning-details"
-              closeBtnAriaLabel="close--details"
-              maxWidth="30rem"
-            >
-              <span className={`pf-c-icon pf-m-warning ${spacing.plSm} `}>
-                <ExclamationTriangleIcon />
-              </span>
-            </Popover>
-          )}
+          <MigrationStatusIcon migration={migration} />
         </FlexItem>
         {status && status?.pipeline && (
           <FlexItem flex={{ default: 'flex_1' }} className={spacing.mAuto}>

--- a/src/app/home/pages/PlansPage/components/PlanActions.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanActions.tsx
@@ -112,25 +112,6 @@ const PlanActions = ({ plan, history }) => {
     >
       Delete
     </DropdownItem>,
-    <DropdownItem
-      key="showLogs"
-      onClick={() => {
-        setKebabIsOpen(false);
-        history.push('/logs/' + plan.MigPlan.metadata.name);
-      }}
-    >
-      Logs
-    </DropdownItem>,
-    <DropdownItem
-      key="debugResourcesModal"
-      href={`/plans/${plan.MigPlan.metadata.name}/debug`}
-      target="_blank"
-      onClick={() => {
-        setKebabIsOpen(false);
-      }}
-    >
-      View migration plan resources (DEBUG)
-    </DropdownItem>,
   ];
   return (
     <Flex>

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -77,6 +77,9 @@ export const findCurrentStep = (pipeline: IStep[]): IStep => {
 };
 
 export const getPipelineSummaryTitle = (migration: IMigration): string => {
+  if (migration === null || !migration) {
+    return MigrationStepsType.NotStarted;
+  }
   const { status, tableStatus } = migration;
   const currentStep = findCurrentStep(status?.pipeline || []);
   if (status?.phase === 'Completed') {

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsPage.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useEffect } from 'react';
+import React from 'react';
 
-import { useParams, Link } from 'react-router-dom';
-import { connect } from 'react-redux';
+import { useParams, Link, useRouteMatch } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import {
   PageSection,
@@ -16,21 +16,16 @@ import {
 } from '@patternfly/react-core';
 import { Alert } from '@patternfly/react-core';
 
-import { IReduxState } from '../../../../../../reducers';
 import { IMigration, IPlan } from '../../../../../plan/duck/types';
 import { planSelectors } from '../../../../../plan/duck';
 import MigrationDetailsTable from './MigrationDetailsTable';
 import { formatGolangTimestamp } from '../../helpers';
 
-interface IMigrationDetailsPageProps {
-  planList: IPlan[];
-  isFetchingInitialPlans: boolean;
-}
-
-const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPageProps> = ({
-  planList,
-}: IMigrationDetailsPageProps) => {
+export const MigrationDetailsPage: React.FunctionComponent = () => {
   const { planName, migrationID } = useParams();
+  const { path, url } = useRouteMatch();
+
+  const planList = useSelector((state) => planSelectors.getPlansWithStatus(state));
   const migration = planList
     .find((planItem: IPlan) => planItem.MigPlan.metadata.name === planName)
     ?.Migrations.find((migration: IMigration) => migration.metadata.name === migrationID);
@@ -140,7 +135,3 @@ const BaseMigrationDetailsPage: React.FunctionComponent<IMigrationDetailsPagePro
     </>
   );
 };
-
-export const MigrationDetailsPage = connect((state: IReduxState) => ({
-  planList: planSelectors.getPlansWithStatus(state),
-}))(BaseMigrationDetailsPage);

--- a/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationDetailsPage/MigrationDetailsTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Table, TableBody, TableHeader, cellWidth, IRow } from '@patternfly/react-table';
 import { Bullseye, EmptyState, Title, Progress, ProgressSize } from '@patternfly/react-core';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useRouteMatch } from 'react-router-dom';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IMigration, IStep } from '../../../../../plan/duck/types';
 import { getElapsedTime, getProgressValues } from '../../helpers';
@@ -16,6 +16,7 @@ interface IProps {
 
 const MigrationDetailsTable: React.FunctionComponent<IProps> = ({ migration }) => {
   const { planName } = useParams();
+  const { path, url } = useRouteMatch();
   const columns = [
     { title: 'Step', transforms: [cellWidth(20)] },
     { title: 'Elapsed time', transforms: [cellWidth(20)] },
@@ -60,9 +61,7 @@ const MigrationDetailsTable: React.FunctionComponent<IProps> = ({ migration }) =
               </>
             ) : progressInfo.detailsAvailable ? (
               <>
-                <Link to={`/plans/${planName}/migrations/${migration.metadata.name}/${step.name}`}>
-                  View Details
-                </Link>
+                <Link to={`${url}/${step.name}`}>View Details</Link>
               </>
             ) : (
               ''

--- a/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationStepDetailsPage/MigrationStepDetailsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import {
   PageSection,
   Title,
@@ -14,20 +14,14 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
-import { IReduxState } from '../../../../../../reducers';
 import { IStep, IMigration, IPlan } from '../../../../../plan/duck/types';
-import { PlanActions, planSelectors } from '../../../../../plan/duck';
+import { planSelectors } from '../../../../../plan/duck';
 import MigrationStepDetailsTable from './MigrationStepDetailsTable';
 import { getStepPageTitle, formatGolangTimestamp } from '../../helpers';
 
-interface IMigrationStepDetailsPageProps {
-  planList: IPlan[];
-}
-
-const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetailsPageProps> = ({
-  planList,
-}: IMigrationStepDetailsPageProps) => {
+export const MigrationStepDetailsPage: React.FunctionComponent = () => {
   const { planName, migrationID, stepName } = useParams();
+  const planList = useSelector((state) => planSelectors.getPlansWithStatus(state));
 
   const migration = planList
     .find((planItem: IPlan) => planItem.MigPlan.metadata.name === planName)
@@ -96,13 +90,3 @@ const BaseMigrationStepDetailsPage: React.FunctionComponent<IMigrationStepDetail
     </>
   );
 };
-
-export const MigrationStepDetailsPage = connect(
-  (state: IReduxState) => ({
-    planList: planSelectors.getPlansWithStatus(state),
-  }),
-  (dispatch) => ({
-    refreshAnalyticRequest: (analyticName: string) =>
-      dispatch(PlanActions.refreshAnalyticRequest(analyticName)),
-  })
-)(BaseMigrationStepDetailsPage);

--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -131,7 +131,7 @@ const getFilteredNamespaces = createSelector(
 const getPlansWithPlanStatus = createSelector(
   [planSelector, lockedPlansSelector],
   (plans, lockedPlans) => {
-    const plansWithStatus = plans.map((plan) => {
+    const plansWithStatus: IPlan[] = plans.map((plan) => {
       const isPlanLocked = !!lockedPlans.some(
         (lockedPlan) => lockedPlan === plan.MigPlan.metadata.name
       );
@@ -480,7 +480,8 @@ const getPlansWithStatus = createSelector([getPlansWithPlanStatus], (plans) => {
           const currentStep = findCurrentStep(migration?.status?.pipeline || []);
           if (step === currentStep) {
             const isError = tableStatus.isFailed || tableStatus.migrationState === 'error';
-            const isWarning = tableStatus.warnings.length || tableStatus.migrationState === 'warn';
+            const isWarning =
+              tableStatus.warnings.length > 0 || tableStatus.migrationState === 'warn';
             const newStep = {
               ...step,
               isError: isError,

--- a/src/layout/AppLayout.module.scss
+++ b/src/layout/AppLayout.module.scss
@@ -12,3 +12,7 @@
   margin: 0.5em 0 0.5em 0;
   vertical-align: middle;
 }
+
+.sidebarModifier {
+  // height: 100vh;
+}

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -89,7 +89,12 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
     <SkipToContent href="#primary-app-container">Skip to Content</SkipToContent>
   );
   const Sidebar = (
-    <PageSidebar theme="dark" nav={nav} isNavOpen={isMobileView ? isNavOpenMobile : isNavOpen} />
+    <PageSidebar
+      className={styles.sidebarModifier}
+      theme="dark"
+      nav={nav}
+      isNavOpen={isMobileView ? isNavOpenMobile : isNavOpen}
+    />
   );
   return (
     <Page

--- a/src/layout/global.scss
+++ b/src/layout/global.scss
@@ -8,7 +8,7 @@ html,
 body,
 #root {
   height: 100%;
-  overflow: hidden;
+  overflow-y: hidden;
 }
 
 .storage-modal-modifier {
@@ -21,4 +21,12 @@ body,
 
 .modal-in-modal-container .pf-c-backdrop {
   z-index: 600;
+}
+
+.pf-c-tree-view__node-text {
+  width: 100% !important;
+}
+
+.pf-c-page {
+  height: 102%;
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -47,12 +47,6 @@ const AppRoutes: React.FunctionComponent<IProps> = ({
             <Route path="/handle-login" component={LoginHandlerComponent} />
             <Route path="/auth-error" component={AuthErrorComponent} />
             <PrivateRoute
-              path={RAW_OBJECT_VIEW_ROUTE}
-              isLoggedIn={isLoggedIn}
-              component={RawDebugObjectView}
-              componentProps={{ debugTree }}
-            />
-            <PrivateRoute
               path="/"
               isLoggedIn={isLoggedIn}
               component={HomeComponent}

--- a/src/sagas.ts
+++ b/src/sagas.ts
@@ -37,6 +37,7 @@ export default function* rootSaga() {
     appStarted(),
     debugSagas.watchDebugObjectFetchRequest(),
     debugSagas.watchDebugTreeFetchRequest(),
+    debugSagas.watchDebugPolling(),
     commonSagas.watchPlanPolling(),
     commonSagas.watchClustersPolling(),
     commonSagas.watchStoragePolling(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8975,6 +8975,11 @@ tslib@1.13.0, tslib@^1.11.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
+tslib@1.13.0, tslib@^1.11.1, tslib@^1.9.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
 tslib@^1.10.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"


### PR DESCRIPTION
* grab status from discovery service

* add warningicon

cleanup

cleanup

cleanup

* wip

* fix expand bug on tooltip click

* Add text changes for tooltip

* clean up mig table and mig actions

* move drill down components to a nested route

* fix nested routes

* upgrade pf and move debug view to expandable card

* remove debug & logs options from the plan actions dropdown

* add polling for tree view

* webpack fix

* wip

* add selectors for velero CRs

* finish selector logic

* finish adding debug status

* fix loading state and add cleanup

* fix rebase

* fix sidebar height

* add kind meta to promise object for plan/migration types with missing king

* Finish styling tree

* align status column

* add active style

* fix overflow issue

* fix view json bug

* add JSON view card

* cleanup when switching plans

* add direct volume case and fix condition check

* Add plan status to debug view

* abstract migraton status icon out of pipeline

* wire in migration and plan status to debug view

* integrate migplan/migmigration status into tree view

* fix type error