### PR TITLE
Bug 2082221: Fix possible console error exposed by #1420 when plan status is undefined

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
@@ -142,7 +142,7 @@ const VolumesForm: React.FunctionComponent<IOtherProps> = (props) => {
     <VolumesTable
       isEdit={props.isEdit}
       isOpen={props.isOpen}
-      storageClasses={planState.currentPlan?.status.destStorageClasses || []}
+      storageClasses={planState.currentPlan?.status?.destStorageClasses || []}
     />
   );
 };

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -293,7 +293,7 @@ const WizardComponent = (props: IOtherProps) => {
   };
 
   const planState = useSelector((state: DefaultRootState) => state.plan);
-  const storageClasses = planState.currentPlan?.status.destStorageClasses || [];
+  const storageClasses = planState.currentPlan?.status?.destStorageClasses || [];
 
   const CustomFooter = (
     <WizardFooter>


### PR DESCRIPTION
In certain conditions, the wizard renders with the `status` field undefined on the current migplan. Changes introduced by #1420 attempt to read `status.destStorageClasses`, potentially resulting in a "Cannot read property destStorageClasses of undefined" error. This was not caught by TypeScript due to loose type definitions. This PR adds an additional `?` to the optional chaining such that the list of storage classes will default to empty if the status of the plan is undefined.

This should be backported as part of the fix for https://bugzilla.redhat.com/show_bug.cgi?id=2082221.