### PR TITLE
Bug 1966417: (Cherry-pick) Show DVMP as completed in debug view if progress is 100% (#1225)

### DIFF
--- a/src/app/debug/duck/selectors.ts
+++ b/src/app/debug/duck/selectors.ts
@@ -421,7 +421,7 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
         (c) =>
           checkListContainsString(c.type, ['InvalidPod', 'InvalidPodRef']) || phase === 'Failed'
       );
-      const hasCompleted = phase === 'Succeeded';
+      const hasCompleted = phase === 'Succeeded' || totalProgressPercentage === '100%';
       const hasRunning = totalProgressPercentage !== '0%' && totalProgressPercentage !== '100%';
       const hasPending = !hasRunning && !hasCompleted;
       const hasTerminating = deletionTimestamp != undefined;


### PR DESCRIPTION
Co-authored-by: Ian Bolton <ibolton@redhat.com>
(cherry picked from commit 93ea7ed70e5c937d0fb431ab26b25c63857c6689)