### PR TITLE
Style pending debug resources in yellow highlighting

### DIFF
--- a/src/app/debug/duck/utils.module.scss
+++ b/src/app/debug/duck/utils.module.scss
@@ -17,9 +17,19 @@
   text-overflow: ellipsis;
 }
 
-.activeHighlight {
+.activeHighlightRunning {
   background-color: #bee1f4;
   border: #bee1f4 solid 1px;
+  border-radius: 7px;
+  font-weight: bold;
+  & > div {
+    padding: 15px 0 15px 0;
+  }
+}
+
+.activeHighlightPending {
+  background-color: #f4eebe;
+  border: #f4eebe solid 1px;
   border-radius: 7px;
   font-weight: bold;
   & > div {

--- a/src/app/debug/duck/utils.tsx
+++ b/src/app/debug/duck/utils.tsx
@@ -17,10 +17,17 @@ const getShallowPropsForNode = (
   const nodeIdentifier = rawNode.namespace
     ? `${rawNode.kind}: ${rawNode.clusterType}/${rawNode.namespace}/${rawNode.name}`
     : `${rawNode.kind}: ${rawNode.clusterType}/${rawNode.name}`;
+  
+  let highlightStyle = null;
+  if (matchingDebugRef?.debugResourceStatus?.hasRunning) {
+    highlightStyle = styles.activeHighlightRunning;
+  } else if (matchingDebugRef?.debugResourceStatus?.hasPending) {
+    highlightStyle = styles.activeHighlightPending;
+  }
   return {
     id: rawNode.name,
     name: (
-      <Flex className={matchingDebugRef?.debugResourceStatus?.hasRunning && styles.activeHighlight}>
+      <Flex className={highlightStyle}>
         <FlexItem className={styles.treeID}>{`${nodeIdentifier}`}</FlexItem>
         <FlexItem className={styles.statusIcon}>
           <div className={styles.alignStatus}>


### PR DESCRIPTION
I realized it's really important to show the user which resources are pending, because pending things, by definition, hold up the migration. 

Right now the blue highlighting kind of overshadows the (unhighlighted) pending resources where the action is happening. I mocked out what it would look like to highlight pending in yellow. 

Please ignore the "active" DVMPs, those need their status fixed, they aren't actually tracking an active transfer yet.

![image](https://user-images.githubusercontent.com/7576968/116750287-386ea880-a9d0-11eb-9245-e5f9ed695342.png)
