### PR TITLE
Use stage, migration, rollback in migmigration names

### DIFF
--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -750,12 +750,13 @@ function* runStageSaga(action) {
     const { migMeta } = state.auth;
     const client: IClusterClient = ClientFactory.cluster(state);
     const { plan } = action;
+    const migrationName = `stage-${uuidv1().slice(0, 5)}`;
 
     yield put(PlanActions.initStage(plan.MigPlan.metadata.name));
     yield put(AlertActions.alertProgressTimeout('Staging Started'));
 
     const migMigrationObj = createMigMigration(
-      uuidv1(),
+      migrationName,
       plan.MigPlan.metadata.name,
       migMeta.namespace,
       true,
@@ -880,11 +881,12 @@ function* runMigrationSaga(action) {
     const state: IReduxState = yield select();
     const { migMeta } = state.auth;
     const client: IClusterClient = ClientFactory.cluster(state);
+    const migrationName = `migration-${uuidv1().slice(0, 5)}`;
     yield put(PlanActions.initMigration(plan.MigPlan.metadata.name));
     yield put(AlertActions.alertProgressTimeout('Migration Started'));
 
     const migMigrationObj = createMigMigration(
-      uuidv1(),
+      migrationName,
       plan.MigPlan.metadata.name,
       migMeta.namespace,
       false,
@@ -1007,12 +1009,13 @@ function* runRollbackSaga(action) {
     const { migMeta } = state.auth;
     const client: IClusterClient = ClientFactory.cluster(state);
     const { plan } = action;
+    const migrationName = `rollback-${uuidv1().slice(0, 5)}`;
 
     yield put(PlanActions.initStage(plan.MigPlan.metadata.name));
     yield put(AlertActions.alertProgressTimeout('Rollback Started'));
 
     const migMigrationObj = createMigMigration(
-      uuidv1(),
+      migrationName,
       plan.MigPlan.metadata.name,
       migMeta.namespace,
       false,


### PR DESCRIPTION
This changes the migmigration names generated by the UI to be meaningful with a shorter 5 char UUID for easier readability and human identification.

The chance of collision with a 5 char UUID is 36^5 (1 / 60466176). I think we can live with that for the easier readability benefits it provides.  

![image](https://user-images.githubusercontent.com/7576968/116589765-fae41f80-a8ea-11eb-9e5c-b4ba1a9a05c0.png)
