### PR TITLE
[MIG-620] Remove progress percentage value from progress message as it is already shown on the progress bar

### DIFF
--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -189,7 +189,9 @@ export const getMigrationStepProgress = (progressLine: string): IStepProgressInf
   // Parse the <message> field in progress line
   const strippedMessage = progressLine.replace(durationRegex, '');
   const messageRegex = /.*?: (.*)/;
-  const message = messageRegex.test(strippedMessage) ? strippedMessage.match(messageRegex)[1] : '';
+  let message = messageRegex.test(strippedMessage) ? strippedMessage.match(messageRegex)[1] : '';
+  // strip progress percentage from message as the progress bar already shows it
+  message = message.replace(/[\d\.]*%/, '');
 
   // Progress parsing for Velero Backup / Restore
   const progressRegex = /.*?([\d\.]*) *(bytes|kB|MB|GB|TB|PB|EB)* out of (estimated total of| )*([\d\.]*) *(bytes|MB|kB|GB|TB|PB|EB)*/;


### PR DESCRIPTION
Removes redundant progress percentage value from <message> part of a progress string.
![Screenshot from 2021-04-23 08-51-55](https://user-images.githubusercontent.com/9839757/115874438-185c4980-a412-11eb-8898-1e4f3c9206bb.png)
