### PR TITLE
[Backport] MIG-1131: Remove 'check connection' buttons from add/edit cluster and replication repository pages (#1395)

### DIFF
--- a/src/app/common/add_edit_state.ts
+++ b/src/app/common/add_edit_state.ts
@@ -97,21 +97,6 @@ export const addEditButtonText = (componentType: string) => (status: IAddEditSta
   }
 };
 
-export const isCheckConnectionButtonDisabled = (
-  currentStatus: IAddEditStatus,
-  valuesUpdatedObject: boolean
-) => {
-  const objectHasPendingUpdate = currentStatus.mode === AddEditMode.Edit && valuesUpdatedObject;
-
-  const isDisabled =
-    currentStatus.mode === AddEditMode.Add ||
-    currentStatus.state === AddEditState.Fetching ||
-    currentStatus.state === AddEditState.Watching ||
-    objectHasPendingUpdate;
-
-  return isDisabled;
-};
-
 export const isAddEditButtonDisabled = (
   status: IAddEditStatus,
   errors: object,

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -17,14 +17,12 @@ import {
   addEditStatusText,
   addEditButtonText,
   isAddEditButtonDisabled,
-  isCheckConnectionButtonDisabled,
   IAddEditStatus,
 } from '../../../../../common/add_edit_state';
 import ConnectionStatusLabel from '../../../../../common/components/ConnectionStatusLabel';
 import CertificateUpload from '../../../../../common/components/CertificateUpload';
 import { validatedState } from '../../../../../common/helpers';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
-import { IMigCluster } from '../../../../../../client/resources/conversions';
 import { IClusterInfo } from '../../helpers';
 import { ICluster } from '../../../../../cluster/duck/types';
 import { usePausedPollingEffect } from '../../../../../common/context/PollingContext';
@@ -83,7 +81,6 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
   const {
     addEditStatus: currentStatus,
     currentCluster,
-    checkConnection,
     values,
     touched,
     errors,
@@ -295,16 +292,6 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         >
           {addEditButtonTextFn(currentStatus)}
         </Button>
-        <Button
-          variant="secondary"
-          isDisabled={isCheckConnectionButtonDisabled(
-            currentStatus,
-            valuesHaveUpdate(values, currentCluster)
-          )}
-          onClick={() => checkConnection(values.name)}
-        >
-          Check connection
-        </Button>
         <Button variant="secondary" onClick={handleClose}>
           Close
         </Button>
@@ -328,7 +315,6 @@ interface IOtherProps {
   handleClose: () => void;
   addEditStatus: IAddEditStatus;
   currentCluster: ICluster;
-  checkConnection: (name: string) => void;
   initialClusterValues?: IClusterInfo;
 }
 const AddEditClusterForm = withFormik<IOtherProps, IFormValues>({

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterForm.test.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/__tests__/AddEditClusterForm.test.tsx
@@ -21,9 +21,6 @@ describe('<AddEditClusterModal />', () => {
       handleClose: () => {
         return;
       },
-      checkConnection: () => {
-        return;
-      },
       currentCluster: null as ICluster,
     };
 
@@ -57,9 +54,6 @@ describe('<AddEditClusterModal />', () => {
         return;
       },
       handleClose: () => {
-        return;
-      },
-      checkConnection: () => {
         return;
       },
       currentCluster: null as ICluster,
@@ -115,9 +109,6 @@ describe('<AddEditClusterModal />', () => {
         return;
       },
       handleClose: () => {
-        return;
-      },
-      checkConnection: () => {
         return;
       },
       currentCluster: null as ICluster,

--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/index.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import AddEditClusterForm, { IFormValues } from './AddEditClusterForm';
 import { Modal } from '@patternfly/react-core';
@@ -6,21 +6,17 @@ import { ClusterActions } from '../../../../../cluster/duck/actions';
 import {
   defaultAddEditStatus,
   AddEditMode,
-  createAddEditStatus,
-  AddEditState,
   IAddEditStatus,
 } from '../../../../../common/add_edit_state';
 import { ICluster } from '../../../../../cluster/duck/types';
 import { IClusterInfo } from '../../helpers';
 import { DefaultRootState } from '../../../../../../configureStore';
-import { FormikValues } from 'formik';
 
 interface IAddEditClusterModal {
   addEditStatus: IAddEditStatus;
   initialClusterValues: IClusterInfo;
   isOpen: boolean;
   isPolling: boolean;
-  checkConnection: (name: string) => void;
   clusterList: ICluster[];
   addCluster: (cluster: IFormValues) => void;
   cancelAddEditWatch: () => void;
@@ -36,7 +32,6 @@ const AddEditClusterModal: React.FunctionComponent<IAddEditClusterModal | any> =
   addEditStatus,
   initialClusterValues,
   isOpen,
-  checkConnection,
   addCluster,
   cancelAddEditWatch,
   onHandleClose,
@@ -88,7 +83,6 @@ const AddEditClusterModal: React.FunctionComponent<IAddEditClusterModal | any> =
         addEditStatus={addEditStatus}
         initialClusterValues={initialClusterValues}
         currentCluster={currentCluster}
-        checkConnection={checkConnection}
       />
     </Modal>
   );
@@ -108,14 +102,6 @@ export default connect(
       dispatch(ClusterActions.addClusterRequest(clusterValues)),
     updateCluster: (updatedClusterValues: IFormValues) =>
       dispatch(ClusterActions.updateClusterRequest(updatedClusterValues)),
-    checkConnection: (clusterName: string) => {
-      dispatch(
-        ClusterActions.setClusterAddEditStatus(
-          createAddEditStatus(AddEditState.Fetching, AddEditMode.Edit)
-        )
-      );
-      dispatch(ClusterActions.watchClusterAddEditStatus(clusterName));
-    },
     cancelAddEditWatch: () => dispatch(ClusterActions.cancelWatchClusterAddEditStatus()),
     resetAddEditState: () => {
       dispatch(ClusterActions.setClusterAddEditStatus(defaultAddEditStatus()));

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -11,7 +11,6 @@ interface IOtherProps {
   onAddEditSubmit: any;
   onClose: any;
   addEditStatus: any;
-  checkConnection: (name: string) => void;
   storageList: IStorage[];
   currentStorage: IStorage;
 }

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
@@ -15,7 +15,6 @@ import {
   addEditStatusText,
   addEditButtonText,
   isAddEditButtonDisabled,
-  isCheckConnectionButtonDisabled,
 } from '../../../../../../common/add_edit_state';
 import ConnectionStatusLabel from '../../../../../../common/components/ConnectionStatusLabel';
 import { withFormik, FormikProps } from 'formik';
@@ -70,7 +69,6 @@ interface IOtherProps {
   onClose: any;
   addEditStatus: any;
   initialStorageValues: any;
-  checkConnection: (name: string) => void;
   currentStorage: any;
   provider: string;
 }
@@ -85,7 +83,6 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
   const {
     addEditStatus: currentStatus,
     currentStorage,
-    checkConnection,
     values,
     touched,
     errors,
@@ -197,16 +194,6 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           )}
         >
           {addEditButtonTextFn(currentStatus)}
-        </Button>
-        <Button
-          variant="secondary"
-          isDisabled={isCheckConnectionButtonDisabled(
-            currentStatus,
-            valuesHaveUpdate(values, currentStorage)
-          )}
-          onClick={() => checkConnection(values.name)}
-        >
-          Check Connection
         </Button>
         <Button variant="secondary" onClick={onClose}>
           Close

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import { Button, TextInput, Form, FormGroup, Grid, GridItem, Flex } from '@patternfly/react-core';
+import { Button, TextInput, Form, FormGroup, Flex } from '@patternfly/react-core';
 import KeyDisplayToggle from '../../../../../../common/components/KeyDisplayToggle';
 import {
   AddEditMode,
   addEditStatusText,
   addEditButtonText,
   isAddEditButtonDisabled,
-  isCheckConnectionButtonDisabled,
 } from '../../../../../../common/add_edit_state';
 import ConnectionStatusLabel from '../../../../../../common/components/ConnectionStatusLabel';
 import { withFormik, FormikProps } from 'formik';
@@ -50,7 +49,6 @@ interface IOtherProps {
   onClose: any;
   addEditStatus: any;
   initialStorageValues: any;
-  checkConnection: (name: string) => void;
   currentStorage?: any;
   provider: string;
 }
@@ -59,7 +57,6 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
   const {
     addEditStatus: currentStatus,
     currentStorage,
-    checkConnection,
     values,
     touched,
     errors,
@@ -170,16 +167,6 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
           )}
         >
           {addEditButtonTextFn(currentStatus)}
-        </Button>
-        <Button
-          variant="secondary"
-          isDisabled={isCheckConnectionButtonDisabled(
-            currentStatus,
-            valuesHaveUpdate(values, currentStorage)
-          )}
-          onClick={() => checkConnection(values.name)}
-        >
-          Check Connection
         </Button>
         <Button variant="secondary" onClick={onClose}>
           Close

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/S3Form.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/ProviderForms/S3Form.tsx
@@ -1,13 +1,11 @@
 import React, { useState } from 'react';
 import { Button, TextInput, Form, FormGroup, Checkbox, Flex } from '@patternfly/react-core';
-import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import KeyDisplayToggle from '../../../../../../common/components/KeyDisplayToggle';
 import {
   AddEditMode,
   addEditStatusText,
   addEditButtonText,
   isAddEditButtonDisabled,
-  isCheckConnectionButtonDisabled,
 } from '../../../../../../common/add_edit_state';
 import ConnectionStatusLabel from '../../../../../../common/components/ConnectionStatusLabel';
 import CertificateUpload from '../../../../../../common/components/CertificateUpload';
@@ -33,7 +31,6 @@ interface IOtherProps {
   onClose: any;
   addEditStatus: any;
   initialStorageValues: any;
-  checkConnection: (name: string) => void;
   provider: string;
   isAWS: boolean;
 }
@@ -44,7 +41,6 @@ const addEditButtonTextFn = addEditButtonText(componentTypeStr);
 
 const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues>> = ({
   addEditStatus: currentStatus,
-  checkConnection,
   values,
   touched,
   errors,
@@ -261,13 +257,6 @@ const InnerS3Form: React.FunctionComponent<IOtherProps & FormikProps<IFormValues
           isDisabled={isAddEditButtonDisabled(currentStatus, errors, touched, true)}
         >
           {addEditButtonTextFn(currentStatus)}
-        </Button>
-        <Button
-          variant="secondary"
-          isDisabled={isCheckConnectionButtonDisabled(currentStatus, true)}
-          onClick={() => checkConnection(values.name)}
-        >
-          Check Connection
         </Button>
         <Button variant="secondary" onClick={onClose}>
           Close

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/__tests__/AddEditStorageModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { createStore } from 'redux';
@@ -82,7 +82,6 @@ describe('<AddEditStorageModal />', () => {
           message: 'The storage is ready.',
           reason: '',
         },
-        checkConnection: jest.fn(),
       };
 
       render(
@@ -269,7 +268,6 @@ describe('<AddEditStorageModal />', () => {
           message: 'The storage is ready.',
           reason: '',
         },
-        checkConnection: jest.fn(),
       };
 
       render(
@@ -383,7 +381,6 @@ describe('<AddEditStorageModal />', () => {
           message: 'The storage is ready.',
           reason: '',
         },
-        checkConnection: jest.fn(),
       };
 
       render(

--- a/src/app/home/pages/StoragesPage/components/AddEditStorageModal/index.tsx
+++ b/src/app/home/pages/StoragesPage/components/AddEditStorageModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import AddEditStorageForm from './AddEditStorageForm';
 import { StorageActions } from '../../../../../storage/duck/actions';
@@ -6,8 +6,6 @@ import { Modal } from '@patternfly/react-core';
 import {
   AddEditMode,
   defaultAddEditStatus,
-  createAddEditStatus,
-  AddEditState,
   IAddEditStatus,
 } from '../../../../../common/add_edit_state';
 import { IStorage } from '../../../../../storage/duck/types';
@@ -17,7 +15,6 @@ interface IAddEditClusterModal {
   addEditStatus: IAddEditStatus;
   isOpen: boolean;
   isPolling: boolean;
-  checkConnection: (name: string) => void;
   storageList: IStorage[];
   addStorage: (storage: any) => void;
   cancelAddEditWatch: () => void;
@@ -32,7 +29,6 @@ const AddEditStorageModal = ({
   addEditStatus,
   isOpen,
   storageList,
-  checkConnection,
   updateStorage,
   addStorage,
   cancelAddEditWatch,
@@ -86,7 +82,6 @@ const AddEditStorageModal = ({
         onAddEditSubmit={onAddEditSubmit}
         onClose={onClose}
         addEditStatus={addEditStatus}
-        checkConnection={checkConnection}
         storageList={storageList}
         currentStorage={currentStorage}
       />
@@ -111,14 +106,6 @@ export default connect(
     cancelAddEditWatch: () => dispatch(StorageActions.cancelWatchStorageAddEditStatus()),
     resetAddEditState: () => {
       dispatch(StorageActions.setStorageAddEditStatus(defaultAddEditStatus()));
-    },
-    checkConnection: (storageName: string) => {
-      dispatch(
-        StorageActions.setStorageAddEditStatus(
-          createAddEditStatus(AddEditState.Fetching, AddEditMode.Edit)
-        )
-      );
-      dispatch(StorageActions.watchStorageAddEditStatus(storageName));
     },
     resetStoragePage: () => dispatch(StorageActions.resetStoragePage()),
     setCurrentStorage: (currentStorage: IStorage) =>


### PR DESCRIPTION
Backports https://github.com/konveyor/mig-ui/pull/1395 to 1.7.1 as listed in the JIRA issue. Not sure if we have a BZ for this one.

https://issues.redhat.com/browse/MIG-1131