### PR TITLE
Properly show None selection for target storage classes, fix suggested target storage class init when creating a new plan

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/PVStorageClassSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/PVStorageClassSelect.tsx
@@ -48,9 +48,11 @@ export const PVStorageClassSelect: React.FunctionComponent<IPVStorageClassSelect
       onChange={(option: any) => onStorageClassChange(currentPV, option.value)}
       options={storageClassOptions}
       value={
-        storageClassOptions.find(
-          (option) => currentStorageClass && option.value === currentStorageClass.name
-        ) || pv.storageClass
+        currentStorageClass === ''
+          ? noneOption
+          : storageClassOptions.find(
+              (option) => currentStorageClass && option.value === currentStorageClass.name
+            ) || pv.storageClass
       }
       placeholderText="Select a storage class..."
     />

--- a/src/app/home/pages/PlansPage/components/Wizard/PVStorageClassSelect.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/PVStorageClassSelect.tsx
@@ -52,7 +52,7 @@ export const PVStorageClassSelect: React.FunctionComponent<IPVStorageClassSelect
           ? noneOption
           : storageClassOptions.find(
               (option) => currentStorageClass && option.value === currentStorageClass.name
-            ) || pv.storageClass
+            ) || undefined
       }
       placeholderText="Select a storage class..."
     />

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -228,12 +228,6 @@ const WizardContainer: React.FunctionComponent<IOtherProps> = (props: IOtherProp
 
   const { currentPlan } = useSelector((state: DefaultRootState) => state.plan);
 
-  console.log(
-    'selected sc: ',
-    currentPlan?.spec?.persistentVolumes &&
-      currentPlan?.spec?.persistentVolumes[0].selection.storageClass
-  );
-
   return (
     <WizardFormik
       initialValues={initialValues}

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -238,6 +238,12 @@ const WizardContainer: React.FunctionComponent<IOtherProps> = (props: IOtherProp
 
   const { currentPlan } = useSelector((state: DefaultRootState) => state.plan);
 
+  console.log(
+    'selected sc: ',
+    currentPlan?.spec?.persistentVolumes &&
+      currentPlan?.spec?.persistentVolumes[0].selection.storageClass
+  );
+
   return (
     <WizardFormik
       initialValues={initialValues}

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardContainer.tsx
@@ -17,6 +17,7 @@ import { DefaultRootState } from '../../../../../../configureStore';
 import { OptionWithValue } from '../../../../../common/components/SimpleSelect';
 import { MigrationType } from '../../types';
 import _ from 'lodash';
+import { getSuggestedPvStorageClasses } from '../../helpers';
 
 export interface IFormValues {
   planName: string;
@@ -116,20 +117,9 @@ const WizardContainer: React.FunctionComponent<IOtherProps> = (props: IOtherProp
       }
     };
     if (editPlanObj && isEdit && isOpen) {
-      let pvStorageClassAssignment = {};
-      const migPlanPvs = editPlanObj.spec.persistentVolumes;
-      if (migPlanPvs) {
-        const storageClasses = editPlanObj?.status?.destStorageClasses || [];
-        pvStorageClassAssignment = migPlanPvs.reduce((assignedScs, pv) => {
-          const suggestedStorageClass = storageClasses.find(
-            (sc) => (sc !== '' && sc.name) === pv.selection.storageClass
-          );
-          return {
-            ...assignedScs,
-            [pv.name]: suggestedStorageClass ? suggestedStorageClass : '',
-          };
-        }, {});
-        initialValuesCopy.pvStorageClassAssignment = pvStorageClassAssignment;
+      const suggestedStorageClasses = getSuggestedPvStorageClasses(editPlanObj);
+      if (suggestedStorageClasses) {
+        initialValuesCopy.pvStorageClassAssignment = suggestedStorageClasses;
       }
 
       initialValuesCopy.migrationType =

--- a/src/app/home/pages/PlansPage/helpers.ts
+++ b/src/app/home/pages/PlansPage/helpers.ts
@@ -8,6 +8,7 @@ dayjs.extend(relativeTime);
 dayjs.extend(customParseFormat);
 
 import {
+  IMigPlan,
   IMigPlanStorageClass,
   IMigration,
   IPlan,
@@ -443,4 +444,21 @@ export const migSpecToAction = (
         : MIG_SPEC_ACTION_FIELDS;
     return fieldsToCompare.every((field) => possibleSpec[field] === (spec[field] || false));
   });
+};
+
+export const getSuggestedPvStorageClasses = (migPlan?: IMigPlan) => {
+  let pvStorageClassAssignment = {};
+  const migPlanPvs = migPlan?.spec.persistentVolumes;
+  if (!migPlanPvs) return null;
+  const storageClasses = migPlan?.status?.destStorageClasses || [];
+  pvStorageClassAssignment = migPlanPvs.reduce((assignedScs, pv) => {
+    const suggestedStorageClass = storageClasses.find(
+      (sc) => (sc !== '' && sc.name) === pv.selection.storageClass
+    );
+    return {
+      ...assignedScs,
+      [pv.name]: suggestedStorageClass ? suggestedStorageClass : '',
+    };
+  }, {});
+  return pvStorageClassAssignment;
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MIG-740

~~This reveals another issue it does not solve: that `|| pv.storageClass` default is misleading. When the user first sees this field (in Copy Options for full/state migrations, or in the PVs step for SCC) it will appear to default to the storage class of the source PV (even if that selection doesn't exist in the target), but really the form data is blank and a default will be used by the backend. The form used to default to a true selection determined by [this block of code](https://github.com/konveyor/mig-ui/pull/1361/files#diff-30964530bef8d26e28a5365204049ffb0fca889c73d890f805b0c0fa19c2f482L22-L54) that was removed in #1361. I'm not sure exactly why that was removed or what the implications would be of restoring it. It may be that instead we need to show this field as blank by default and require that the user make an explicit selection, or indicate that blank is a valid option and somehow convey what it will do. (note that this blank state is distinct from selecting None, which is a valid option)~~

This PR now also fixes the above issue by properly initializing these fields based on the selections in the Plan CR if they are not yet initialized upon PV discovery completion (i.e. when creating a new plan).

See slack discussion starting here for context: https://coreos.slack.com/archives/CHB7WSNUX/p1642699829044500