### PR TITLE
Add pending state to PVR/PVB/Backup/Restore

### DIFF
--- a/src/app/debug/duck/selectors.ts
+++ b/src/app/debug/duck/selectors.ts
@@ -184,6 +184,7 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
       const hasFailure = errors?.length > 0 || phase === 'Failed';
       const hasCompleted = phase === 'Completed';
       const hasRunning = phase === 'InProgress';
+      const hasPending = phase === undefined;
       const hasTerminating = deletionTimestamp != undefined;
       return {
         hasWarning,
@@ -191,13 +192,14 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
         hasCompleted,
         hasRunning,
         hasTerminating,
+        hasPending,
         currentStatus: calculateCurrentStatus(
           hasWarning,
           hasFailure,
           hasCompleted,
           hasRunning,
           hasTerminating,
-          null,
+          hasPending,
           null,
           null,
           null
@@ -211,21 +213,22 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
       const hasFailure = errors?.length > 0 || phase === 'Failed';
       const hasCompleted = phase === 'Completed';
       const hasRunning = phase === 'InProgress';
+      const hasPending = phase === undefined;
       const hasTerminating = deletionTimestamp != undefined;
       return {
         hasWarning,
         hasFailure,
         hasCompleted,
         hasRunning,
-
         hasTerminating,
+        hasPending,
         currentStatus: calculateCurrentStatus(
           hasWarning,
           hasFailure,
           hasCompleted,
           hasRunning,
           hasTerminating,
-          null,
+          hasPending,
           null,
           null,
           null

--- a/src/app/debug/duck/selectors.ts
+++ b/src/app/debug/duck/selectors.ts
@@ -239,6 +239,7 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
       const hasFailure = phase === 'Failed';
       const hasCompleted = phase === 'Completed';
       const hasRunning = phase === 'InProgress';
+      const hasPending = phase === undefined;
       const hasTerminating = deletionTimestamp != undefined;
       return {
         hasWarning,
@@ -246,13 +247,14 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
         hasCompleted,
         hasRunning,
         hasTerminating,
+        hasPending,
         currentStatus: calculateCurrentStatus(
           hasWarning,
           hasFailure,
           hasCompleted,
           hasRunning,
           hasTerminating,
-          null,
+          hasPending,
           null,
           null,
           null
@@ -266,6 +268,7 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
       const hasFailure = phase === 'Failed';
       const hasCompleted = phase === 'Completed';
       const hasRunning = phase === 'InProgress';
+      const hasPending = phase === undefined;
       const hasTerminating = deletionTimestamp != undefined;
       return {
         hasWarning,
@@ -273,13 +276,14 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
         hasCompleted,
         hasRunning,
         hasTerminating,
+        hasPending,
         currentStatus: calculateCurrentStatus(
           hasWarning,
           hasFailure,
           hasCompleted,
           hasRunning,
           hasTerminating,
-          null,
+          hasPending,
           null,
           null,
           null


### PR DESCRIPTION
When these Velero Resources haven't started, show them as "Pending" in the debug view instead of just a blank status.