### PR TITLE
Bug 1936886: - Updating appropriate secret on sa token update on migCluster

### DIFF
--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -408,7 +408,9 @@ function* updateClusterRequest(action: any): Generator<any, any, any> {
     const newTokenSecret = updateTokenSecret(clusterValues.token, isMigTokenSecret);
     const secretResource = new CoreNamespacedResource(
       CoreNamespacedResourceKind.Secret,
-      migMeta.configNamespace
+      getClusterRes?.data?.spec.serviceAccountSecretRef.namespace
+        ? getClusterRes.data.spec.serviceAccountSecretRef.namespace
+        : migMeta.configNamespace
     );
 
     // Pushing a request fn to delay the call until its yielded in a batch at same time


### PR DESCRIPTION
Making sure to update the secret referenced in the cluster when updating a token for source cluster