### PR TITLE
[Backport - 1.7.2] Bug 2078459: Prevent migStorageRef from being added to plans that don't already have one

### DIFF
--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -393,7 +393,7 @@ export function updateMigPlanFromValues(
   currentPlan: IMigPlan
 ) {
   const updatedSpec: IMigPlan['spec'] = Object.assign({}, migPlan.spec);
-  if (planValues.selectedStorage) {
+  if (planValues.selectedStorage && migPlan.spec.migStorageRef) {
     updatedSpec.migStorageRef = {
       name: planValues.selectedStorage,
       namespace: migPlan.metadata.namespace,


### PR DESCRIPTION
Backports #1452 to 1.7.2