### PR TITLE
Add missing reverse proxy forward

### DIFF
--- a/src/app/logs/duck/sagas.ts
+++ b/src/app/logs/duck/sagas.ts
@@ -163,7 +163,7 @@ function* fetchPodNames(action: PayloadAction<string>): Generator<any, any, any>
   const discoveryClient: IDiscoveryClient = DiscoveryFactory.discovery(
     state.auth.user,
     state.auth.migMeta.namespace,
-    'discovery-api'
+    '/discovery-api'
   );
 
   const planName = action.payload;

--- a/src/app/logs/duck/sagas.ts
+++ b/src/app/logs/duck/sagas.ts
@@ -163,7 +163,7 @@ function* fetchPodNames(action: PayloadAction<string>): Generator<any, any, any>
   const discoveryClient: IDiscoveryClient = DiscoveryFactory.discovery(
     state.auth.user,
     state.auth.migMeta.namespace,
-    state.auth.migMeta.discoveryApi
+    'discovery-api'
   );
 
   const planName = action.payload;


### PR DESCRIPTION
For pod requests, we need to use the reverse proxy for discovery service as we are everywhere else