### PR TITLE
Update retry text for pod restart warnings

### DIFF
--- a/src/app/debug/duck/selectors.ts
+++ b/src/app/debug/duck/selectors.ts
@@ -552,7 +552,7 @@ const getResourceStatus = (debugRef: IDebugRefRes): IDerivedDebugStatusObject =>
       const backoffLimit = debugRef?.hookChildren?.jobStatus?.backoffLimit;
       const waitingMessage = debugRef?.hookChildren?.podStatus?.waitingMessage;
       const waitingReason = debugRef?.hookChildren?.podStatus?.waitingReason;
-      const restartWarningText = `On attempt ${restartCount} of ${backoffLimit}`;
+      const restartWarningText = `Pod restarted. Retry attempt ${restartCount} of ${backoffLimit}`;
       const restartWarningWaitingMessage = `${waitingReason} - ${waitingMessage}`;
       const hookWarningArr = [
         ...(restartCount && backoffLimit ? [restartWarningText] : []),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11218376/133824877-aeadf9d9-fd05-4c96-9a42-a0c82ae1b57c.png)

Old screenshot of bug ^^

This pr changes the text shown in the warning list nested in the debug tree view for pod restart warnings. 

The warning message will now read: 
```     Pod restarted. Retry attempt ${restartCount} of ${backoffLimit}`; ``` 
