### PR TITLE
Move PR-BZ branch_to_release mapping to Org secret (#1227)

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -33,5 +33,5 @@ jobs:
           bz_product: "Migration Toolkit for Containers"
           title: ${{ github.event.pull_request.title }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch_to_release: "release-1.3.2:1.3.z,release-1.4.4:1.4.4,release-1.4.3:1.4.3,release-1.4.0:1.4.0,release-1.4.5:1.4.5,release-1.5.0:1.5.0,master:1.5.z"
+          branch_to_release: ${{ secrets.BRANCH_TO_RELEASE }}
           base_branch: ${{ github.base_ref }}


### PR DESCRIPTION
Bring https://github.com/konveyor/mig-ui/pull/1227 into `release-1.5.0` branch