### PR TITLE
Change 'can' to 'should' for consistency.

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
@@ -29,7 +29,7 @@ const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
       } else if (!utils.testDNS1123(values.planName)) {
         errors.planName = utils.DNS1123Error(values.planName);
       } else if (values.planName.length < 3 || values.planName.length > 63) {
-        errors.planName = 'The plan name can be between 3 and 63 characters long.';
+        errors.planName = 'The plan name should be between 3 and 63 characters long.';
       } else if (
         !isEdit &&
         planList.some((plan) => plan.MigPlan.metadata.name === values.planName)


### PR DESCRIPTION
@ibolton336 , This PR changes `can` to `should` to be consistent with existing messaging elsewhere.

Such as [src/app/common/duck/utils.ts#L52](https://github.com/konveyor/mig-ui/blob/master/src/app/common/duck/utils.ts#L52):
```
  if (value?.length < 3 || value?.length > 63) {
    return 'The namespace name should be between 3 and 63 characters long.';
  } else if (!DNS1123Validator.test(value)) {
```

Thanks!