### PR TITLE
Add storage pending status when adding/editing

### DIFF
--- a/src/app/home/pages/StoragesPage/StoragesPage.tsx
+++ b/src/app/home/pages/StoragesPage/StoragesPage.tsx
@@ -27,14 +27,18 @@ import { IPlanCountByResourceName } from '../../../common/duck/types';
 import { IReduxState } from '../../../../reducers';
 
 interface IStoragesPageBaseProps {
+  currentStorage: IStorage;
   storageList: IStorage[];
   storageAssociatedPlans: IPlanCountByResourceName;
   watchStorageAddEditStatus: (storageName: string) => void;
   removeStorage: (storageName: string) => void;
+  setCurrentStorage: (storage: IStorage) => void;
   isFetchingInitialStorages: boolean;
 }
 
 const StoragesPageBase: React.FunctionComponent<IStoragesPageBaseProps> = ({
+  currentStorage,
+  setCurrentStorage,
   storageList,
   storageAssociatedPlans,
   watchStorageAddEditStatus,
@@ -42,7 +46,6 @@ const StoragesPageBase: React.FunctionComponent<IStoragesPageBaseProps> = ({
   isFetchingInitialStorages,
 }: IStoragesPageBaseProps) => {
   const [isAddEditModalOpen, toggleAddEditModal] = useOpenModal(false);
-  const [currentStorage, setCurrentStorage] = useState(null);
   return (
     <>
       <PageSection variant="light">
@@ -67,9 +70,7 @@ const StoragesPageBase: React.FunctionComponent<IStoragesPageBaseProps> = ({
         ) : (
           <Card>
             <CardBody>
-              <StorageContext.Provider
-                value={{ watchStorageAddEditStatus, setCurrentStorage, currentStorage }}
-              >
+              <StorageContext.Provider value={{ watchStorageAddEditStatus }}>
                 {!storageList ? null : storageList.length === 0 ? (
                   <EmptyState variant="full">
                     <EmptyStateIcon icon={AddCircleOIcon} />
@@ -94,7 +95,6 @@ const StoragesPageBase: React.FunctionComponent<IStoragesPageBaseProps> = ({
                   isOpen={isAddEditModalOpen}
                   onHandleClose={() => {
                     toggleAddEditModal();
-                    setCurrentStorage(null);
                   }}
                 />
               </StorageContext.Provider>
@@ -110,6 +110,7 @@ const mapStateToProps = (state: IReduxState) => ({
   storageList: storageSelectors.getAllStorage(state),
   storageAssociatedPlans: storageSelectors.getAssociatedPlans(state),
   isFetchingInitialStorages: state.storage.isFetchingInitialStorages,
+  currentStorage: state.storage.currentStorage,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -124,6 +125,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
   removeStorage: (storageName: string) =>
     dispatch(StorageActions.removeStorageRequest(storageName)),
+  setCurrentStorage: (storage: IStorage) => dispatch(StorageActions.setCurrentStorage(storage)),
 });
 
 export const StoragesPage = connect(mapStateToProps, mapDispatchToProps)(StoragesPageBase);

--- a/src/app/home/pages/StoragesPage/StoragesPage.tsx
+++ b/src/app/home/pages/StoragesPage/StoragesPage.tsx
@@ -86,6 +86,8 @@ const StoragesPageBase: React.FunctionComponent<IStoragesPageBaseProps> = ({
                     associatedPlans={storageAssociatedPlans}
                     toggleAddEditModal={toggleAddEditModal}
                     removeStorage={removeStorage}
+                    setCurrentStorage={setCurrentStorage}
+                    currentStorage={currentStorage}
                   />
                 )}
                 <AddEditStorageModal

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { Form, FormGroup } from '@patternfly/react-core';
 import S3Form from './ProviderForms/S3Form';
 import GCPForm from './ProviderForms/GCPForm';
 import AzureForm from './ProviderForms/AzureForm';
-import { StorageContext } from '../../../../duck/context';
 import { IStorage } from '../../../../../storage/duck/types';
 import SimpleSelect, { OptionWithValue } from '../../../../../common/components/SimpleSelect';
 import { usePausedPollingEffect } from '../../../../../common/context/PollingContext';
@@ -14,6 +13,7 @@ interface IOtherProps {
   addEditStatus: any;
   checkConnection: (name) => void;
   storageList: IStorage[];
+  currentStorage: IStorage;
 }
 
 interface IProviderOption extends OptionWithValue {
@@ -23,10 +23,10 @@ interface IProviderOption extends OptionWithValue {
 const AddEditStorageForm = (props: IOtherProps) => {
   usePausedPollingEffect();
 
-  const { storageList } = props;
-  const storageContext = useContext(StorageContext);
+  const { storageList, currentStorage } = props;
   const storage = storageList.find(
-    (storageItem) => storageItem.MigStorage.metadata.name === storageContext.currentStorage
+    (storageItem) =>
+      storageItem.MigStorage.metadata.name === currentStorage?.MigStorage?.metadata?.name
   );
 
   let name;

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/index.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/index.tsx
@@ -25,6 +25,8 @@ interface IAddEditClusterModal {
   resetAddEditState: () => void;
   resetStoragePage: () => void;
   updateStorage: (updatedStorage) => void;
+  setCurrentStorage: (currentStorage: IStorage) => void;
+  currentStorage: IStorage;
 }
 const AddEditStorageModal = ({
   addEditStatus,
@@ -37,9 +39,9 @@ const AddEditStorageModal = ({
   resetAddEditState,
   onHandleClose,
   resetStoragePage,
+  setCurrentStorage,
+  currentStorage,
 }: IAddEditClusterModal) => {
-  const storageContext = useContext(StorageContext);
-
   const onAddEditSubmit = (storageValues) => {
     switch (addEditStatus.mode) {
       case AddEditMode.Edit: {
@@ -48,7 +50,6 @@ const AddEditStorageModal = ({
       }
       case AddEditMode.Add: {
         addStorage(storageValues);
-        storageContext.setCurrentStorage(storageValues.name);
         break;
       }
       default: {
@@ -64,6 +65,7 @@ const AddEditStorageModal = ({
     resetAddEditState();
     onHandleClose();
     resetStoragePage();
+    setCurrentStorage(null);
   };
 
   const modalTitle =
@@ -85,6 +87,7 @@ const AddEditStorageModal = ({
         addEditStatus={addEditStatus}
         checkConnection={checkConnection}
         storageList={storageList}
+        currentStorage={currentStorage}
       />
     </Modal>
   );
@@ -97,6 +100,7 @@ export default connect(
       isPolling: state.storage.isPolling,
       storageList: state.storage.migStorageList,
       isLoadingStorage: state.storage.isLoadingStorage,
+      currentStorage: state.storage.currentStorage,
     };
   },
   (dispatch) => ({
@@ -116,5 +120,7 @@ export default connect(
       dispatch(StorageActions.watchStorageAddEditStatus(storageName));
     },
     resetStoragePage: () => dispatch(StorageActions.resetStoragePage()),
+    setCurrentStorage: (currentStorage: IStorage) =>
+      dispatch(StorageActions.setCurrentStorage(currentStorage)),
   })
 )(AddEditStorageModal);

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/index.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/index.tsx
@@ -9,29 +9,45 @@ import {
   defaultAddEditStatus,
   createAddEditStatus,
   AddEditState,
+  IAddEditStatus,
 } from '../../../../../common/add_edit_state';
+import { IStorage } from '../../../../../storage/duck/types';
 
-// TODO add types here
+interface IAddEditClusterModal {
+  addEditStatus: IAddEditStatus;
+  isOpen: boolean;
+  isPolling: boolean;
+  checkConnection: (name) => void;
+  storageList: IStorage[];
+  addStorage: (storage) => void;
+  cancelAddEditWatch: () => void;
+  onHandleClose: () => void;
+  resetAddEditState: () => void;
+  resetStoragePage: () => void;
+  updateStorage: (updatedStorage) => void;
+}
 const AddEditStorageModal = ({
   addEditStatus,
   isOpen,
-  isPolling,
   storageList,
   checkConnection,
-  isLoadingStorage,
-  initialStorageValues,
-  ...props
-}) => {
+  updateStorage,
+  addStorage,
+  cancelAddEditWatch,
+  resetAddEditState,
+  onHandleClose,
+  resetStoragePage,
+}: IAddEditClusterModal) => {
   const storageContext = useContext(StorageContext);
 
   const onAddEditSubmit = (storageValues) => {
     switch (addEditStatus.mode) {
       case AddEditMode.Edit: {
-        props.updateStorage(storageValues);
+        updateStorage(storageValues);
         break;
       }
       case AddEditMode.Add: {
-        props.addStorage(storageValues);
+        addStorage(storageValues);
         storageContext.setCurrentStorage(storageValues.name);
         break;
       }
@@ -44,9 +60,10 @@ const AddEditStorageModal = ({
   };
 
   const onClose = () => {
-    props.cancelAddEditWatch();
-    props.resetAddEditState();
-    props.onHandleClose();
+    cancelAddEditWatch();
+    resetAddEditState();
+    onHandleClose();
+    resetStoragePage();
   };
 
   const modalTitle =
@@ -98,5 +115,6 @@ export default connect(
       );
       dispatch(StorageActions.watchStorageAddEditStatus(storageName));
     },
+    resetStoragePage: () => dispatch(StorageActions.resetStoragePage()),
   })
 )(AddEditStorageModal);

--- a/src/app/home/pages/StoragesPage/components/StorageActionsDropdown.tsx
+++ b/src/app/home/pages/StoragesPage/components/StorageActionsDropdown.tsx
@@ -10,17 +10,22 @@ import { IStorageInfo } from '../helpers';
 import { useOpenModal } from '../../../duck';
 import { StorageContext } from '../../../duck/context';
 import ConfirmModal from '../../../../common/components/ConfirmModal';
+import { IStorage } from '../../../../storage/duck/types';
 
 interface IStorageActionsDropdownProps {
+  storage: IStorage;
   storageInfo: IStorageInfo;
   removeStorage: (storageName: string) => void;
   toggleAddEditModal: () => void;
+  setCurrentStorage: (currentStorage: IStorage) => void;
 }
 
 const StorageActionsDropdown: React.FunctionComponent<IStorageActionsDropdownProps> = ({
   storageInfo,
   removeStorage,
   toggleAddEditModal,
+  setCurrentStorage,
+  storage,
 }: IStorageActionsDropdownProps) => {
   const { storageName, associatedPlanCount } = storageInfo;
 
@@ -68,6 +73,7 @@ const StorageActionsDropdown: React.FunctionComponent<IStorageActionsDropdownPro
             onClick={() => {
               setKebabIsOpen(false);
               editStorage();
+              setCurrentStorage(storage);
             }}
             key="editStorage"
           >

--- a/src/app/home/pages/StoragesPage/components/StorageActionsDropdown.tsx
+++ b/src/app/home/pages/StoragesPage/components/StorageActionsDropdown.tsx
@@ -43,12 +43,6 @@ const StorageActionsDropdown: React.FunctionComponent<IStorageActionsDropdownPro
 
   const storageContext = useContext(StorageContext);
 
-  const editStorage = () => {
-    storageContext.watchStorageAddEditStatus(storageName);
-    storageContext.setCurrentStorage(storageName);
-    toggleAddEditModal();
-  };
-
   const removeItem = (
     <DropdownItem
       onClick={() => {
@@ -72,8 +66,9 @@ const StorageActionsDropdown: React.FunctionComponent<IStorageActionsDropdownPro
           <DropdownItem
             onClick={() => {
               setKebabIsOpen(false);
-              editStorage();
+              storageContext.watchStorageAddEditStatus(storageName);
               setCurrentStorage(storage);
+              toggleAddEditModal();
             }}
             key="editStorage"
           >

--- a/src/app/home/pages/StoragesPage/components/StoragesTable.tsx
+++ b/src/app/home/pages/StoragesPage/components/StoragesTable.tsx
@@ -12,12 +12,15 @@ import StorageActionsDropdown from './StorageActionsDropdown';
 import { IStorage } from '../../../../storage/duck/types';
 import { IPlanCountByResourceName } from '../../../../common/duck/types';
 import { usePaginationState } from '../../../../common/duck/hooks/usePaginationState';
+import PendingIcon from '@patternfly/react-icons/dist/js/icons/pending-icon';
 
 interface IStoragesTableProps {
   storageList: IStorage[];
   associatedPlans: IPlanCountByResourceName;
   toggleAddEditModal: () => void;
   removeStorage: (storageName: string) => void;
+  setCurrentStorage: (currentCluster: IStorage) => void;
+  currentStorage: IStorage;
 }
 
 const StoragesTable: React.FunctionComponent<IStoragesTableProps> = ({
@@ -25,6 +28,8 @@ const StoragesTable: React.FunctionComponent<IStoragesTableProps> = ({
   associatedPlans,
   toggleAddEditModal,
   removeStorage,
+  currentStorage,
+  setCurrentStorage,
 }: IStoragesTableProps) => {
   const hasSomeLocationValue = storageList.some(
     (storage) => !!getStorageInfo(storage, associatedPlans).s3Url
@@ -75,10 +80,19 @@ const StoragesTable: React.FunctionComponent<IStoragesTableProps> = ({
         },
         {
           title: (
-            <StatusIcon
-              status={storageStatus ? StatusType.Ok : StatusType.Error}
-              label={storageStatus ? 'Connected' : 'Connection Failed'}
-            />
+            <>
+              {storageName === currentStorage?.MigStorage?.metadata?.name ? (
+                <div>
+                  <PendingIcon className="pf-c-icon pf-m-default"> </PendingIcon>
+                  <span className={spacing.mlSm}> Pending </span>
+                </div>
+              ) : (
+                <StatusIcon
+                  status={storageStatus ? StatusType.Ok : StatusType.Error}
+                  label={storageStatus ? 'Connected' : 'Connection Failed'}
+                />
+              )}
+            </>
           ),
         },
         {
@@ -87,6 +101,8 @@ const StoragesTable: React.FunctionComponent<IStoragesTableProps> = ({
               storageInfo={storageInfo}
               removeStorage={removeStorage}
               toggleAddEditModal={toggleAddEditModal}
+              storage={storage}
+              setCurrentStorage={setCurrentStorage}
             />
           ),
         },

--- a/src/app/storage/duck/actions.ts
+++ b/src/app/storage/duck/actions.ts
@@ -1,5 +1,6 @@
 import { IAddEditStatus } from '../../common/add_edit_state';
 import { IMigStorage } from '../../../client/resources/conversions';
+import { IStorage } from './types';
 
 export const StorageActionTypes = {
   MIG_STORAGE_FETCH_REQUEST: 'MIG_STORAGE_FETCH_REQUEST',
@@ -21,6 +22,8 @@ export const StorageActionTypes = {
   UPDATE_STORAGES: 'UPDATE_STORAGES',
   STORAGE_POLL_START: 'STORAGE_POLL_START',
   STORAGE_POLL_STOP: 'STORAGE_POLL_STOP',
+  RESET_STORAGE_PAGE: 'RESET_STORAGE_PAGE',
+  SET_CURRENT_STORAGE: 'SET_CURRENT_STORAGE',
 };
 
 const updateStorageSearchText = (StorageSearchText: string) => ({
@@ -114,6 +117,17 @@ const stopStoragePolling = () => ({
   type: StorageActionTypes.STORAGE_POLL_STOP,
 });
 
+const resetStoragePage = () => ({
+  type: StorageActionTypes.RESET_STORAGE_PAGE,
+});
+
+const setCurrentStorage = (currentStorage: IStorage) => {
+  return {
+    type: StorageActionTypes.SET_CURRENT_STORAGE,
+    currentStorage,
+  };
+};
+
 export const StorageActions = {
   updateSearchTerm,
   setStorageAddEditStatus,
@@ -134,4 +148,6 @@ export const StorageActions = {
   updateStorages,
   startStoragePolling,
   stopStoragePolling,
+  resetStoragePage,
+  setCurrentStorage,
 };

--- a/src/app/storage/duck/reducers.ts
+++ b/src/app/storage/duck/reducers.ts
@@ -170,6 +170,8 @@ const storageReducer: StorageReducerFn = (state = INITIAL_STATE, action) => {
       return stopStoragePolling(state, action);
     case StorageActionTypes.RESET_STORAGE_PAGE:
       return resetStoragePage(state, action);
+    case StorageActionTypes.SET_CURRENT_STORAGE:
+      return setCurrentStorage(state, action);
     default:
       return state;
   }

--- a/src/app/storage/duck/reducers.ts
+++ b/src/app/storage/duck/reducers.ts
@@ -12,6 +12,7 @@ export interface IStorageReducerState {
   searchTerm: string;
   addEditStatus: IAddEditStatus;
   isFetchingInitialStorages: boolean;
+  currentStorage: IStorage;
 }
 
 type StorageReducerFn = (state: IStorageReducerState, action: any) => IStorageReducerState;
@@ -25,6 +26,14 @@ export const INITIAL_STATE: IStorageReducerState = {
   searchTerm: '',
   addEditStatus: defaultAddEditStatus(),
   isFetchingInitialStorages: true,
+  currentStorage: null,
+};
+
+export const setCurrentStorage: StorageReducerFn = (state = INITIAL_STATE, action) => {
+  return {
+    ...state,
+    currentStorage: action.currentStorage,
+  };
 };
 
 export const migStorageFetchRequest: StorageReducerFn = (state = INITIAL_STATE, action) => {
@@ -36,6 +45,7 @@ export const migStorageFetchSuccess: StorageReducerFn = (state = INITIAL_STATE, 
     ...state,
     migStorageList: action.migStorageList,
     isFetching: false,
+    isFetchingInitialStorages: false,
   };
 };
 export const migStorageFetchFailure: StorageReducerFn = (state = INITIAL_STATE, action) => {
@@ -43,6 +53,7 @@ export const migStorageFetchFailure: StorageReducerFn = (state = INITIAL_STATE, 
     ...state,
     isError: true,
     isFetching: false,
+    isFetchingInitialStorages: false,
   };
 };
 
@@ -122,6 +133,13 @@ export const stopStoragePolling: StorageReducerFn = (state = INITIAL_STATE, acti
   };
 };
 
+export const resetStoragePage: StorageReducerFn = (state = INITIAL_STATE, action) => {
+  return {
+    ...state,
+    isFetchingInitialStorages: true,
+  };
+};
+
 const storageReducer: StorageReducerFn = (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case StorageActionTypes.MIG_STORAGE_FETCH_REQUEST:
@@ -150,6 +168,8 @@ const storageReducer: StorageReducerFn = (state = INITIAL_STATE, action) => {
       return startStoragePolling(state, action);
     case StorageActionTypes.STORAGE_POLL_STOP:
       return stopStoragePolling(state, action);
+    case StorageActionTypes.RESET_STORAGE_PAGE:
+      return resetStoragePage(state, action);
     default:
       return state;
   }

--- a/src/app/storage/duck/sagas.ts
+++ b/src/app/storage/duck/sagas.ts
@@ -199,6 +199,7 @@ function* addStorageRequest(action) {
     }, {});
 
     yield put(StorageActions.addStorageSuccess(storage));
+    yield put(StorageActions.setCurrentStorage(storage));
 
     // Push into watching state
     yield put(
@@ -384,6 +385,8 @@ function* updateStorageRequest(action) {
     // Update the state tree with the updated storage, and start to watch
     // again to check for its condition after edits
     yield put(StorageActions.updateStorageSuccess(updatedStorage));
+    yield put(StorageActions.setCurrentStorage(updatedStorage));
+
     yield put(
       StorageActions.setStorageAddEditStatus(
         createAddEditStatus(AddEditState.Watching, AddEditMode.Edit)


### PR DESCRIPTION
Add https://github.com/konveyor/mig-ui/pull/1195 functionality for storage add/edit. 

When adding/editing a storage, you will now see a pending status instead of incorrect status in the background table. Also fixes the flash of incorrect status when closing a the storage add/adit modal.