### PR TITLE
Bug 2056962-follow-up: Fix slight regression with an error leaking to global state

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -319,7 +319,11 @@ const WizardComponent = (props: IOtherProps) => {
                 }
                 break;
               case 'Namespaces':
-                return !errors.selectedNamespaces && !isFetchingNamespaceList;
+                return (
+                  !errors.selectedNamespaces &&
+                  !isFetchingNamespaceList &&
+                  !errors.currentTargetNamespaceName
+                );
               case 'Copy options':
                 return !errors.currentTargetPVCName;
               case 'Persistent volumes':

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
@@ -73,9 +73,13 @@ const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
             (editedNSName === ns.oldName && editedNSNameID !== ns.id)
           );
         });
+        const existingNSTargetName = values?.currentTargetNamespaceName?.name;
+        const existingNSSourceName = values?.currentTargetNamespaceName?.srcName;
         const hasUnchangedIntraClusterNs =
           values?.sourceCluster === values?.targetCluster &&
           values.migrationType.value !== 'scc' &&
+          existingNSTargetName &&
+          existingNSSourceName &&
           values?.currentTargetNamespaceName?.name === values?.currentTargetNamespaceName?.srcName;
 
         const targetNamespaceNameError = utils.testTargetName(

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
@@ -80,7 +80,7 @@ const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
           values.migrationType.value !== 'scc' &&
           existingNSTargetName &&
           existingNSSourceName &&
-          values?.currentTargetNamespaceName?.name === values?.currentTargetNamespaceName?.srcName;
+          existingNSSourceName === existingNSTargetName;
 
         const targetNamespaceNameError = utils.testTargetName(
           values?.currentTargetNamespaceName?.name


### PR DESCRIPTION
- Add a next button disable for the currentTargetNamespaceName error
- Make sure the fields being validated are populated before throwing an error. I was seeing an error leak into global state causing submit to be disabled. 