### PR TITLE
Bug 2062991: [Backport - 1.7.2] Bump follow-redirects from 1.14.7 to 1.14.8 

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,9 +3477,9 @@ focus-trap@6.2.2:
     tabbable "^5.1.4"
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Backports #1386 to 1.7.2 to resolve https://bugzilla.redhat.com/show_bug.cgi?id=2062991