### PR TITLE
Bug 2027382: Use timeouts on 'copied to clipboard' alerts, change alert timeout delay to PF-standard 8 seconds

### DIFF
--- a/src/app/common/duck/sagas.ts
+++ b/src/app/common/duck/sagas.ts
@@ -37,7 +37,7 @@ function* getState(): Generator<StrictEffect, DefaultRootState, DefaultRootState
 }
 
 export const StatusPollingInterval = 4000;
-const ErrorToastTimeout = 5000;
+const ErrorToastTimeout = 8000;
 
 function* fetchCraneVersion(action: any): Generator<any, any, any> {
   const state = yield* getState();
@@ -206,7 +206,7 @@ function* watchHookPolling(): Generator {
 export function* progressTimeoutSaga(action: any) {
   try {
     yield put(alertProgress(action.payload));
-    yield delay(5000);
+    yield delay(8000);
     yield put(alertClear());
   } catch (error) {
     put(alertClear());
@@ -226,7 +226,7 @@ export function* errorTimeoutSaga(action: any) {
 export function* successTimeoutSaga(action: any) {
   try {
     yield put(alertSuccess(action.payload));
-    yield delay(5000);
+    yield delay(8000);
     yield put(alertClear());
   } catch (error) {
     yield put(alertClear());

--- a/src/app/home/pages/PlanDebugPage/components/TreeActionsDropdown.tsx
+++ b/src/app/home/pages/PlanDebugPage/components/TreeActionsDropdown.tsx
@@ -8,7 +8,7 @@ import {
   IDebugTreeNode,
   RAW_OBJECT_VIEW_ROUTE,
 } from '../../../../debug/duck/types';
-import { alertSuccess } from '../../../../common/duck/slice';
+import { alertSuccessTimeout } from '../../../../common/duck/slice';
 import { getDebugCommand, hasLogsCommand } from '../helpers';
 import { DefaultRootState } from '../../../../../configureStore';
 import { ILogReducerState } from '../../../../logs/duck/slice';
@@ -45,7 +45,7 @@ const TreeActionsDropdown: React.FunctionComponent<ITreeActionsDropdownProps> = 
     document.execCommand('copy');
     clipboard.removeChild(el);
     dispatch(
-      alertSuccess(
+      alertSuccessTimeout(
         `Command copied to clipboard. Run 'oc describe' on the 
       ${rawNode.clusterType} cluster to view resource details.`
       )
@@ -67,7 +67,7 @@ const TreeActionsDropdown: React.FunctionComponent<ITreeActionsDropdownProps> = 
     document.execCommand('copy');
     clipboard.removeChild(el);
     dispatch(
-      alertSuccess(
+      alertSuccessTimeout(
         `Command copied to clipboard. Run 'oc logs' on the 
       ${rawNode.clusterType} cluster to view resource details.`
       )


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2027382