### PR TITLE
Bug 1966417: Mark DVMP as finished when total progress percent == 100%

### DIFF
--- a/src/app/debug/duck/selectors.ts
+++ b/src/app/debug/duck/selectors.ts
@@ -421,7 +421,7 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
         (c) =>
           checkListContainsString(c.type, ['InvalidPod', 'InvalidPodRef']) || phase === 'Failed'
       );
-      const hasCompleted = phase === 'Succeeded';
+      const hasCompleted = phase === 'Succeeded' || totalProgressPercentage === '100%';
       const hasRunning = totalProgressPercentage !== '0%' && totalProgressPercentage !== '100%';
       const hasPending = !hasRunning && !hasCompleted;
       const hasTerminating = deletionTimestamp != undefined;


### PR DESCRIPTION
Previous
```
const hasCompleted = phase === 'Succeeded';
```

New
```
const hasCompleted = phase === 'Succeeded' || totalProgressPercentage === '100%';
```

![image](https://user-images.githubusercontent.com/7576968/121421381-1a378900-c93c-11eb-8421-b0239ee49cd7.png)
