### PR TITLE
Refresh touched value after changes made to mapping

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/NamespacesTable.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/NamespacesTable.tsx
@@ -347,6 +347,7 @@ const NamespacesTable: React.FunctionComponent<INamespacesTableProps> = ({
                                     }
                                     setFieldValue('editedNamespaces', newEditedNamespaces);
                                     setFieldValue(currentTargetNameKey, null);
+                                    setFieldTouched(currentTargetNameKey, false);
                                   }}
                                 />
                               </span>
@@ -362,6 +363,7 @@ const NamespacesTable: React.FunctionComponent<INamespacesTableProps> = ({
                                 onClick={() => {
                                   setEditableRow(null);
                                   setFieldValue(currentTargetNameKey, null);
+                                  setFieldTouched(currentTargetNameKey, false);
                                 }}
                               />
                             </span>


### PR DESCRIPTION
Fixes small bug with ns mapping validation. After a mapping value has been added to edited values array, reset the touched state so that the validation doesnt immediately show for future edits. 