### PR TITLE
Move PR-BZ branch_to_release mapping to Org secret

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -33,5 +33,5 @@ jobs:
           bz_product: "Migration Toolkit for Containers"
           title: ${{ github.event.pull_request.title }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch_to_release: "release-1.3.2:1.3.z,release-1.4.4:1.4.4,release-1.4.3:1.4.3,release-1.4.0:1.4.0,release-1.4.5:1.4.5,release-1.5.0:1.5.0,master:1.5.z"
+          branch_to_release: ${{ secrets.BRANCH_TO_RELEASE }}
           base_branch: ${{ github.base_ref }}


### PR DESCRIPTION
Revisiting https://github.com/konveyor/bz-github-action/issues/2

@djwhatle , Given the number of incoming PRs expected for 1.5.0, I'd like to enable this as a trial on mig-ui to exercise the change before rolling it out across the remaining repos.  The intention is to reduce the amount of "lift" required to manage the mapping across all repos every time we need to update it.

cc: @eriknelson 