### PR TITLE
Add scroll to card effect for view json functionality

### DIFF
--- a/src/app/debug/components/RawDebugObjectView.tsx
+++ b/src/app/debug/components/RawDebugObjectView.tsx
@@ -20,7 +20,7 @@ import {
 } from '@patternfly/react-core';
 import { QuestionCircleIcon, TimesIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactJson from 'react-json-view';
 import { useDispatch, useSelector } from 'react-redux';
 import { clearJSONView } from '../duck/slice';
@@ -32,6 +32,10 @@ const RawDebugObjectView: React.FunctionComponent = () => {
   const closeJSONView = () => {
     dispatch(clearJSONView());
   };
+  useEffect(() => {
+    const anchor = document.querySelector('#view-json-id');
+    anchor.scrollIntoView({ behavior: 'smooth', inline: 'start' });
+  }, []);
   return (
     <>
       <PageSection>

--- a/src/app/home/HomeComponent.tsx
+++ b/src/app/home/HomeComponent.tsx
@@ -32,7 +32,11 @@ const HomeComponent: React.FunctionComponent = () => {
           <Route path="/plans/:planName/migrations">
             <MigrationsPage />
             <PlanDebugPage />
-            {debug.objJson && <RawDebugObjectView />}
+            {debug.objJson && (
+              <div id="view-json-id">
+                <RawDebugObjectView />
+              </div>
+            )}
           </Route>
           <Route exact path="/hooks">
             <HooksPage />

--- a/src/layout/global.scss
+++ b/src/layout/global.scss
@@ -28,5 +28,5 @@ body,
 }
 
 .pf-c-page {
-  height: 102%;
+  height: 108%;
 }


### PR DESCRIPTION
Fixes a poor user experience bug where the json view card would be rendered outside of the viewport. This adds a scroll animation to the viewjson div when the card is initially redered.