### PR TITLE
Bug 2049867: Disable Stage/Cutover for state migrations

### DIFF
--- a/src/app/home/pages/PlansPage/components/PlanActions/PlanActionsComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/PlanActions/PlanActionsComponent.tsx
@@ -56,6 +56,7 @@ export const PlanActionsComponent: React.FunctionComponent<IPlanActionsProps> = 
     hasReadyCondition = null,
     hasErrorCondition = null,
     hasRunningMigrations = null,
+    hasStateMigrations = null,
     finalMigrationComplete = null,
     isPlanLocked = null,
     hasCopyPVs = null,
@@ -98,6 +99,7 @@ export const PlanActionsComponent: React.FunctionComponent<IPlanActionsProps> = 
         !hasReadyCondition ||
         hasErrorCondition ||
         hasRunningMigrations ||
+        hasStateMigrations ||
         finalMigrationComplete ||
         isPlanLocked ||
         isIntraClusterPlan
@@ -118,6 +120,7 @@ export const PlanActionsComponent: React.FunctionComponent<IPlanActionsProps> = 
         !hasReadyCondition ||
         hasErrorCondition ||
         hasRunningMigrations ||
+        hasStateMigrations ||
         finalMigrationComplete ||
         isPlanLocked ||
         isIntraClusterPlan
@@ -163,13 +166,13 @@ export const PlanActionsComponent: React.FunctionComponent<IPlanActionsProps> = 
       </DropdownItem>
     </DropdownGroup>,
     <DropdownGroup label="Migrations" key="migrations">
-      {isIntraClusterPlan ? (
+      {isIntraClusterPlan || hasStateMigrations ? (
         <Tooltip
           position={PopoverPosition.bottom}
           content={
             <div>
-              Stage is not supported for intra-cluster migrations. Please use the State migration
-              option.
+              Stage is not supported for {isIntraClusterPlan ? 'intra-cluster' : 'state'}{' '}
+              migrations. Please use the State migration option.
             </div>
           }
           aria-label="disabled state details"
@@ -180,13 +183,13 @@ export const PlanActionsComponent: React.FunctionComponent<IPlanActionsProps> = 
       ) : (
         stageItem
       )}
-      {isIntraClusterPlan ? (
+      {isIntraClusterPlan || hasStateMigrations ? (
         <Tooltip
           position={PopoverPosition.bottom}
           content={
             <div>
-              Cutover is not supported for intra-cluster migrations. Please use the State migration
-              option.
+              Cutover is not supported for {isIntraClusterPlan ? 'intra-cluster' : 'state'}{' '}
+              migrations. Please use the State migration option.
             </div>
           }
           aria-label="disabled state details"

--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -229,6 +229,12 @@ const getPlansWithPlanStatus = createSelector(
         }
       }).length;
 
+      const hasStateMigrations = !!planMigrations.filter((m) => {
+        if (m.metadata?.annotations) {
+          return m.metadata?.annotations['migration.openshift.io/state-transfer'] === 'true';
+        }
+      }).length;
+
       const hasCopyPVs = plan.MigPlan.spec.persistentVolumes?.some(
         (pv) => pv.selection.action === 'copy'
       );
@@ -239,6 +245,7 @@ const getPlansWithPlanStatus = createSelector(
         hasSucceededState,
         hasSucceededRollback,
         hasAttemptedMigration,
+        hasStateMigrations,
         finalMigrationComplete,
         hasRunningMigrations,
         latestType,

--- a/src/app/plan/duck/types.ts
+++ b/src/app/plan/duck/types.ts
@@ -168,6 +168,7 @@ export interface IPlan {
     hasPVWarnCondition?: boolean;
     hasReadyCondition?: boolean;
     hasRunningMigrations?: boolean;
+    hasStateMigrations?: boolean;
     hasSucceededMigration?: boolean;
     hasSucceededWithWarningsCondition?: boolean;
     hasDVMBlockedCondition?: boolean;


### PR DESCRIPTION
Stage/Cutover options will be disabled whenever there are state migrations associated with a plan. The tooltip is updated to reflect the appropriate message in this case. 