### PR TITLE
Bug 2038298: Upgrade deep dependency ansi-regex to 3.0.1, 4.1.1, 5.0.1 to address CVE-2021-3807

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,19 +1437,19 @@ ansi-regex@^2.0.0:
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
 ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
 ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
See https://github.com/advisories/GHSA-93q8-gq69-wqmw for vulnerability details.

> | Affected versions | Patched versions |
> | ------------------ | ----------------- |
> | >= 6.0.0, < 6.0.1 | 6.0.1 |
> | >= 5.0.0, < 5.0.1 | 5.0.1 |
> | >= 4.0.0, < 4.1.1 | 4.1.1 |
> | >= 3.0.0, < 3.0.1 | 3.0.1 |

We depend on vulnerable versions ansi-regex@5.0.0, ansi-regex@4.1.0 and ansi-regex@3.0.0 via transitive dependencies of `webpack-dev-server`, `node-sass`, `html-webpack-plugin`, `strip-ansi`, `pretty-format`, `yargs`, `cliui`, `wrap-ansi`, `wide-align` and `ansi-align` (see `yarn why` output below).

This PR upgrades our lockfile to use the patched versions for each of these (3.0.1, 4.1.1, 5.0.1).
* The original fix in ansi-regex is here: https://github.com/chalk/ansi-regex/pull/37
* The backport to ansi-regex@5.0.1 is documented here: https://github.com/chalk/ansi-regex/releases/tag/v5.0.1
* The backports to ansi-regex@4.1.1 and ansi-regex@3.0.1 are not documented on the ansi-regex releases page, but they can be seen on the release branches [here](https://github.com/chalk/ansi-regex/compare/v4.1.0...v4.1.1) and [here](https://github.com/chalk/ansi-regex/compare/v3.0.0...v3.0.1), as supported by these versions being listed as patched on [the advisory page](https://github.com/advisories/GHSA-93q8-gq69-wqmw).

Related BZs:
* 1.7.2: https://bugzilla.redhat.com/show_bug.cgi?id=2038298
* 1.6.5: https://bugzilla.redhat.com/show_bug.cgi?id=2013356
  * Backport: https://github.com/konveyor/mig-ui/pull/1411
* 1.5.5: No BZ yet
  * Backport: https://github.com/konveyor/mig-ui/pull/1412

```
$ yarn why ansi-regex
yarn why v1.22.10
[1/4] 🤔  Why do we have the module "ansi-regex"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "ansi-regex@2.1.1"
info Has been hoisted to "ansi-regex"
info Reasons this module exists
   - Hoisted from "webpack-dev-server#strip-ansi#ansi-regex"
   - Hoisted from "node-sass#chalk#has-ansi#ansi-regex"
   - Hoisted from "node-sass#chalk#strip-ansi#ansi-regex"
   - Hoisted from "html-webpack-plugin#pretty-error#renderkid#strip-ansi#ansi-regex"
   - Hoisted from "node-sass#npmlog#gauge#strip-ansi#ansi-regex"
info Disk size without dependencies: "16KB"
info Disk size with unique dependencies: "16KB"
info Disk size with transitive dependencies: "16KB"
info Number of shared dependencies: 0
=> Found "strip-ansi#ansi-regex@5.0.0"
info This module exists because "strip-ansi" depends on it.
info Disk size without dependencies: "20KB"
info Disk size with unique dependencies: "20KB"
info Disk size with transitive dependencies: "20KB"
info Number of shared dependencies: 0
=> Found "pretty-format#ansi-regex@5.0.0"
info This module exists because "@types#jest#pretty-format" depends on it.
info Disk size without dependencies: "20KB"
info Disk size with unique dependencies: "20KB"
info Disk size with transitive dependencies: "20KB"
info Number of shared dependencies: 0
=> Found "yargs#ansi-regex@4.1.0"
info Reasons this module exists
   - "yargs#string-width#strip-ansi" depends on it
   - Hoisted from "yargs#string-width#strip-ansi#ansi-regex"
info Disk size without dependencies: "16KB"
info Disk size with unique dependencies: "16KB"
info Disk size with transitive dependencies: "16KB"
info Number of shared dependencies: 0
=> Found "cliui#ansi-regex@4.1.0"
info Reasons this module exists
   - "yargs#cliui#strip-ansi" depends on it
   - Hoisted from "yargs#cliui#strip-ansi#ansi-regex"
info Disk size without dependencies: "16KB"
info Disk size with unique dependencies: "16KB"
info Disk size with transitive dependencies: "16KB"
info Number of shared dependencies: 0
=> Found "wrap-ansi#ansi-regex@4.1.0"
info Reasons this module exists
   - "yargs#cliui#wrap-ansi#strip-ansi" depends on it
   - Hoisted from "yargs#cliui#wrap-ansi#strip-ansi#ansi-regex"
info Disk size without dependencies: "16KB"
info Disk size with unique dependencies: "16KB"
info Disk size with transitive dependencies: "16KB"
info Number of shared dependencies: 0
=> Found "wide-align#ansi-regex@3.0.0"
info Reasons this module exists
   - "node-sass#npmlog#gauge#wide-align#string-width#strip-ansi" depends on it
   - Hoisted from "node-sass#npmlog#gauge#wide-align#string-width#strip-ansi#ansi-regex"
info Disk size without dependencies: "16KB"
info Disk size with unique dependencies: "16KB"
info Disk size with transitive dependencies: "16KB"
info Number of shared dependencies: 0
=> Found "ansi-align#ansi-regex@4.1.0"
info Reasons this module exists
   - "nodemon#update-notifier#boxen#ansi-align#string-width#strip-ansi" depends on it
   - Hoisted from "nodemon#update-notifier#boxen#ansi-align#string-width#strip-ansi#ansi-regex"
info Disk size without dependencies: "16KB"
info Disk size with unique dependencies: "16KB"
info Disk size with transitive dependencies: "16KB"
info Number of shared dependencies: 0
✨  Done in 0.50s.
```