### PR TITLE
Prune devDependencies from node_modules before copying to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ COPY . /mig-ui
 WORKDIR /mig-ui
 USER root
 RUN dnf config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo && \
-    dnf -y install yarn && yarn && yarn build
+    dnf -y install yarn && yarn && yarn build && yarn install --production
 
 FROM registry.access.redhat.com/ubi8/nodejs-12:latest
 COPY --from=builder /mig-ui/dist /opt/app-root/src/staticroot


### PR DESCRIPTION
cc @rayfordj 