### PR TITLE
Add migration type column and filter on the plans table

### DIFF
--- a/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
+++ b/src/app/common/components/FilterToolbar/SelectFilterControl.tsx
@@ -57,6 +57,7 @@ const SelectFilterControl: React.FunctionComponent<ISelectFilterControlProps> = 
           onFilterSelect(value);
           setIsFilterDropdownOpen(false);
         }}
+        isOpen={isFilterDropdownOpen}
         placeholderText="Any"
         toggleId={`id-${category.key}`}
       >

--- a/src/app/common/components/TruncatedText.module.scss
+++ b/src/app/common/components/TruncatedText.module.scss
@@ -1,0 +1,6 @@
+.truncatedText {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/app/common/components/TruncatedText.tsx
+++ b/src/app/common/components/TruncatedText.tsx
@@ -1,0 +1,42 @@
+// TODO lib-ui candidate copied from forklift-ui
+
+import { Tooltip, TooltipProps } from '@patternfly/react-core';
+import * as React from 'react';
+const styles = require('./TruncatedText.module').default;
+
+interface ITruncatedTextProps {
+  children: React.ReactNode;
+  className?: string;
+  tooltipProps?: Partial<TooltipProps>;
+}
+
+export const TruncatedText: React.FunctionComponent<ITruncatedTextProps> = ({
+  children,
+  className = '',
+  tooltipProps = {},
+}: ITruncatedTextProps) => {
+  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
+
+  const onMouseEnter = (event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLDivElement;
+    if (target.offsetWidth < target.scrollWidth) {
+      !isTooltipVisible && setIsTooltipVisible(true);
+    } else {
+      isTooltipVisible && setIsTooltipVisible(false);
+    }
+  };
+
+  const truncatedChildren = (
+    <div className={`${styles.truncatedText} ${className}`} onMouseEnter={onMouseEnter}>
+      {children}
+    </div>
+  );
+
+  return isTooltipVisible ? (
+    <Tooltip content={children} isVisible {...tooltipProps}>
+      {truncatedChildren}
+    </Tooltip>
+  ) : (
+    truncatedChildren
+  );
+};

--- a/src/app/home/pages/PlansPage/components/PlanStatus.module.scss
+++ b/src/app/home/pages/PlansPage/components/PlanStatus.module.scss
@@ -1,0 +1,9 @@
+.planStatusIcon {
+  vertical-align: middle;
+}
+
+.planStatusTextContainer {
+  display: inline-block;
+  width: 100%;
+  vertical-align: middle;
+}

--- a/src/app/home/pages/PlansPage/components/PlanStatus.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanStatus.tsx
@@ -5,6 +5,8 @@ import { getPlanStatusText } from '../helpers';
 import { IPlan } from '../../../../plan/duck/types';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { HashLink } from 'react-router-hash-link';
+import { TruncatedText } from '../../../../common/components/TruncatedText';
+const styles = require('./PlanStatus.module').default;
 
 interface IProps {
   plan: IPlan;
@@ -43,16 +45,22 @@ const PlanStatus: React.FunctionComponent<IProps> = ({ plan, isNestedDebugView }
   const planName = plan?.MigPlan?.metadata?.name;
   const latestMigrationName = latestMigration?.metadata?.name;
 
+  const statusTextSpan = (
+    <span className={`${styles.planStatusTextContainer} ${spacing.mlSm}`}>
+      <TruncatedText>{getPlanStatusText(plan)}</TruncatedText>
+    </span>
+  );
+
   return (
     <Flex>
       <FlexItem>
         <PlanStatusIcon plan={plan} />
         {!isNestedDebugView && showDebugLink && planName && latestMigrationName ? (
           <HashLink to={`/plans/${planName}/migrations/${latestMigrationName}#debug`}>
-            <span className={spacing.mlSm}>{getPlanStatusText(plan)}</span>
+            {statusTextSpan}
           </HashLink>
         ) : (
-          <span className={spacing.mlSm}>{getPlanStatusText(plan)}</span>
+          statusTextSpan
         )}
       </FlexItem>
     </Flex>

--- a/src/app/home/pages/PlansPage/components/PlanStatusIcon.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanStatusIcon.tsx
@@ -11,7 +11,7 @@ import { Popover, PopoverPosition } from '@patternfly/react-core';
 import { Spinner } from '@patternfly/react-core';
 import { ICondition, IPlan } from '../../../../plan/duck/types';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+const styles = require('./PlanStatus.module').default;
 
 interface IProps {
   plan: IPlan;
@@ -34,7 +34,7 @@ const PlanStatusIcon: React.FunctionComponent<IProps> = ({ plan }) => {
 
   if (latestIsFailed || hasCriticalCondition) {
     return (
-      <span className="pf-c-icon pf-m-danger">
+      <span className={`${styles.planStatusIcon} pf-c-icon pf-m-danger`}>
         <ExclamationCircleIcon />
       </span>
     );
@@ -47,44 +47,44 @@ const PlanStatusIcon: React.FunctionComponent<IProps> = ({ plan }) => {
         closeBtnAriaLabel="close-warning-details"
         maxWidth="200rem"
       >
-        <span className={`pf-c-icon pf-m-warning`}>
+        <span className={`${styles.planStatusIcon} pf-c-icon pf-m-warning`}>
           <ExclamationTriangleIcon />
         </span>
       </Popover>
     );
   } else if (hasNotReadyCondition || hasDVMBlockedCondition) {
     return (
-      <span className={`pf-c-icon pf-m-warning`}>
+      <span className={`${styles.planStatusIcon} pf-c-icon pf-m-warning`}>
         <ExclamationTriangleIcon />
       </span>
     );
   } else if (hasRunningMigrations || isPlanLocked) {
-    return <Spinner size="md" />;
+    return <Spinner className={styles.planStatusIcon} size="md" />;
   } else if (
     (hasSucceededMigration && hasWarnCondition) ||
     (hasSucceededStage && hasWarnCondition) ||
     hasSucceededWithWarningsCondition
   ) {
     return (
-      <span className={`pf-c-icon pf-m-warning`}>
+      <span className={`${styles.planStatusIcon} pf-c-icon pf-m-warning`}>
         <ExclamationTriangleIcon />
       </span>
     );
   } else if (hasSucceededMigration) {
     return (
-      <span className="pf-c-icon pf-m-success">
+      <span className={`${styles.planStatusIcon} pf-c-icon pf-m-success`}>
         <ResourcesFullIcon />
       </span>
     );
   } else if (hasSucceededStage) {
     return (
-      <span className="pf-c-icon pf-m-success">
+      <span className={`${styles.planStatusIcon} pf-c-icon pf-m-success`}>
         <ResourcesAlmostEmptyIcon />
       </span>
     );
   } else {
     return (
-      <span className="pf-c-icon pf-m-info">
+      <span className={`${styles.planStatusIcon} pf-c-icon pf-m-info`}>
         <OutlinedCircleIcon />
       </span>
     );

--- a/src/app/home/pages/PlansPage/components/PlansTable.tsx
+++ b/src/app/home/pages/PlansPage/components/PlansTable.tsx
@@ -19,7 +19,7 @@ import MigrationIcon from '@patternfly/react-icons/dist/js/icons/migration-icon'
 
 import PlanStatus from './PlanStatus';
 import { useFilterState, useSortState } from '../../../../common/duck/hooks';
-import { getPlanInfo } from '../helpers';
+import { getPlanInfo, migrationTypeToString } from '../helpers';
 import { IPlan } from '../../../../plan/duck/types';
 import namespacesIcon from '../../../../common/components/namespaces_icon.svg';
 import { usePaginationState } from '../../../../common/duck/hooks/usePaginationState';
@@ -49,19 +49,20 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
   const [expandedCells, setExpandedCells] = useState<IExpandedCells>({});
 
   const columns = [
-    { title: 'Name', transforms: [sortable, cellWidth(10)] },
+    { title: 'Name', transforms: [sortable, cellWidth(15)] },
     {
       title: 'Migrations',
-      transforms: [sortable, cellWidth(15)],
+      transforms: [sortable, cellWidth(10)],
     },
+    { title: 'Type', transforms: [sortable, cellWidth(10)], cellTransforms: [truncate] },
     { title: 'Source', transforms: [sortable, cellWidth(10)] },
     { title: 'Target', transforms: [sortable, cellWidth(10)] },
     { title: 'Repository', transforms: [sortable, cellWidth(10)] },
     {
       title: 'Namespaces',
-      transforms: [sortable, cellWidth(15)],
+      transforms: [sortable, cellWidth(10)],
     },
-    { title: 'Last state', transforms: [sortable, cellWidth(40)], cellTransforms: [truncate] },
+    { title: 'Last state', transforms: [sortable, cellWidth(25)], cellTransforms: [truncate] },
     '',
   ];
 
@@ -79,6 +80,18 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
       type: FilterType.search,
       placeholderText: 'Filter by Migrations...',
       getItemValue: (plan) => getPlanInfo(plan).migrationCount,
+    },
+    {
+      key: 'migrationType',
+      title: 'Type',
+      type: FilterType.select,
+      placeholderText: 'Filter by Type...',
+      selectOptions: [
+        { key: 'full', value: 'Full migration' },
+        { key: 'state', value: 'State migration' },
+        { key: 'scc', value: 'Storage class conversion' },
+      ],
+      getItemValue: (plan) => getPlanInfo(plan).migrationType,
     },
     {
       key: 'sourceClusterName',
@@ -121,6 +134,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     const {
       planName,
       migrationCount,
+      migrationType,
       sourceClusterName,
       targetClusterName,
       storageName,
@@ -130,6 +144,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     return [
       planName,
       migrationCount,
+      migrationTypeToString(migrationType),
       sourceClusterName,
       targetClusterName,
       storageName,
@@ -151,6 +166,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     currentPageItems.map((plan: IPlan, planIndex) => {
       const {
         planName,
+        migrationType,
         migrationCount,
         sourceClusterName,
         targetClusterName,
@@ -185,7 +201,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                 </>
               ),
             },
-
+            migrationTypeToString(migrationType),
             sourceClusterName,
             targetClusterName,
             storageName,

--- a/src/app/home/pages/PlansPage/components/PlansTable.tsx
+++ b/src/app/home/pages/PlansPage/components/PlansTable.tsx
@@ -13,6 +13,7 @@ import {
   sortable,
   truncate,
   cellWidth,
+  fitContent,
 } from '@patternfly/react-table';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import MigrationIcon from '@patternfly/react-icons/dist/js/icons/migration-icon';
@@ -52,17 +53,17 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     { title: 'Name', transforms: [sortable, cellWidth(15)] },
     {
       title: 'Migrations',
-      transforms: [sortable, cellWidth(10)],
+      transforms: [sortable, fitContent],
     },
-    { title: 'Type', transforms: [sortable, cellWidth(10)], cellTransforms: [truncate] },
-    { title: 'Source', transforms: [sortable, cellWidth(10)] },
-    { title: 'Target', transforms: [sortable, cellWidth(10)] },
-    { title: 'Repository', transforms: [sortable, cellWidth(10)] },
+    { title: 'Type', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Source', transforms: [sortable] },
+    { title: 'Target', transforms: [sortable] },
+    { title: 'Repository', transforms: [sortable] },
     {
       title: 'Namespaces',
-      transforms: [sortable, cellWidth(10)],
+      transforms: [sortable, fitContent],
     },
-    { title: 'Last state', transforms: [sortable, cellWidth(25)], cellTransforms: [truncate] },
+    { title: 'Last state', transforms: [sortable, cellWidth(20)], cellTransforms: [truncate] },
     '',
   ];
 

--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -51,17 +51,17 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     {
       value: 'full',
       toString: () =>
-        'Full migration - migrate namespaces, persistent volumes (PVs) and Kubernetes resources from one cluster to another',
+        `Full migration - migrate namespaces, persistent volumes (PVs) and Kubernetes resources from one cluster to another`,
     },
     {
       value: 'state',
       toString: () =>
-        'State migration - migrate only PVs and Kubernetes resources between namespaces in the same cluster or different clusters',
+        `State migration - migrate only PVs and Kubernetes resources between namespaces in the same cluster or different clusters`,
     },
     {
       value: 'scc',
       toString: () =>
-        'Storage class conversion - convert PVs to a different storage class within the same cluster and namespace',
+        `Storage class conversion - convert PVs to a different storage class within the same cluster and namespace`,
     },
   ];
 

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -14,7 +14,7 @@ import {
   IPlanPersistentVolume,
   IStep,
 } from '../../../plan/duck/types';
-import { MigrationStepsType, IProgressInfoObj, IStepProgressInfo } from './types';
+import { MigrationStepsType, IProgressInfoObj, IStepProgressInfo, MigrationType } from './types';
 
 export const getPlanStatusText = (plan: IPlan) => {
   if (!plan || !plan?.PlanStatus) {
@@ -74,6 +74,8 @@ export const getPlanInfo = (plan: IPlan) => {
     latestMigAnalytic?.status?.analytics?.k8sResourceTotal > 10000 ? true : false;
   return {
     planName: plan.MigPlan.metadata.name,
+    migrationType:
+      plan?.MigPlan?.metadata?.annotations['migration.openshift.io/selected-migplan-type'],
     migrationCount: plan.Migrations.length || 0,
     sourceClusterName: plan.MigPlan.spec.srcMigClusterRef.name
       ? plan.MigPlan.spec?.srcMigClusterRef?.name
@@ -372,3 +374,12 @@ export const pvcNameToString = (pvc: IPlanPersistentVolume['pvc']) => {
   }
   return pvc.name;
 };
+
+export const migrationTypeToString = (migrationType: MigrationType) =>
+  migrationType === 'full'
+    ? 'Full migration'
+    : migrationType === 'state'
+    ? 'State migration'
+    : migrationType === 'scc'
+    ? 'Storage class conversion'
+    : '';


### PR DESCRIPTION
Adds a Type column to the plans table and adjusts widths and other layout transforms of the columns on the table to attempt to minimize wrapping. The state column is a little smaller now, so I made sure it will truncate properly with ellipses and a tooltip if it displays a longer message.

Also adds a Type filter to the filter dropdown and fixes a bug with FilterToolbar where select-mode filter dropdowns wouldn't open.

![Screen Shot 2022-01-07 at 2 34 40 PM](https://user-images.githubusercontent.com/811963/148598429-07237670-d79d-4684-a299-154118e3f5c8.png)