### PR TITLE
Plan wizard: Prevent editing/validating plan name once the plan CR has been created

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/GeneralForm.tsx
@@ -11,6 +11,8 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/e
 import { usePausedPollingEffect } from '../../../../../common/context';
 import { IStorage } from '../../../../../storage/duck/types';
 import { MigrationType } from '../../types';
+import { useSelector } from 'react-redux';
+import { DefaultRootState } from '../../../../../../configureStore';
 
 export type IGeneralFormProps = {
   isEdit: boolean;
@@ -34,6 +36,8 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     errors,
     validateForm,
   } = useFormikContext<IFormValues>();
+
+  const { currentPlan } = useSelector((state: DefaultRootState) => state.plan);
 
   useForcedValidationOnChange<IFormValues>(values, isEdit, validateForm);
 
@@ -215,7 +219,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           type="text"
           validated={validatedState(touched?.planName, errors?.planName)}
           id="planName"
-          isDisabled={isEdit}
+          isDisabled={isEdit || !!currentPlan}
         />
       </FormGroup>
       <FormGroup

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -215,10 +215,13 @@ const WizardContainer: React.FunctionComponent<IOtherProps> = (props: IOtherProp
     setInitialValues(initialValuesCopy);
   }, [isOpen]);
 
+  const { currentPlan } = useSelector((state: DefaultRootState) => state.plan);
+
   return (
     <WizardFormik
       initialValues={initialValues}
       isEdit={isEdit}
+      currentPlan={currentPlan}
       planList={planList}
       sourceClusterNamespaces={sourceClusterNamespaces}
     >

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IPlan, ISourceClusterNamespace } from '../../../../../plan/duck/types';
+import { IMigPlan, IPlan, ISourceClusterNamespace } from '../../../../../plan/duck/types';
 import { IFormValues } from './WizardContainer';
 import utils from '../../../../../common/duck/utils';
 
 export interface IWizardFormikProps {
   initialValues: IFormValues;
   isEdit?: boolean;
+  currentPlan?: IMigPlan;
   planList?: IPlan[];
   sourceClusterNamespaces: ISourceClusterNamespace[];
   children: React.ReactNode;
@@ -15,6 +16,7 @@ export interface IWizardFormikProps {
 const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
   initialValues,
   isEdit = false,
+  currentPlan = null,
   planList = [],
   sourceClusterNamespaces,
   children,
@@ -32,6 +34,7 @@ const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
         errors.planName = 'The plan name should be between 3 and 63 characters long.';
       } else if (
         !isEdit &&
+        !currentPlan &&
         planList.some((plan) => plan.MigPlan.metadata.name === values.planName)
       ) {
         errors.planName =


### PR DESCRIPTION
Once the `currentPlan` is set in the redux store, the plan CR has been created and the wizard should lock in the plan name to prevent further changes or validation errors. You can observe this by proceeding to the PVs step of the wizard, then going back to the general step (the name field will be disabled).

https://issues.redhat.com/browse/MIG-874