### PR TITLE
Add namespace to pod log command

### DIFF
--- a/src/app/debug/duck/sagas.ts
+++ b/src/app/debug/duck/sagas.ts
@@ -134,8 +134,6 @@ function* fetchDebugRefs(action: any): Generator<any, any, any> {
               conditions: hookChildren?.job?.value?.data?.object?.status?.conditions,
             };
           }
-          // oc get job - o json | jq - r.items[].spec.backoffLimit
-          // oc get pod -l job-name=plan-hook-prebackup-9nwfd -o json | jq -r '.status.containerStatuses[].restartCount'V
         });
       }
       return {

--- a/src/app/debug/duck/selectors.ts
+++ b/src/app/debug/duck/selectors.ts
@@ -566,7 +566,7 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
         hasReady,
         hasTerminating,
         currentStatus: calculateCurrentStatus(
-          hasWarning || hasEventWarning || !!warningTextArr,
+          hasWarning || hasEventWarning || !!warningTextArr.length,
           hasFailure,
           null,
           null,

--- a/src/app/home/pages/HooksPage/HooksPage.tsx
+++ b/src/app/home/pages/HooksPage/HooksPage.tsx
@@ -29,6 +29,7 @@ import {
   AddEditMode,
   AddEditState,
   createAddEditStatus,
+  defaultAddEditStatus,
   IAddEditStatus,
 } from '../../../common/add_edit_state';
 import { cellWidth, Table, TableBody, TableHeader, truncate } from '@patternfly/react-table';
@@ -53,6 +54,7 @@ interface IHooksPageBaseProps {
   currentPlan: IMigPlan;
   removeHookRequest: (hookName: string) => void;
   watchHookAddEditStatus: (name: string) => void;
+  cancelAddEditWatch?: () => void;
 }
 
 const HooksPageBase: React.FunctionComponent<IHooksPageBaseProps | any> = (
@@ -71,6 +73,7 @@ const HooksPageBase: React.FunctionComponent<IHooksPageBaseProps | any> = (
     watchHookAddEditStatus,
     migMeta,
     isFetchingInitialHooks,
+    cancelAddEditWatch,
   } = props;
 
   const defaultHookRunnerImage = migMeta?.hookRunnerImage || fallbackHookRunnerImage;
@@ -248,6 +251,7 @@ const HooksPageBase: React.FunctionComponent<IHooksPageBaseProps | any> = (
                         setInitialHookValues={setInitialHookValues}
                         setIsAddHooksOpen={setIsAddHooksOpen}
                         currentPlan={currentPlan}
+                        cancelAddEditWatch={cancelAddEditWatch}
                         {...props}
                       />
                     </GridItem>
@@ -330,6 +334,10 @@ const mapDispatchToProps = (dispatch: any) => {
     },
     removeHookRequest: (name: string) => dispatch(PlanActions.removeHookRequest(name)),
     updateHookRequest: (migHook: IMigHook) => dispatch(PlanActions.updateHookRequest(migHook)),
+    cancelAddEditWatch: () => dispatch(PlanActions.cancelWatchHookAddEditStatus()),
+    resetAddEditState: () => {
+      dispatch(PlanActions.setHookAddEditStatus(defaultAddEditStatus()));
+    },
   };
 };
 

--- a/src/app/home/pages/PlanDebugPage/helpers.ts
+++ b/src/app/home/pages/PlanDebugPage/helpers.ts
@@ -101,21 +101,21 @@ export const getDebugCommand = (
       return {
         ocDescribeCommand: `oc describe ${getFullKindName(kind)} --namespace ${namespace} ${name}`,
         ocLogsCommand: logPodName
-          ? `oc logs ${logPodName} -c plain | grep '"dism":"${name}"'`
+          ? `oc -n ${namespace} logs ${logPodName} -c plain | grep '"dism":"${name}"'`
           : `oc logs --selector control-plane=controller-manager --namespace ${namespace} --container mtc | grep '"dism":"${name}"'`,
       };
     case 'DirectVolumeMigrationProgress':
       return {
         ocDescribeCommand: `oc describe ${getFullKindName(kind)} --namespace ${namespace} ${name}`,
         ocLogsCommand: logPodName
-          ? `oc logs ${logPodName} -c plain | grep '"dvmp":"${name}"'`
+          ? `oc -n ${namespace} logs ${logPodName} -c plain | grep '"dvmp":"${name}"'`
           : `oc logs --selector control-plane=controller-manager --namespace ${namespace} --container mtc | grep '"dvmp":"${name}"'`,
       };
     case 'Hook':
       return {
         ocDescribeCommand: `oc describe ${getFullKindName(kind)} --namespace ${namespace} ${name}`,
         ocLogsCommand: logPodName
-          ? `oc logs ${logPodName} -c plain | grep '"migHook":"${name}"'`
+          ? `oc -n ${namespace} logs ${logPodName} -c plain | grep '"migHook":"${name}"'`
           : `oc logs --selector control-plane=controller-manager --namespace ${namespace} --container mtc | grep '"migHook":"${name}"'`,
       };
     case 'Job':
@@ -147,14 +147,14 @@ export const getDebugCommand = (
       return {
         ocDescribeCommand: `oc describe ${getFullKindName(kind)} --namespace ${namespace} ${name}`,
         ocLogsCommand: logPodName
-          ? `oc logs ${logPodName} -c plain | grep '"migMigration":"${name}"'`
+          ? `oc -n ${namespace} logs ${logPodName} -c plain | grep '"migMigration":"${name}"'`
           : `oc logs --selector control-plane=controller-manager --namespace ${namespace} --container mtc | grep '"migMigration":"${name}"'`,
       };
     case 'Plan':
       return {
         ocDescribeCommand: `oc describe ${getFullKindName(kind)} --namespace ${namespace} ${name}`,
         ocLogsCommand: logPodName
-          ? `oc logs ${logPodName} -c plain | grep '"migPlan":"${name}"'`
+          ? `oc -n ${namespace} logs ${logPodName} -c plain | grep '"migPlan":"${name}"'`
           : `oc logs --selector control-plane=controller-manager --namespace ${namespace} --container mtc | grep '"migPlan":"${name}"'`,
       };
     case 'Backup':
@@ -181,14 +181,14 @@ export const getDebugCommand = (
       return {
         ocDescribeCommand: `oc describe ${getFullKindName(kind)} --namespace ${namespace} ${name}`,
         ocLogsCommand: logPodName
-          ? `oc logs ${logPodName} -c plain | grep '"dvm":"${name}"'`
+          ? `oc -n ${namespace} logs ${logPodName} -c plain | grep '"dvm":"${name}"'`
           : `oc logs --selector control-plane=controller-manager --namespace ${namespace} --container mtc | grep '"dvm":"${name}"'`,
       };
     case 'DirectImageMigration':
       return {
         ocDescribeCommand: `oc describe ${getFullKindName(kind)} --namespace ${namespace} ${name}`,
         ocLogsCommand: logPodName
-          ? `oc logs ${logPodName} -c plain | grep '"dim":"${name}"'`
+          ? `oc -n ${namespace} logs ${logPodName} -c plain | grep '"dim":"${name}"'`
           : `oc logs --selector control-plane=controller-manager --namespace ${namespace} --container mtc | grep '"dim":"${name}"'`,
       };
     default:

--- a/src/app/home/pages/PlansPage/components/Wizard/HooksFormComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/HooksFormComponent.tsx
@@ -632,8 +632,8 @@ const HooksFormComponent: React.FunctionComponent<
                 cancelAddEditWatch();
                 resetAddEditState();
                 setInitialHookValues({});
-                setSelectedExistingHook(null);
-                setIsCreateHookSelected(false);
+                currentPlan && setSelectedExistingHook(null);
+                currentPlan && setIsCreateHookSelected(false);
               }}
             >
               Cancel


### PR DESCRIPTION
Fixes bug when namespace is not added to the oc logs command within the debug view. 