### PR TITLE
Bug 2055658: Always hide Cancel action if it would be disabled

### DIFF
--- a/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
+++ b/src/app/home/pages/PlansPage/components/MigrationsTable.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Table, TableBody, TableHeader, cellWidth, sortable, IRow } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
-import MigrationActions from './MigrationActions';
+import SingleMigrationActions from './SingleMigrationActions';
 import {
   Bullseye,
   EmptyState,
@@ -76,7 +76,7 @@ const MigrationsTable: React.FunctionComponent<IProps> = ({ migrations, isPlanLo
           ),
         },
         {
-          title: <MigrationActions migration={migration} />,
+          title: <SingleMigrationActions migration={migration} />,
           props: {
             className: 'pf-c-table__action',
           },

--- a/src/app/home/pages/PlansPage/components/SingleMigrationActions.tsx
+++ b/src/app/home/pages/PlansPage/components/SingleMigrationActions.tsx
@@ -1,14 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useDispatch } from 'react-redux';
-import {
-  KebabToggle,
-  DropdownItem,
-  Dropdown,
-  DropdownPosition,
-  Flex,
-  FlexItem,
-  Button,
-} from '@patternfly/react-core';
+import { Flex, FlexItem, Button } from '@patternfly/react-core';
 import { IMigration } from '../../../../plan/duck/types';
 import { PlanActions } from '../../../../plan/duck';
 
@@ -16,14 +8,16 @@ interface IProps {
   migration: IMigration;
 }
 
-const MigrationActions: React.FunctionComponent<IProps> = ({ migration }) => {
-  const [kebabIsOpen, setKebabIsOpen] = useState(false);
+const SingleMigrationActions: React.FunctionComponent<IProps> = ({ migration }) => {
   const dispatch = useDispatch();
 
   return (
     <Flex>
       <FlexItem>
         {!migration.tableStatus.isSucceeded &&
+          !migration.tableStatus.isSucceededWithWarnings &&
+          !migration.tableStatus.isFailed &&
+          migration.tableStatus.stepName !== 'Canceled' &&
           !migration.tableStatus.isCanceled &&
           !migration.tableStatus.isCanceling && (
             <Button
@@ -31,12 +25,6 @@ const MigrationActions: React.FunctionComponent<IProps> = ({ migration }) => {
               onClick={() => {
                 dispatch(PlanActions.migrationCancelRequest(migration.metadata.name));
               }}
-              isDisabled={
-                migration.tableStatus.isSucceeded ||
-                migration.tableStatus.isSucceededWithWarnings ||
-                migration.tableStatus.isFailed ||
-                migration.tableStatus.stepName === 'Canceled'
-              }
               key={`cancelMigration-${migration.metadata.name}`}
             >
               Cancel
@@ -47,4 +35,4 @@ const MigrationActions: React.FunctionComponent<IProps> = ({ migration }) => {
   );
 };
 
-export default MigrationActions;
+export default SingleMigrationActions;


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2055658

Also renames the MigrationActions component (which appears on each individual migration row) to SingleMigrationActions, so as not to be confused with MigrationActionsDropdownGroup (which are the migration-related actions for each migplan). Cleaned up some unused variables/imports in that file as well.