### PR TITLE
Remove splitter next to view logs button

### DIFF
--- a/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
+++ b/src/app/home/pages/PlansPage/pages/MigrationsPage/MigrationsPage.tsx
@@ -146,9 +146,6 @@ export const MigrationsPage: React.FunctionComponent = () => {
                           View logs
                         </Button>
                       </FlexItem>
-                      <FlexItem className={styles.lineContainer}>
-                        <div className={styles.verticalLine}></div>
-                      </FlexItem>
                       <FlexItem className={styles.kebabContainer}>
                         <Dropdown
                           toggle={<KebabToggle onToggle={() => setKebabIsOpen(!kebabIsOpen)} />}


### PR DESCRIPTION
Discussed with @vconzola, I think this splitter snuck into the mocks from a different mock. We agreed it should be removed.


Previous
![image](https://user-images.githubusercontent.com/7576968/121421941-b5306300-c93c-11eb-9ef0-b127097e6a9f.png)


New
![image](https://user-images.githubusercontent.com/7576968/121421907-a9dd3780-c93c-11eb-9688-48dab51756e1.png)
