### PR TITLE
Bug 2078459: Prevent migStorageRef from being added to plans that don't already have one

### DIFF
--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -393,7 +393,7 @@ export function updateMigPlanFromValues(
   currentPlan: IMigPlan
 ) {
   const updatedSpec: IMigPlan['spec'] = Object.assign({}, migPlan.spec);
-  if (planValues.selectedStorage) {
+  if (planValues.selectedStorage && migPlan.spec.migStorageRef) {
     updatedSpec.migStorageRef = {
       name: planValues.selectedStorage,
       namespace: migPlan.metadata.namespace,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2078459 after #1424 failed QA.

#1424 prevents the migStorageRef from being added to the plan when it is first created, but not when it is updated. This PR fixes that update case.