### PR TITLE
[Backport - 1.7.2] Bug 2082221: Don't allow SCC migration when only one storage class is present or when no PVs are selected

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
@@ -142,9 +142,7 @@ const VolumesForm: React.FunctionComponent<IOtherProps> = (props) => {
     <VolumesTable
       isEdit={props.isEdit}
       isOpen={props.isOpen}
-      storageClasses={
-        (planState.currentPlan && planState.currentPlan.status.destStorageClasses) || []
-      }
+      storageClasses={planState.currentPlan?.status.destStorageClasses || []}
     />
   );
 };

--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesTable.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesTable.tsx
@@ -18,6 +18,9 @@ import {
   EmptyStateVariant,
   PopoverPosition,
   Title,
+  Alert,
+  AlertActionLink,
+  WizardContext,
 } from '@patternfly/react-core';
 import {
   sortable,
@@ -412,6 +415,8 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     };
   });
 
+  const { goToStepByName, onClose } = React.useContext(WizardContext);
+
   return (
     <Grid hasGutter>
       <GridItem>
@@ -423,6 +428,41 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
           </Text>
         </TextContent>
       </GridItem>
+      {isSCC && values.persistentVolumes.length === 0 ? (
+        <GridItem>
+          <Alert
+            variant="danger"
+            isInline
+            title="Storage class conversion is unavailable"
+            actionLinks={
+              <React.Fragment>
+                <AlertActionLink onClick={() => goToStepByName('General')}>Go back</AlertActionLink>
+                <AlertActionLink onClick={() => onClose()}>Cancel</AlertActionLink>
+              </React.Fragment>
+            }
+          >
+            At least one PV must be attached to the project for storage class conversion.
+          </Alert>
+        </GridItem>
+      ) : null}
+      {isSCC && storageClasses.length < 2 ? (
+        <GridItem>
+          <Alert
+            variant="danger"
+            isInline
+            title="Storage class conversion is unavailable"
+            actionLinks={
+              <React.Fragment>
+                <AlertActionLink onClick={() => goToStepByName('General')}>Go back</AlertActionLink>
+                <AlertActionLink onClick={() => onClose()}>Cancel</AlertActionLink>
+              </React.Fragment>
+            }
+          >
+            At least two storage classes must be available in the cluster for storage class
+            conversion.
+          </Alert>
+        </GridItem>
+      ) : null}
       <GridItem>
         <Level>
           <LevelItem>
@@ -503,7 +543,9 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
             titleText={values.persistentVolumes.length === 0 && 'No persistent volumes found'}
             bodyText={
               values.persistentVolumes.length === 0 &&
-              'No persistent volumes are attached to the selected projects. Click Next to continue.'
+              `No persistent volumes are attached to the selected projects.${
+                !isSCC ? ' Click Next to continue.' : ''
+              }`
             }
           />
         )}

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -292,6 +292,9 @@ const WizardComponent = (props: IOtherProps) => {
     });
   };
 
+  const planState = useSelector((state: DefaultRootState) => state.plan);
+  const storageClasses = planState.currentPlan?.status.destStorageClasses || [];
+
   const CustomFooter = (
     <WizardFooter>
       <WizardContextConsumer>
@@ -302,7 +305,7 @@ const WizardComponent = (props: IOtherProps) => {
                 {
                   if (
                     values.migrationType.value === 'full' ||
-                    values.migrationType.value == 'state'
+                    values.migrationType.value === 'state'
                   ) {
                     return areFieldsTouchedAndValid([
                       'planName',
@@ -324,7 +327,9 @@ const WizardComponent = (props: IOtherProps) => {
                   !isFetchingPVResources &&
                   !isFetchingPVList &&
                   currentPlanStatus.state !== 'Pending' &&
-                  currentPlanStatus.state !== 'Critical'
+                  currentPlanStatus.state !== 'Critical' &&
+                  (values.migrationType.value !== 'scc' ||
+                    (values.selectedPVs.length > 0 && storageClasses.length > 1))
                 );
               case 'Hooks':
                 return !isAddHooksOpen;

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
@@ -52,10 +52,7 @@ const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
         if (!values.selectedNamespaces || values.selectedNamespaces.length === 0) {
           errors.selectedNamespaces = 'Required';
         }
-        if (
-          values.migrationType.value !== 'scc' &&
-          (!values.selectedPVs || values.selectedPVs.length === 0)
-        ) {
+        if (!values.selectedPVs || values.selectedPVs.length === 0) {
           errors.selectedPVs = 'Required';
         }
 


### PR DESCRIPTION
Backports #1420 to 1.7.2. See that PR for important details on verifying this fix.