### PR TITLE
[Backport - 1.7.2] Bug 2056962: For non-SCC intra-cluster migrations, don't allow target namespace to equal source namespace (#1439)

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
@@ -73,12 +73,19 @@ const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
             (editedNSName === ns.oldName && editedNSNameID !== ns.id)
           );
         });
+        const hasUnchangedIntraClusterNs =
+          values?.sourceCluster === values?.targetCluster &&
+          values.migrationType.value !== 'scc' &&
+          values?.currentTargetNamespaceName?.name === values?.currentTargetNamespaceName?.srcName;
 
         const targetNamespaceNameError = utils.testTargetName(
           values?.currentTargetNamespaceName?.name
         );
         if (targetNamespaceNameError !== '') {
           errors.currentTargetNamespaceName = targetNamespaceNameError;
+        } else if (hasUnchangedIntraClusterNs) {
+          errors.currentTargetNamespaceName =
+            'Target namespace name cannot be the same as source namespace name. Enter a unique name for this target namespace.';
         } else if (hasDuplicateMapping) {
           errors.currentTargetNamespaceName =
             'A mapped target namespace with that name already exists. Enter a unique name for this target namespace.';


### PR DESCRIPTION
Backports #1439 