### PR TITLE
Bug 2055157: Fix pvs showing up empty after pv discovery (#1391)

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesTable.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesTable.tsx
@@ -356,7 +356,8 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
           pv.name,
           pvcNameToString(pv.pvc),
           pv.pvc.namespace,
-          pv.storageClass,
+          // Storage class can be empty here if none exists/ none selected initially
+          pv.storageClass || '',
           pv.capacity,
           {
             title: (
@@ -382,7 +383,8 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
           pv.name,
           pvcNameToString(pv.pvc),
           pv.pvc.namespace,
-          pv.storageClass,
+          // Storage class can be empty here if none exists/ none selected initially
+          pv.storageClass || '',
           pv.capacity,
           {
             title: (
@@ -482,7 +484,7 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
                           dataLabel={
                             typeof columns[cellIndex].title === 'string'
                               ? (columns[cellIndex].title as string)
-                              : undefined
+                              : ''
                           }
                         >
                           {typeof cell !== 'string' ? cell.title : cell}

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -6,9 +6,9 @@ import {
 import { IMigPlan, IPlanPersistentVolume } from '../../app/plan/duck/types';
 import { INameNamespaceRef } from '../../app/common/duck/types';
 import { IClusterSpec } from '../../app/cluster/duck/types';
-import { select } from 'redux-saga/effects';
 import { MigrationAction, MigrationType } from '../../app/home/pages/PlansPage/types';
 import { actionToMigSpec } from '../../app/home/pages/PlansPage/helpers';
+import _ from 'lodash';
 
 export function createMigClusterSecret(
   name: string,
@@ -472,12 +472,16 @@ export function updateMigPlanFromValues(
 
       return updatedPV;
     });
-    updatedSpec.persistentVolumes = planValues.persistentVolumes;
+    updatedSpec.persistentVolumes = _.unionBy(
+      planValues.persistentVolumes,
+      updatedSpec.persistentVolumes,
+      (pv) => pv.name
+    );
   }
   if (planValues.planClosed) {
     updatedSpec.closed = true;
   }
-  if (currentPlan.status) {
+  if (currentPlan?.status) {
     // if currentPlan has status, this is not 1st MigPlan reconcile.
     // we should refresh corresponding MigStorage and MigClusters.
     updatedSpec.refresh = true;


### PR DESCRIPTION
* Bug 2055157: Fix pvs showing up empty after pv discovery

* cleanup

* Instantiate storage class value to empty string in the case of empty storage class

* Update to unionBy

* Update unionby function arguments to include iterator

* satisfy linter