### PR TITLE
[Backport - 1.7.2] Bug 2062862: Check for errors in promise.all call and allow partial failure (#1435)

### DIFF
--- a/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/home/pages/ClustersPage/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -50,7 +50,9 @@ const valuesHaveUpdate = (values: IFormValues, currentCluster: ICluster) => {
     return true;
   }
   const requireSSL = !currentCluster.MigCluster.spec.insecure;
-  const rawToken = atob(currentCluster.Secret.data.saToken);
+  const rawToken = currentCluster?.Secret?.data?.saToken
+    ? atob(currentCluster?.Secret?.data?.saToken)
+    : null;
   const existingEndpoint = currentCluster.MigCluster.spec.url;
   const azureResourceGroup = currentCluster.MigCluster.spec.azureResourceGroup
     ? currentCluster.MigCluster.spec.azureResourceGroup

--- a/src/app/home/pages/ClustersPage/helpers.ts
+++ b/src/app/home/pages/ClustersPage/helpers.ts
@@ -23,7 +23,7 @@ export const getClusterInfo = (
       : cluster.MigCluster.status.conditions.filter((c) => c.type === 'Ready').length > 0,
     clusterUrl: isHostCluster ? migMeta.clusterApi : cluster.MigCluster.spec.url,
     clusterSvcToken:
-      !isHostCluster && cluster.Secret.data.saToken ? atob(cluster.Secret.data.saToken) : null,
+      !isHostCluster && cluster?.Secret?.data?.saToken ? atob(cluster.Secret.data.saToken) : null,
     clusterRequireSSL: !cluster.MigCluster.spec.insecure,
     clusterCABundle: cluster.MigCluster.spec.caBundle,
     exposedRegistryPath: cluster.MigCluster.spec.exposedRegistryPath,

--- a/src/app/home/pages/HooksPage/helpers.ts
+++ b/src/app/home/pages/HooksPage/helpers.ts
@@ -18,7 +18,7 @@ export const getClusterInfo = (
       : cluster.MigCluster.status.conditions.filter((c) => c.type === 'Ready').length > 0,
     clusterUrl: isHostCluster ? migMeta.clusterApi : cluster.MigCluster.spec.url,
     clusterSvcToken:
-      !isHostCluster && cluster.Secret.data.saToken ? atob(cluster.Secret.data.saToken) : null,
+      !isHostCluster && cluster?.Secret?.data?.saToken ? atob(cluster.Secret.data.saToken) : null,
     clusterRequireSSL: !cluster.MigCluster.spec.insecure,
     clusterCABundle: cluster.MigCluster.spec.caBundle,
     exposedRegistryPath: cluster.MigCluster.spec.exposedRegistryPath,


### PR DESCRIPTION
cherry-pick: https://github.com/konveyor/mig-ui/pull/1435

* Check for errors in promise.all call and allow partial failure

* cleanup

* cleanup

* Change from string to undefined to match storage implementation