### PR TITLE
Bug xxxxxx: Allow longer extensions for cluster urls

### DIFF
--- a/src/app/common/duck/utils.ts
+++ b/src/app/common/duck/utils.ts
@@ -3,7 +3,7 @@ import { alertErrorModal } from './slice';
 
 const DNS1123Validator = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const URLValidator =
-  /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
+  /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,256}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
 const RouteHostValidator =
   /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
 


### PR DESCRIPTION
Currently, urls with an extension longer than 6 characters are invalid from within the UI. 

This pr changes the REGEX to allow for longer domain extensions.