### PR TITLE
Move devDependencies over to main deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "clean-webpack-plugin": "^4.0.0",
-    "compression": "^1.7.4",
     "concurrently": "^5.2.0",
     "css-loader": "^5.0.1",
     "eslint": "^7.22.0",
@@ -54,7 +53,6 @@
     "eslint-plugin-testing-library": "^3.3.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
-    "https-proxy-agent": "^5.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.0.1",
     "json-merge-patch": "^0.2.3",
@@ -76,6 +74,8 @@
     "webpack-dev-server": "^4.8.1"
   },
   "dependencies": {
+    "https-proxy-agent": "^5.0.0",
+    "compression": "^1.7.4",
     "@hot-loader/react-dom": "^17.0.1",
     "@konveyor/lib-ui": "^5.1.2",
     "@patternfly/react-core": "^4.115.5",


### PR DESCRIPTION
Fixes the build error resulting from using yarn --production flag in docker file. 